### PR TITLE
Persist still-image selection across export/import and handle missing files gracefully

### DIFF
--- a/node/input_node/node_still_image.py
+++ b/node/input_node/node_still_image.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import os
+
 import cv2
 import numpy as np
 import dearpygui.dearpygui as dpg
@@ -142,15 +144,30 @@ class Node(DpgNodeABC):
         tag_node_name = str(node_id) + ':' + self.node_tag
 
         pos = dpg.get_item_pos(tag_node_name)
+        image_path = self._image_filepath.get(str(node_id), None)
 
         setting_dict = {}
         setting_dict['ver'] = self._ver
         setting_dict['pos'] = pos
+        setting_dict['image_path'] = image_path
 
         return setting_dict
 
     def set_setting_dict(self, node_id, setting_dict):
-        pass
+        image_path = setting_dict.get('image_path', None)
+
+        if image_path is None:
+            return
+
+        node_id = str(node_id)
+        if os.path.isfile(image_path):
+            self._image_filepath[node_id] = image_path
+            return
+
+        self._image_filepath.pop(node_id, None)
+        self._prev_image_filepath.pop(node_id, None)
+        self._image.pop(node_id, None)
+        print(f'WARNING : Image file not found ({image_path})')
 
     def _callback_file_select(self, sender, data):
         if data['file_name'] != '.':

--- a/tests/unit/test_node_still_image.py
+++ b/tests/unit/test_node_still_image.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+from node.input_node.node_still_image import Node
+
+
+class TestNodeStillImageSettings:
+    def test_get_setting_dict_includes_image_path(self):
+        node = Node()
+        node._image_filepath['1'] = '/tmp/example.png'
+
+        with patch('node.input_node.node_still_image.dpg') as mock_dpg:
+            mock_dpg.get_item_pos.return_value = [10, 20]
+
+            setting = node.get_setting_dict(1)
+
+        assert setting['ver'] == node._ver
+        assert setting['pos'] == [10, 20]
+        assert setting['image_path'] == '/tmp/example.png'
+
+    def test_set_setting_dict_loads_existing_image_path(self):
+        node = Node()
+        setting = {'image_path': '/tmp/example.png'}
+
+        with patch('node.input_node.node_still_image.os.path.isfile', return_value=True):
+            node.set_setting_dict(1, setting)
+
+        assert node._image_filepath['1'] == '/tmp/example.png'
+
+    def test_set_setting_dict_handles_missing_image_path_gracefully(self, capsys):
+        node = Node()
+        node._image_filepath['1'] = '/tmp/old.png'
+        node._prev_image_filepath['1'] = '/tmp/old.png'
+        node._image['1'] = object()
+        setting = {'image_path': '/tmp/missing.png'}
+
+        with patch('node.input_node.node_still_image.os.path.isfile', return_value=False):
+            node.set_setting_dict(1, setting)
+
+        captured = capsys.readouterr()
+        assert 'WARNING : Image file not found (/tmp/missing.png)' in captured.out
+        assert '1' not in node._image_filepath
+        assert '1' not in node._prev_image_filepath
+        assert '1' not in node._image


### PR DESCRIPTION
### Motivation
- Remember the image file selected in the still-image input node so exported project files can restore the user's selection when re-imported.
- Avoid crashes or leaving stale in-memory state when an imported image path no longer exists on the target system by failing gracefully.

### Description
- Add `image_path` to the exported settings returned by `Node.get_setting_dict()` in `node/input_node/node_still_image.py` so the selected file path is persisted.
- Implement `Node.set_setting_dict()` in `node/input_node/node_still_image.py` to restore the persisted path when `os.path.isfile(image_path)` is true, and to clear cached `_image`, `_image_filepath`, and `_prev_image_filepath` and print a warning when the file is missing.
- Add unit tests `tests/unit/test_node_still_image.py` that verify the exported settings include `image_path`, that an existing image path is restored, and that a missing image path is handled gracefully and clears stale state.

### Testing
- Ran the new unit tests with the OpenCV stub: `python -m pytest --use-cv2-stub tests/unit/test_node_still_image.py`, and they passed (`3 passed`).
- Ran the full test suite with the OpenCV stub: `python -m pytest --use-cv2-stub`, and the suite passed (`43 passed, 16 skipped`).
- Running `python -m pytest` without the CV2 stub fails in this environment due to missing `libGL.so.1` when importing OpenCV (known environment constraint), so the stub mode is used for CI-friendly verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4cc2da17083238920adb11fe44328)