### PR TITLE
Add signature-based caching for node updates

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,6 +131,16 @@ def update_node_info(
     node_cache_dict=None,
     mode_async=True,
 ):
+    """
+    Update all nodes in topological order with optional in-memory caching.
+
+    Cache path (connected nodes):
+      1) build a signature from upstream outputs + node settings
+      2) if signature matches previous run, reuse cached output and skip update()
+
+    Non-cache path (source nodes without inbound links):
+      always run update() so UI/callback-driven state changes are picked up.
+    """
     if node_cache_dict is None:
         node_cache_dict = {}
 
@@ -155,8 +165,11 @@ def update_node_info(
             node_setting = node_instance.get_setting_dict(node_id)
 
         cache_signature = None
+        # Only cache nodes that have inbound links (downstream processors).
+        # Source/input nodes must keep running every frame.
         use_cache = len(connection_list) > 0
         if use_cache:
+            # Cache-hit path: skip expensive update() when nothing relevant changed.
             cache_signature = _build_node_signature(
                 node_id,
                 connection_list,
@@ -198,17 +211,21 @@ def update_node_info(
                 node_image_dict,
                 node_result_dict,
             )
+        # Cache-miss path (or source node path): run node update and store outputs.
         node_image_dict[node_id_name] = copy.deepcopy(image)
         node_result_dict[node_id_name] = copy.deepcopy(result)
         if use_cache:
+            # Persist latest outputs for the next signature match.
             node_cache_dict[node_id_name] = {
                 'signature': cache_signature,
                 'image': copy.deepcopy(image),
                 'result': copy.deepcopy(result),
             }
         elif node_id_name in node_cache_dict:
+            # Ensure source nodes never keep stale cache entries.
             del node_cache_dict[node_id_name]
 
+    # Remove cache entries for nodes that were deleted from the graph.
     deleted_node_id_name_list = [
         node_id_name for node_id_name in node_cache_dict.keys()
         if node_id_name not in node_list

--- a/main.py
+++ b/main.py
@@ -154,23 +154,28 @@ def update_node_info(
         if hasattr(node_instance, 'get_setting_dict'):
             node_setting = node_instance.get_setting_dict(node_id)
 
-        cache_signature = _build_node_signature(
-            node_id,
-            connection_list,
-            node_image_dict,
-            node_result_dict,
-            node_setting,
-        )
-        cached_result = node_cache_dict.get(node_id_name)
-        if (
-            cached_result is not None and
-            cached_result.get('signature') == cache_signature
-        ):
-            node_image_dict[node_id_name] = copy.deepcopy(cached_result['image'])
-            node_result_dict[node_id_name] = copy.deepcopy(
-                cached_result['result']
+        cache_signature = None
+        use_cache = len(connection_list) > 0
+        if use_cache:
+            cache_signature = _build_node_signature(
+                node_id,
+                connection_list,
+                node_image_dict,
+                node_result_dict,
+                node_setting,
             )
-            continue
+            cached_result = node_cache_dict.get(node_id_name)
+            if (
+                cached_result is not None and
+                cached_result.get('signature') == cache_signature
+            ):
+                node_image_dict[node_id_name] = copy.deepcopy(
+                    cached_result['image']
+                )
+                node_result_dict[node_id_name] = copy.deepcopy(
+                    cached_result['result']
+                )
+                continue
 
         # 指定ノードの情報を更新
         if mode_async:
@@ -195,11 +200,14 @@ def update_node_info(
             )
         node_image_dict[node_id_name] = copy.deepcopy(image)
         node_result_dict[node_id_name] = copy.deepcopy(result)
-        node_cache_dict[node_id_name] = {
-            'signature': cache_signature,
-            'image': copy.deepcopy(image),
-            'result': copy.deepcopy(result),
-        }
+        if use_cache:
+            node_cache_dict[node_id_name] = {
+                'signature': cache_signature,
+                'image': copy.deepcopy(image),
+                'result': copy.deepcopy(result),
+            }
+        elif node_id_name in node_cache_dict:
+            del node_cache_dict[node_id_name]
 
     deleted_node_id_name_list = [
         node_id_name for node_id_name in node_cache_dict.keys()

--- a/main.py
+++ b/main.py
@@ -5,6 +5,8 @@ import copy
 import json
 import asyncio
 import argparse
+import hashlib
+import pickle
 from collections import OrderedDict
 import os
 
@@ -42,18 +44,96 @@ def async_main(node_editor):
     # 各ノードの処理結果保持用Dict
     node_image_dict = {}
     node_result_dict = {}
+    node_cache_dict = {}
 
     # メインループ
     while not node_editor.get_terminate_flag():
-        update_node_info(node_editor, node_image_dict, node_result_dict)
+        update_node_info(
+            node_editor,
+            node_image_dict,
+            node_result_dict,
+            node_cache_dict=node_cache_dict,
+        )
+
+
+def _freeze_cache_value(value):
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+
+    if isinstance(value, bytes):
+        return hashlib.sha1(value).hexdigest()
+
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_cache_value(item) for item in value)
+
+    if isinstance(value, set):
+        return tuple(sorted(_freeze_cache_value(item) for item in value))
+
+    if isinstance(value, dict):
+        return tuple(
+            sorted(
+                (
+                    _freeze_cache_value(key),
+                    _freeze_cache_value(item),
+                )
+                for key, item in value.items()
+            )
+        )
+
+    if (
+        hasattr(value, 'shape') and
+        hasattr(value, 'dtype') and
+        hasattr(value, 'tobytes')
+    ):
+        try:
+            return (
+                'ndarray',
+                tuple(value.shape),
+                str(value.dtype),
+                hashlib.sha1(value.tobytes()).hexdigest(),
+            )
+        except TypeError:
+            pass
+
+    return repr(value)
+
+
+def _build_node_signature(
+    node_id,
+    connection_list,
+    node_image_dict,
+    node_result_dict,
+    node_setting,
+):
+    upstream_values = []
+    for source_tag, _ in connection_list:
+        source_node_id_name = ':'.join(source_tag.split(':')[:2])
+        upstream_values.append((
+            source_tag,
+            _freeze_cache_value(node_image_dict.get(source_node_id_name)),
+            _freeze_cache_value(node_result_dict.get(source_node_id_name)),
+        ))
+
+    signature_payload = {
+        'node_id': node_id,
+        'connection_list': connection_list,
+        'upstream_values': upstream_values,
+        'node_setting': _freeze_cache_value(node_setting),
+    }
+    payload_bytes = pickle.dumps(signature_payload)
+    return hashlib.sha1(payload_bytes).hexdigest()
 
 
 def update_node_info(
     node_editor,
     node_image_dict,
     node_result_dict,
+    node_cache_dict=None,
     mode_async=True,
 ):
+    if node_cache_dict is None:
+        node_cache_dict = {}
+
     # ノードリスト取得
     node_list = node_editor.get_node_list()
 
@@ -70,6 +150,27 @@ def update_node_info(
 
         # ノード名からインスタンスを取得
         node_instance = node_editor.get_node_instance(node_name)
+        node_setting = {}
+        if hasattr(node_instance, 'get_setting_dict'):
+            node_setting = node_instance.get_setting_dict(node_id)
+
+        cache_signature = _build_node_signature(
+            node_id,
+            connection_list,
+            node_image_dict,
+            node_result_dict,
+            node_setting,
+        )
+        cached_result = node_cache_dict.get(node_id_name)
+        if (
+            cached_result is not None and
+            cached_result.get('signature') == cache_signature
+        ):
+            node_image_dict[node_id_name] = copy.deepcopy(cached_result['image'])
+            node_result_dict[node_id_name] = copy.deepcopy(
+                cached_result['result']
+            )
+            continue
 
         # 指定ノードの情報を更新
         if mode_async:
@@ -94,6 +195,18 @@ def update_node_info(
             )
         node_image_dict[node_id_name] = copy.deepcopy(image)
         node_result_dict[node_id_name] = copy.deepcopy(result)
+        node_cache_dict[node_id_name] = {
+            'signature': cache_signature,
+            'image': copy.deepcopy(image),
+            'result': copy.deepcopy(result),
+        }
+
+    deleted_node_id_name_list = [
+        node_id_name for node_id_name in node_cache_dict.keys()
+        if node_id_name not in node_list
+    ]
+    for deleted_node_id_name in deleted_node_id_name_list:
+        del node_cache_dict[deleted_node_id_name]
 
 
 def main():
@@ -204,11 +317,13 @@ def main():
         # 各ノードの処理結果保持用Dict
         node_image_dict = {}
         node_result_dict = {}
+        node_cache_dict = {}
         while dpg.is_dearpygui_running():
             update_node_info(
                 node_editor,
                 node_image_dict,
                 node_result_dict,
+                node_cache_dict=node_cache_dict,
                 mode_async=False,
             )
             dpg.render_dearpygui_frame()

--- a/tests/unit/test_update_node_info.py
+++ b/tests/unit/test_update_node_info.py
@@ -121,6 +121,95 @@ def test_update_node_info_sync_exception():
 
 
 def test_update_node_info_uses_cache_when_signature_unchanged():
+    source_node = Mock()
+    source_node.update.return_value = ('src-img', {'source': 1})
+    source_node.get_setting_dict.return_value = {'alpha': 0.1}
+
+    process_node = Mock()
+    process_node.update.return_value = ('img1', {'v': 1})
+    process_node.get_setting_dict.return_value = {'alpha': 0.5}
+
+    nodes = ['1:SourceNode', '2:TestNode']
+    conn_dict = OrderedDict([
+        ('1:SourceNode', []),
+        ('2:TestNode', [['1:SourceNode:image:Output01', '2:TestNode:image:Input01']]),
+    ])
+    editor = FakeEditor(
+        nodes,
+        conn_dict,
+        {'SourceNode': source_node, 'TestNode': process_node},
+    )
+
+    image_dict = {}
+    result_dict = {}
+    cache_dict = {}
+
+    update_node_info(
+        editor,
+        image_dict,
+        result_dict,
+        node_cache_dict=cache_dict,
+        mode_async=False,
+    )
+    update_node_info(
+        editor,
+        image_dict,
+        result_dict,
+        node_cache_dict=cache_dict,
+        mode_async=False,
+    )
+
+    assert source_node.update.call_count == 2
+    assert process_node.update.call_count == 1
+    assert image_dict['2:TestNode'] == 'img1'
+    assert result_dict['2:TestNode'] == {'v': 1}
+
+
+def test_update_node_info_invalidates_cache_when_setting_changes():
+    source_node = Mock()
+    source_node.update.return_value = ('src-img', {'source': 1})
+    source_node.get_setting_dict.return_value = {'alpha': 0.1}
+
+    process_node = Mock()
+    process_node.update.side_effect = [('img1', {'v': 1}), ('img2', {'v': 2})]
+    process_node.get_setting_dict.side_effect = [{'alpha': 0.5}, {'alpha': 0.7}]
+
+    nodes = ['1:SourceNode', '2:TestNode']
+    conn_dict = OrderedDict([
+        ('1:SourceNode', []),
+        ('2:TestNode', [['1:SourceNode:image:Output01', '2:TestNode:image:Input01']]),
+    ])
+    editor = FakeEditor(
+        nodes,
+        conn_dict,
+        {'SourceNode': source_node, 'TestNode': process_node},
+    )
+
+    image_dict = {}
+    result_dict = {}
+    cache_dict = {}
+
+    update_node_info(
+        editor,
+        image_dict,
+        result_dict,
+        node_cache_dict=cache_dict,
+        mode_async=False,
+    )
+    update_node_info(
+        editor,
+        image_dict,
+        result_dict,
+        node_cache_dict=cache_dict,
+        mode_async=False,
+    )
+
+    assert process_node.update.call_count == 2
+    assert image_dict['2:TestNode'] == 'img2'
+    assert result_dict['2:TestNode'] == {'v': 2}
+
+
+def test_update_node_info_does_not_cache_source_nodes_without_inputs():
     node = Mock()
     node.update.return_value = ('img1', {'v': 1})
     node.get_setting_dict.return_value = {'alpha': 0.5}
@@ -148,42 +237,8 @@ def test_update_node_info_uses_cache_when_signature_unchanged():
         mode_async=False,
     )
 
-    assert node.update.call_count == 1
-    assert image_dict['1:TestNode'] == 'img1'
-    assert result_dict['1:TestNode'] == {'v': 1}
-
-
-def test_update_node_info_invalidates_cache_when_setting_changes():
-    node = Mock()
-    node.update.side_effect = [('img1', {'v': 1}), ('img2', {'v': 2})]
-    node.get_setting_dict.side_effect = [{'alpha': 0.5}, {'alpha': 0.7}]
-
-    nodes = ['1:TestNode']
-    conn_dict = OrderedDict([('1:TestNode', [])])
-    editor = FakeEditor(nodes, conn_dict, {'TestNode': node})
-
-    image_dict = {}
-    result_dict = {}
-    cache_dict = {}
-
-    update_node_info(
-        editor,
-        image_dict,
-        result_dict,
-        node_cache_dict=cache_dict,
-        mode_async=False,
-    )
-    update_node_info(
-        editor,
-        image_dict,
-        result_dict,
-        node_cache_dict=cache_dict,
-        mode_async=False,
-    )
-
     assert node.update.call_count == 2
-    assert image_dict['1:TestNode'] == 'img2'
-    assert result_dict['1:TestNode'] == {'v': 2}
+    assert cache_dict == {}
 
 
 def test_update_node_info_cleans_cache_for_deleted_nodes():

--- a/tests/unit/test_update_node_info.py
+++ b/tests/unit/test_update_node_info.py
@@ -117,3 +117,104 @@ def test_update_node_info_sync_exception():
     with pytest.raises(RuntimeError) as exc_info:
         update_node_info(editor, image_dict, result_dict, mode_async=False)
     assert "sync boom" in str(exc_info.value)
+
+
+
+def test_update_node_info_uses_cache_when_signature_unchanged():
+    node = Mock()
+    node.update.return_value = ('img1', {'v': 1})
+    node.get_setting_dict.return_value = {'alpha': 0.5}
+
+    nodes = ['1:TestNode']
+    conn_dict = OrderedDict([('1:TestNode', [])])
+    editor = FakeEditor(nodes, conn_dict, {'TestNode': node})
+
+    image_dict = {}
+    result_dict = {}
+    cache_dict = {}
+
+    update_node_info(
+        editor,
+        image_dict,
+        result_dict,
+        node_cache_dict=cache_dict,
+        mode_async=False,
+    )
+    update_node_info(
+        editor,
+        image_dict,
+        result_dict,
+        node_cache_dict=cache_dict,
+        mode_async=False,
+    )
+
+    assert node.update.call_count == 1
+    assert image_dict['1:TestNode'] == 'img1'
+    assert result_dict['1:TestNode'] == {'v': 1}
+
+
+def test_update_node_info_invalidates_cache_when_setting_changes():
+    node = Mock()
+    node.update.side_effect = [('img1', {'v': 1}), ('img2', {'v': 2})]
+    node.get_setting_dict.side_effect = [{'alpha': 0.5}, {'alpha': 0.7}]
+
+    nodes = ['1:TestNode']
+    conn_dict = OrderedDict([('1:TestNode', [])])
+    editor = FakeEditor(nodes, conn_dict, {'TestNode': node})
+
+    image_dict = {}
+    result_dict = {}
+    cache_dict = {}
+
+    update_node_info(
+        editor,
+        image_dict,
+        result_dict,
+        node_cache_dict=cache_dict,
+        mode_async=False,
+    )
+    update_node_info(
+        editor,
+        image_dict,
+        result_dict,
+        node_cache_dict=cache_dict,
+        mode_async=False,
+    )
+
+    assert node.update.call_count == 2
+    assert image_dict['1:TestNode'] == 'img2'
+    assert result_dict['1:TestNode'] == {'v': 2}
+
+
+def test_update_node_info_cleans_cache_for_deleted_nodes():
+    node = Mock()
+    node.update.return_value = ('img1', {'v': 1})
+    node.get_setting_dict.return_value = {'alpha': 0.5}
+
+    nodes = ['1:TestNode']
+    conn_dict = OrderedDict([('1:TestNode', [])])
+    editor = FakeEditor(nodes, conn_dict, {'TestNode': node})
+
+    image_dict = {}
+    result_dict = {}
+    cache_dict = {}
+
+    update_node_info(
+        editor,
+        image_dict,
+        result_dict,
+        node_cache_dict=cache_dict,
+        mode_async=False,
+    )
+
+    editor.nodes = []
+    editor.conn_dict = OrderedDict([])
+    update_node_info(
+        editor,
+        image_dict,
+        result_dict,
+        node_cache_dict=cache_dict,
+        mode_async=False,
+    )
+
+    assert cache_dict == {}


### PR DESCRIPTION
### Motivation
- Reduce redundant work by avoiding repeated `node_instance.update(...)` calls when a node's inputs and settings have not changed.
- Implement caching centrally in the update loop so nodes require no modifications and the solution can be migrated later into a base node API.

### Description
- Introduced a persistent `node_cache_dict` used by both `async_main` and the synchronous loop so cached outputs survive iterations without touching node implementations. (`async_main`, `main`) 
- Added helpers `_freeze_cache_value` and `_build_node_signature` to create stable signatures from upstream image/result values, connection lists, and `get_setting_dict(...)` results, including safe handling/hashing for ndarray-like payloads. (`main.py`) 
- Updated `update_node_info` to accept `node_cache_dict`, compute per-node signatures, reuse cached `image`/`result` when signatures match, write new cache entries after updates, and remove cache entries for deleted nodes. (`main.py`) 
- Added unit tests to `tests/unit/test_update_node_info.py` covering cache hits, invalidation when settings change, and cache cleanup for deleted nodes. (`tests/unit/test_update_node_info.py`) 

### Testing
- `python -m pytest` (full test run) failed during collection in this environment due to a missing system OpenCV shared dependency (`libGL.so.1`).
- Unit tests for the modified behavior passed when running with a small `cv2` stub, e.g. `PYTHONPATH=/tmp/test_stubs python -m pytest tests/unit/test_update_node_info.py` (7 passed). 
- Additional unit suites were exercised with the same stub and passed, e.g. `PYTHONPATH=/tmp/test_stubs python -m pytest tests/unit/test_node_editor_core.py tests/unit/test_node_editor_import_export.py` (32 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933b40ff8e48323b46b5f6dbaf7f890)