### PR TITLE
Handle node deletion races in update loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,5 +33,11 @@ stub mode:
 python -m pytest --use-cv2-stub
 ```
 
+## Async DearPyGui safety notes
+- In this repository, `Node.update()` runs in an async worker by default (`main.py` loop). GUI callbacks can mutate/delete DPG items concurrently.
+- For code paths reachable from `Node.update()`, prefer guarded helpers in `node_editor/util.py` (`dpg_get_value`, `dpg_set_value`, `dpg_get_item_children`) instead of direct `dpg.get_*` calls.
+- Parse node inputs defensively (`None` / malformed UI values can occur during delete/import races).
+- See `docs/async-dpg-race-guide.md` for details and architecture recommendations.
+
 ## Commit messages
 Write clear commit messages in English. Use a short summary line followed by a blank line and additional details if necessary.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ If your environment cannot import OpenCV (for example `libGL.so.1` is missing), 
 python -m pytest --use-cv2-stub
 ```
 
+## Async update-loop safety / 非同期更新ループの安全性
+
+**English**
+
+- During delete/import stress, async node updates can race with GUI callbacks and hit transient DearPyGui errors.
+- For node code reachable from `Node.update()`, prefer guarded helpers in `node_editor/util.py` (`dpg_get_value`, `dpg_set_value`, `dpg_get_item_children`) over direct `dpg.get_*` calls.
+- Keep node input parsing defensive (for example, tolerate `None` / malformed values).
+- For a deeper explanation and architecture recommendations, see: [`docs/async-dpg-race-guide.md`](docs/async-dpg-race-guide.md).
+
+**日本語**
+
+- ノード削除・Import の繰り返し時は、GUI コールバックと非同期更新が競合し、DearPyGui の一時的な例外が発生することがあります。
+- `Node.update()` から到達する処理では、`dpg.get_*` を直接呼ぶより、`node_editor/util.py` のガード付きヘルパー（`dpg_get_value` / `dpg_set_value` / `dpg_get_item_children`）の利用を推奨します。
+- ノード入力値のパースは、`None` や不正値を許容する防御的な実装にしてください。
+- 詳細な背景と推奨アーキテクチャは [`docs/async-dpg-race-guide.md`](docs/async-dpg-race-guide.md) を参照してください。
+
 ---
 
 テスト実行方法:

--- a/docs/async-dpg-race-guide.md
+++ b/docs/async-dpg-race-guide.md
@@ -1,0 +1,63 @@
+# Async DearPyGui Race Guide
+
+This guide explains intermittent update-loop errors seen during delete/import stress (for example, deleting nodes while the async worker is running).
+
+## What's really happening
+
+The application runs two kinds of work concurrently:
+
+1. **GUI callbacks** (add/delete/import, widget interaction)
+2. **Async node updates** in `async_main` (`run_in_executor`)
+
+When both touch DearPyGui state in the same time window, a "time-of-check vs time-of-use" race can happen:
+
+- Item exists when checked
+- Item is deleted by callback
+- Async update calls `dpg.get_*` and receives `SystemError` / `RuntimeError`
+
+This is why failures often appear around delete/import operations, but the root cause is **concurrent GUI state access**, not deletion alone.
+
+## Best general-purpose solution
+
+The most reliable architecture is:
+
+1. **Single-thread ownership for DearPyGui calls**  
+   Restrict raw DPG API calls to the GUI thread.
+2. **Snapshot state for async updates**  
+   Keep per-node settings/data snapshots updated by GUI callbacks; async update logic reads snapshots instead of DPG widgets.
+3. **UI command application on GUI thread**  
+   Async workers emit results/intents; GUI thread applies widget updates.
+4. **Defensive fallback layer**  
+   Keep guarded wrappers and node-level safe parsing as safety nets.
+
+## Practical recommendations for this repository
+
+### Keep (stability-critical)
+
+- Top-level async loop exception guard in `async_main`
+- Per-node async exception handling in `update_node_info`
+- Deleted-node/stale-connection cleanup
+- Guarded DPG helpers in `node_editor/util.py`
+- Safe int parsing for node input values (`Blur`, `Resize`)
+
+### Prefer for future implementation
+
+- For code reachable from `Node.update()`, prefer `node_editor.util` guarded wrappers over direct `dpg.get_*` calls.
+- Treat node UI reads as optional in async mode:
+  - if read fails, use default/fallback values
+  - continue processing rather than exiting
+- Keep exception logs concise and actionable:
+  - node id/name
+  - exception type/message
+  - traceback
+
+### Debug workflow
+
+1. Reproduce with async mode (default)
+2. Confirm behavior in sync mode (`--unuse_async_draw`)
+3. Compare outputs/logs to classify race vs logic bug
+4. Harden specific node read paths where exceptions repeat
+
+## Why not rely only on deferred deletion?
+
+Mark-for-deletion can reduce one race window, but if async updates still call DPG APIs concurrently, races can still happen. Deferred deletion helps, but **thread ownership and snapshot-based updates** are the durable fix.

--- a/main.py
+++ b/main.py
@@ -159,8 +159,23 @@ def update_node_info(
         return True
 
     # ノードリスト取得
-    node_list = node_editor.get_node_list()
+    node_list = list(node_editor.get_node_list())
     active_node_set = set(node_list)
+
+    # Remove stale outputs for nodes deleted from the editor.
+    deleted_image_node_id_name_list = [
+        node_id_name for node_id_name in node_image_dict.keys()
+        if node_id_name not in active_node_set
+    ]
+    for deleted_node_id_name in deleted_image_node_id_name_list:
+        del node_image_dict[deleted_node_id_name]
+
+    deleted_result_node_id_name_list = [
+        node_id_name for node_id_name in node_result_dict.keys()
+        if node_id_name not in active_node_set
+    ]
+    for deleted_node_id_name in deleted_result_node_id_name_list:
+        del node_result_dict[deleted_node_id_name]
 
     # ノード接続情報取得
     sorted_node_connection_dict = node_editor.get_sorted_node_connection()
@@ -171,6 +186,15 @@ def update_node_info(
             node_image_dict[node_id_name] = None
 
         node_id, node_name = node_id_name.split(':')
+
+        # Skip nodes that were deleted in GUI callbacks during this update tick.
+        if hasattr(node_editor, 'is_node_active'):
+            try:
+                if not node_editor.is_node_active(node_id_name):
+                    continue
+            except Exception:
+                pass
+
         connection_list = sorted_node_connection_dict.get(node_id_name, [])
         connection_list = [
             connection_info for connection_info in connection_list
@@ -179,6 +203,10 @@ def update_node_info(
 
         # ノード名からインスタンスを取得
         node_instance = node_editor.get_node_instance(node_name)
+        if node_instance is None:
+            node_image_dict[node_id_name] = None
+            node_result_dict[node_id_name] = None
+            continue
         node_setting = {}
         if hasattr(node_instance, 'get_setting_dict'):
             node_setting = node_instance.get_setting_dict(node_id)

--- a/main.py
+++ b/main.py
@@ -40,20 +40,60 @@ def get_args():
     return args
 
 
-def async_main(node_editor):
+def async_main(node_editor, use_debug_print=False):
     # 各ノードの処理結果保持用Dict
     node_image_dict = {}
     node_result_dict = {}
     node_cache_dict = {}
 
+    idle_warning_tick_count = 0
+
     # メインループ
     while not node_editor.get_terminate_flag():
-        update_node_info(
+        update_summary = update_node_info(
             node_editor,
             node_image_dict,
             node_result_dict,
             node_cache_dict=node_cache_dict,
         )
+
+        if not use_debug_print:
+            continue
+
+        active_count = update_summary['active_node_count']
+        progressed = (
+            update_summary['updated_node_count'] > 0 or
+            update_summary['cache_hit_count'] > 0
+        )
+        if active_count > 0 and not progressed:
+            idle_warning_tick_count += 1
+        else:
+            idle_warning_tick_count = 0
+
+        if idle_warning_tick_count == 30:
+            print('WARNING: update loop has no progress for 30 ticks')
+            print(f"\tactive_node_count    : {active_count}")
+            print(
+                f"\tupdated_node_count   : "
+                f"{update_summary['updated_node_count']}"
+            )
+            print(
+                f"\tcache_hit_count      : "
+                f"{update_summary['cache_hit_count']}"
+            )
+            print(
+                f"\tskipped_inactive     : "
+                f"{update_summary['skipped_inactive_count']}"
+            )
+            print(
+                f"\tmissing_instance     : "
+                f"{update_summary['missing_instance_count']}"
+            )
+            print(
+                f"\texception_count      : "
+                f"{update_summary['exception_count']}"
+            )
+            print()
 
 
 def _freeze_cache_value(value):
@@ -144,6 +184,15 @@ def update_node_info(
     if node_cache_dict is None:
         node_cache_dict = {}
 
+    update_summary = {
+        'active_node_count': 0,
+        'updated_node_count': 0,
+        'cache_hit_count': 0,
+        'skipped_inactive_count': 0,
+        'missing_instance_count': 0,
+        'exception_count': 0,
+    }
+
     def _is_valid_connection(connection_info, valid_nodes):
         if len(connection_info) != 2:
             return False
@@ -161,6 +210,7 @@ def update_node_info(
     # ノードリスト取得
     node_list = list(node_editor.get_node_list())
     active_node_set = set(node_list)
+    update_summary['active_node_count'] = len(node_list)
 
     # Remove stale outputs for nodes deleted from the editor.
     deleted_image_node_id_name_list = [
@@ -191,6 +241,7 @@ def update_node_info(
         if hasattr(node_editor, 'is_node_active'):
             try:
                 if not node_editor.is_node_active(node_id_name):
+                    update_summary['skipped_inactive_count'] += 1
                     continue
             except Exception:
                 pass
@@ -204,6 +255,7 @@ def update_node_info(
         # ノード名からインスタンスを取得
         node_instance = node_editor.get_node_instance(node_name)
         if node_instance is None:
+            update_summary['missing_instance_count'] += 1
             node_image_dict[node_id_name] = None
             node_result_dict[node_id_name] = None
             continue
@@ -235,6 +287,7 @@ def update_node_info(
                 node_result_dict[node_id_name] = copy.deepcopy(
                     cached_result['result']
                 )
+                update_summary['cache_hit_count'] += 1
                 continue
 
         # 指定ノードの情報を更新
@@ -250,6 +303,7 @@ def update_node_info(
                 print(e)
                 import traceback
                 traceback.print_exc()
+                update_summary['exception_count'] += 1
                 image, result = None, None
         else:
             image, result = node_instance.update(
@@ -261,6 +315,7 @@ def update_node_info(
         # Cache-miss path (or source node path): run node update and store outputs.
         node_image_dict[node_id_name] = copy.deepcopy(image)
         node_result_dict[node_id_name] = copy.deepcopy(result)
+        update_summary['updated_node_count'] += 1
         if use_cache:
             # Persist latest outputs for the next signature match.
             node_cache_dict[node_id_name] = {
@@ -279,6 +334,8 @@ def update_node_info(
     ]
     for deleted_node_id_name in deleted_node_id_name_list:
         del node_cache_dict[deleted_node_id_name]
+
+    return update_summary
 
 
 def main():
@@ -383,7 +440,7 @@ def main():
     print('**** Start Main Event Loop ********')
     if not unuse_async_draw:
         event_loop = asyncio.get_event_loop()
-        event_loop.run_in_executor(None, async_main, node_editor)
+        event_loop.run_in_executor(None, async_main, node_editor, use_debug_print)
         dpg.start_dearpygui()
     else:
         # 各ノードの処理結果保持用Dict

--- a/main.py
+++ b/main.py
@@ -294,27 +294,35 @@ def update_node_info(
                     f'{node_id_name}: missing_instance'
                 )
             continue
+        cache_signature = None
+        # Only cache nodes that have inbound links (downstream processors).
+        # Source/input nodes must keep running every frame.
+        use_cache = len(connection_list) > 0
         node_setting = {}
-        if hasattr(node_instance, 'get_setting_dict'):
+        if use_cache and hasattr(node_instance, 'get_setting_dict'):
             if mode_async:
                 try:
                     node_setting = node_instance.get_setting_dict(node_id)
                 except Exception as e:
                     update_summary['exception_count'] += 1
-                    node_image_dict[node_id_name] = None
-                    node_result_dict[node_id_name] = None
                     if use_debug_print:
-                        update_summary['node_states'].append(
-                            f'{node_id_name}: exception:{type(e).__name__}'
+                        print(
+                            'WARNING: failed to read node settings in '
+                            f'update_node_info ({node_id_name})'
                         )
-                    continue
+                        print(
+                            f"\terror                : "
+                            f"{type(e).__name__}: {e}"
+                        )
+                        import traceback
+                        traceback.print_exc()
+                        update_summary['node_states'].append(
+                            f'{node_id_name}: setting_error:{type(e).__name__}'
+                        )
+                    use_cache = False
             else:
                 node_setting = node_instance.get_setting_dict(node_id)
 
-        cache_signature = None
-        # Only cache nodes that have inbound links (downstream processors).
-        # Source/input nodes must keep running every frame.
-        use_cache = len(connection_list) > 0
         if use_cache:
             # Cache-hit path: skip expensive update() when nothing relevant changed.
             cache_signature = _build_node_signature(
@@ -352,7 +360,10 @@ def update_node_info(
                     node_result_dict,
                 )
             except Exception as e:
-                print(e)
+                print(
+                    'WARNING: node update exception '
+                    f'({node_id_name}) {type(e).__name__}: {e}'
+                )
                 import traceback
                 traceback.print_exc()
                 update_summary['exception_count'] += 1

--- a/main.py
+++ b/main.py
@@ -52,13 +52,22 @@ def async_main(node_editor, use_debug_print=False):
     # メインループ
     while not node_editor.get_terminate_flag():
         tick_count += 1
-        update_summary = update_node_info(
-            node_editor,
-            node_image_dict,
-            node_result_dict,
-            node_cache_dict=node_cache_dict,
-            use_debug_print=use_debug_print,
-        )
+        try:
+            update_summary = update_node_info(
+                node_editor,
+                node_image_dict,
+                node_result_dict,
+                node_cache_dict=node_cache_dict,
+                use_debug_print=use_debug_print,
+            )
+        except Exception as e:
+            print('ERROR: async_main loop exception')
+            print(f"\ttick                 : {tick_count}")
+            print(f"\terror                : {type(e).__name__}: {e}")
+            import traceback
+            traceback.print_exc()
+            print()
+            continue
 
         if not use_debug_print:
             continue
@@ -287,7 +296,20 @@ def update_node_info(
             continue
         node_setting = {}
         if hasattr(node_instance, 'get_setting_dict'):
-            node_setting = node_instance.get_setting_dict(node_id)
+            if mode_async:
+                try:
+                    node_setting = node_instance.get_setting_dict(node_id)
+                except Exception as e:
+                    update_summary['exception_count'] += 1
+                    node_image_dict[node_id_name] = None
+                    node_result_dict[node_id_name] = None
+                    if use_debug_print:
+                        update_summary['node_states'].append(
+                            f'{node_id_name}: exception:{type(e).__name__}'
+                        )
+                    continue
+            else:
+                node_setting = node_instance.get_setting_dict(node_id)
 
         cache_signature = None
         # Only cache nodes that have inbound links (downstream processors).

--- a/main.py
+++ b/main.py
@@ -47,14 +47,17 @@ def async_main(node_editor, use_debug_print=False):
     node_cache_dict = {}
 
     idle_warning_tick_count = 0
+    tick_count = 0
 
     # メインループ
     while not node_editor.get_terminate_flag():
+        tick_count += 1
         update_summary = update_node_info(
             node_editor,
             node_image_dict,
             node_result_dict,
             node_cache_dict=node_cache_dict,
+            use_debug_print=use_debug_print,
         )
 
         if not use_debug_print:
@@ -72,6 +75,7 @@ def async_main(node_editor, use_debug_print=False):
 
         if idle_warning_tick_count == 30:
             print('WARNING: update loop has no progress for 30 ticks')
+            print(f"\ttick                 : {tick_count}")
             print(f"\tactive_node_count    : {active_count}")
             print(
                 f"\tupdated_node_count   : "
@@ -93,6 +97,18 @@ def async_main(node_editor, use_debug_print=False):
                 f"\texception_count      : "
                 f"{update_summary['exception_count']}"
             )
+            if update_summary['node_states']:
+                print('\tnode_states          :')
+                for state in update_summary['node_states']:
+                    print(f"\t  - {state}")
+            print()
+
+        if update_summary['exception_count'] > 0:
+            print('WARNING: update loop had node exceptions this tick')
+            print(f"\ttick                 : {tick_count}")
+            for state in update_summary['node_states']:
+                if 'exception:' in state:
+                    print(f"\t  - {state}")
             print()
 
 
@@ -170,6 +186,7 @@ def update_node_info(
     node_result_dict,
     node_cache_dict=None,
     mode_async=True,
+    use_debug_print=False,
 ):
     """
     Update all nodes in topological order with optional in-memory caching.
@@ -191,6 +208,7 @@ def update_node_info(
         'skipped_inactive_count': 0,
         'missing_instance_count': 0,
         'exception_count': 0,
+        'node_states': [],
     }
 
     def _is_valid_connection(connection_info, valid_nodes):
@@ -242,6 +260,10 @@ def update_node_info(
             try:
                 if not node_editor.is_node_active(node_id_name):
                     update_summary['skipped_inactive_count'] += 1
+                    if use_debug_print:
+                        update_summary['node_states'].append(
+                            f'{node_id_name}: skipped_inactive'
+                        )
                     continue
             except Exception:
                 pass
@@ -258,6 +280,10 @@ def update_node_info(
             update_summary['missing_instance_count'] += 1
             node_image_dict[node_id_name] = None
             node_result_dict[node_id_name] = None
+            if use_debug_print:
+                update_summary['node_states'].append(
+                    f'{node_id_name}: missing_instance'
+                )
             continue
         node_setting = {}
         if hasattr(node_instance, 'get_setting_dict'):
@@ -288,6 +314,10 @@ def update_node_info(
                     cached_result['result']
                 )
                 update_summary['cache_hit_count'] += 1
+                if use_debug_print:
+                    update_summary['node_states'].append(
+                        f'{node_id_name}: cache_hit'
+                    )
                 continue
 
         # 指定ノードの情報を更新
@@ -305,6 +335,10 @@ def update_node_info(
                 traceback.print_exc()
                 update_summary['exception_count'] += 1
                 image, result = None, None
+                if use_debug_print:
+                    update_summary['node_states'].append(
+                        f'{node_id_name}: exception:{type(e).__name__}'
+                    )
         else:
             image, result = node_instance.update(
                 node_id,
@@ -316,6 +350,11 @@ def update_node_info(
         node_image_dict[node_id_name] = copy.deepcopy(image)
         node_result_dict[node_id_name] = copy.deepcopy(result)
         update_summary['updated_node_count'] += 1
+        if use_debug_print:
+            image_state = 'none' if image is None else 'image'
+            update_summary['node_states'].append(
+                f'{node_id_name}: updated:{image_state}'
+            )
         if use_cache:
             # Persist latest outputs for the next signature match.
             node_cache_dict[node_id_name] = {
@@ -334,6 +373,9 @@ def update_node_info(
     ]
     for deleted_node_id_name in deleted_node_id_name_list:
         del node_cache_dict[deleted_node_id_name]
+
+    if not use_debug_print:
+        update_summary['node_states'] = []
 
     return update_summary
 

--- a/main.py
+++ b/main.py
@@ -144,8 +144,23 @@ def update_node_info(
     if node_cache_dict is None:
         node_cache_dict = {}
 
+    def _is_valid_connection(connection_info, valid_nodes):
+        if len(connection_info) != 2:
+            return False
+
+        source_tag, dest_tag = connection_info
+        source_node_id_name = ':'.join(source_tag.split(':')[:2])
+        dest_node_id_name = ':'.join(dest_tag.split(':')[:2])
+        if source_node_id_name not in valid_nodes:
+            return False
+        if dest_node_id_name not in valid_nodes:
+            return False
+
+        return True
+
     # ノードリスト取得
     node_list = node_editor.get_node_list()
+    active_node_set = set(node_list)
 
     # ノード接続情報取得
     sorted_node_connection_dict = node_editor.get_sorted_node_connection()
@@ -157,6 +172,10 @@ def update_node_info(
 
         node_id, node_name = node_id_name.split(':')
         connection_list = sorted_node_connection_dict.get(node_id_name, [])
+        connection_list = [
+            connection_info for connection_info in connection_list
+            if _is_valid_connection(connection_info, active_node_set)
+        ]
 
         # ノード名からインスタンスを取得
         node_instance = node_editor.get_node_instance(node_name)
@@ -203,7 +222,7 @@ def update_node_info(
                 print(e)
                 import traceback
                 traceback.print_exc()
-                sys.exit()
+                image, result = None, None
         else:
             image, result = node_instance.update(
                 node_id,

--- a/main.py
+++ b/main.py
@@ -46,79 +46,22 @@ def async_main(node_editor, use_debug_print=False):
     node_result_dict = {}
     node_cache_dict = {}
 
-    idle_warning_tick_count = 0
-    tick_count = 0
-
     # メインループ
     while not node_editor.get_terminate_flag():
-        tick_count += 1
         try:
-            update_summary = update_node_info(
+            update_node_info(
                 node_editor,
                 node_image_dict,
                 node_result_dict,
                 node_cache_dict=node_cache_dict,
-                use_debug_print=use_debug_print,
             )
         except Exception as e:
             print('ERROR: async_main loop exception')
-            print(f"\ttick                 : {tick_count}")
             print(f"\terror                : {type(e).__name__}: {e}")
             import traceback
             traceback.print_exc()
             print()
             continue
-
-        if not use_debug_print:
-            continue
-
-        active_count = update_summary['active_node_count']
-        progressed = (
-            update_summary['updated_node_count'] > 0 or
-            update_summary['cache_hit_count'] > 0
-        )
-        if active_count > 0 and not progressed:
-            idle_warning_tick_count += 1
-        else:
-            idle_warning_tick_count = 0
-
-        if idle_warning_tick_count == 30:
-            print('WARNING: update loop has no progress for 30 ticks')
-            print(f"\ttick                 : {tick_count}")
-            print(f"\tactive_node_count    : {active_count}")
-            print(
-                f"\tupdated_node_count   : "
-                f"{update_summary['updated_node_count']}"
-            )
-            print(
-                f"\tcache_hit_count      : "
-                f"{update_summary['cache_hit_count']}"
-            )
-            print(
-                f"\tskipped_inactive     : "
-                f"{update_summary['skipped_inactive_count']}"
-            )
-            print(
-                f"\tmissing_instance     : "
-                f"{update_summary['missing_instance_count']}"
-            )
-            print(
-                f"\texception_count      : "
-                f"{update_summary['exception_count']}"
-            )
-            if update_summary['node_states']:
-                print('\tnode_states          :')
-                for state in update_summary['node_states']:
-                    print(f"\t  - {state}")
-            print()
-
-        if update_summary['exception_count'] > 0:
-            print('WARNING: update loop had node exceptions this tick')
-            print(f"\ttick                 : {tick_count}")
-            for state in update_summary['node_states']:
-                if 'exception:' in state:
-                    print(f"\t  - {state}")
-            print()
 
 
 def _freeze_cache_value(value):
@@ -195,7 +138,6 @@ def update_node_info(
     node_result_dict,
     node_cache_dict=None,
     mode_async=True,
-    use_debug_print=False,
 ):
     """
     Update all nodes in topological order with optional in-memory caching.
@@ -209,16 +151,6 @@ def update_node_info(
     """
     if node_cache_dict is None:
         node_cache_dict = {}
-
-    update_summary = {
-        'active_node_count': 0,
-        'updated_node_count': 0,
-        'cache_hit_count': 0,
-        'skipped_inactive_count': 0,
-        'missing_instance_count': 0,
-        'exception_count': 0,
-        'node_states': [],
-    }
 
     def _is_valid_connection(connection_info, valid_nodes):
         if len(connection_info) != 2:
@@ -237,8 +169,6 @@ def update_node_info(
     # ノードリスト取得
     node_list = list(node_editor.get_node_list())
     active_node_set = set(node_list)
-    update_summary['active_node_count'] = len(node_list)
-
     # Remove stale outputs for nodes deleted from the editor.
     deleted_image_node_id_name_list = [
         node_id_name for node_id_name in node_image_dict.keys()
@@ -268,11 +198,6 @@ def update_node_info(
         if hasattr(node_editor, 'is_node_active'):
             try:
                 if not node_editor.is_node_active(node_id_name):
-                    update_summary['skipped_inactive_count'] += 1
-                    if use_debug_print:
-                        update_summary['node_states'].append(
-                            f'{node_id_name}: skipped_inactive'
-                        )
                     continue
             except Exception:
                 pass
@@ -286,13 +211,8 @@ def update_node_info(
         # ノード名からインスタンスを取得
         node_instance = node_editor.get_node_instance(node_name)
         if node_instance is None:
-            update_summary['missing_instance_count'] += 1
             node_image_dict[node_id_name] = None
             node_result_dict[node_id_name] = None
-            if use_debug_print:
-                update_summary['node_states'].append(
-                    f'{node_id_name}: missing_instance'
-                )
             continue
         cache_signature = None
         # Only cache nodes that have inbound links (downstream processors).
@@ -304,21 +224,13 @@ def update_node_info(
                 try:
                     node_setting = node_instance.get_setting_dict(node_id)
                 except Exception as e:
-                    update_summary['exception_count'] += 1
-                    if use_debug_print:
-                        print(
-                            'WARNING: failed to read node settings in '
-                            f'update_node_info ({node_id_name})'
-                        )
-                        print(
-                            f"\terror                : "
-                            f"{type(e).__name__}: {e}"
-                        )
-                        import traceback
-                        traceback.print_exc()
-                        update_summary['node_states'].append(
-                            f'{node_id_name}: setting_error:{type(e).__name__}'
-                        )
+                    print(
+                        'WARNING: failed to read node settings in '
+                        f'update_node_info ({node_id_name}) '
+                        f'{type(e).__name__}: {e}'
+                    )
+                    import traceback
+                    traceback.print_exc()
                     use_cache = False
             else:
                 node_setting = node_instance.get_setting_dict(node_id)
@@ -343,11 +255,6 @@ def update_node_info(
                 node_result_dict[node_id_name] = copy.deepcopy(
                     cached_result['result']
                 )
-                update_summary['cache_hit_count'] += 1
-                if use_debug_print:
-                    update_summary['node_states'].append(
-                        f'{node_id_name}: cache_hit'
-                    )
                 continue
 
         # 指定ノードの情報を更新
@@ -366,12 +273,7 @@ def update_node_info(
                 )
                 import traceback
                 traceback.print_exc()
-                update_summary['exception_count'] += 1
                 image, result = None, None
-                if use_debug_print:
-                    update_summary['node_states'].append(
-                        f'{node_id_name}: exception:{type(e).__name__}'
-                    )
         else:
             image, result = node_instance.update(
                 node_id,
@@ -382,12 +284,6 @@ def update_node_info(
         # Cache-miss path (or source node path): run node update and store outputs.
         node_image_dict[node_id_name] = copy.deepcopy(image)
         node_result_dict[node_id_name] = copy.deepcopy(result)
-        update_summary['updated_node_count'] += 1
-        if use_debug_print:
-            image_state = 'none' if image is None else 'image'
-            update_summary['node_states'].append(
-                f'{node_id_name}: updated:{image_state}'
-            )
         if use_cache:
             # Persist latest outputs for the next signature match.
             node_cache_dict[node_id_name] = {
@@ -407,10 +303,7 @@ def update_node_info(
     for deleted_node_id_name in deleted_node_id_name_list:
         del node_cache_dict[deleted_node_id_name]
 
-    if not use_debug_print:
-        update_summary['node_states'] = []
-
-    return update_summary
+    return
 
 
 def main():

--- a/node/process_node/node_blur.py
+++ b/node/process_node/node_blur.py
@@ -31,6 +31,15 @@ class Node(DpgNodeABC):
     def __init__(self):
         pass
 
+    def _safe_int_value(self, tag, default_value):
+        value = dpg_get_value(tag)
+        if value is None:
+            return default_value
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default_value
+
     def add_node(
         self,
         parent,
@@ -148,7 +157,7 @@ class Node(DpgNodeABC):
                 source_tag = connection_info[0] + 'Value'
                 destination_tag = connection_info[1] + 'Value'
                 # 値更新
-                input_value = int(dpg_get_value(source_tag))
+                input_value = self._safe_int_value(source_tag, self._min_val)
                 input_value = max([self._min_val, input_value])
                 input_value = min([self._max_val, input_value])
                 dpg_set_value(destination_tag, input_value)
@@ -162,7 +171,7 @@ class Node(DpgNodeABC):
         frame = node_image_dict.get(connection_info_src, None)
 
         # カーネルサイズ
-        kernel_size = int(dpg_get_value(input_value02_tag))
+        kernel_size = self._safe_int_value(input_value02_tag, 1)
 
         # 計測開始
         if frame is not None and use_pref_counter:

--- a/node/process_node/node_curves.py
+++ b/node/process_node/node_curves.py
@@ -48,9 +48,31 @@ class Node(DpgNodeABC):
 
     def _get_drag_points(self, node_id):
         plot_tag = self._get_tag_plot_name(node_id)
+        if not dpg.does_item_exist(plot_tag):
+            return [
+                [self._min_val, self._min_val],
+                [self._max_val, self._max_val],
+            ]
         # Drag points should be only children in slot 0
         point_items = dpg.get_item_children(plot_tag, slot=0)
-        return sorted([dpg.get_value(tag) for tag in point_items])
+        points = []
+        for tag in point_items:
+            value = dpg.get_value(tag)
+            if (
+                isinstance(value, (list, tuple)) and
+                len(value) == 2 and
+                value[0] is not None and
+                value[1] is not None
+            ):
+                points.append([value[0], value[1]])
+
+        if len(points) < 2:
+            return [
+                [self._min_val, self._min_val],
+                [self._max_val, self._max_val],
+            ]
+
+        return sorted(points)
 
     def _callback_add_point(self, sender, app_data, user_data):
         node_id = user_data[0]

--- a/node/process_node/node_curves.py
+++ b/node/process_node/node_curves.py
@@ -7,7 +7,12 @@ import cv2
 import numpy as np
 import dearpygui.dearpygui as dpg
 
-from node_editor.util import dpg_get_value, dpg_set_value, convert_cv_to_dpg
+from node_editor.util import (
+    dpg_get_value,
+    dpg_set_value,
+    dpg_get_item_children,
+    convert_cv_to_dpg,
+)
 from node.node_abc import DpgNodeABC
 
 
@@ -54,7 +59,7 @@ class Node(DpgNodeABC):
                 [self._max_val, self._max_val],
             ]
         # Drag points should be only children in slot 0
-        point_items = dpg.get_item_children(plot_tag, slot=0)
+        point_items = dpg_get_item_children(plot_tag, slot=0)
         points = []
         for tag in point_items:
             value = dpg.get_value(tag)
@@ -110,7 +115,7 @@ class Node(DpgNodeABC):
     def _callback_delete_point(self, sender, app_data, user_data):
         node_id = user_data[0]
         plot_tag = self._get_tag_plot_name(node_id)
-        point_items = dpg.get_item_children(plot_tag, slot=0)
+        point_items = dpg_get_item_children(plot_tag, slot=0)
         mouse_x, mouse_y = dpg.get_plot_mouse_pos()
 
         closest_point_tag = None

--- a/node/process_node/node_resize.py
+++ b/node/process_node/node_resize.py
@@ -43,6 +43,15 @@ class Node(DpgNodeABC):
     def __init__(self):
         pass
 
+    def _safe_int_value(self, tag, default_value):
+        value = dpg_get_value(tag)
+        if value is None:
+            return default_value
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default_value
+
     def add_node(
         self,
         parent,
@@ -202,8 +211,8 @@ class Node(DpgNodeABC):
         frame = node_image_dict.get(connection_info_src, None)
 
         # リサイズパラメータ
-        width = int(dpg_get_value(input_value02_tag))
-        height = int(dpg_get_value(input_value03_tag))
+        width = self._safe_int_value(input_value02_tag, 960)
+        height = self._safe_int_value(input_value03_tag, 540)
         if self._min_val > width:
             width = 1
             dpg_set_value(input_value02_tag, width)

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -472,6 +472,9 @@ class DpgNodeEditor(object):
     def get_node_list(self):
         return self._node_list
 
+    def is_node_active(self, node_id_name):
+        return node_id_name in self._node_list
+
     def get_sorted_node_connection(self):
         return self._node_connection_dict
 

--- a/node_editor/util.py
+++ b/node_editor/util.py
@@ -61,12 +61,27 @@ def check_serial_connection(is_debug=False):
     return serial_device_no_list
 
 def dpg_set_value(tag, value):
-    if dpg.does_item_exist(tag):
-        dpg.set_value(tag, value)
+    try:
+        if dpg.does_item_exist(tag):
+            dpg.set_value(tag, value)
+    except (SystemError, RuntimeError):
+        pass
 
 
 def dpg_get_value(tag):
     value = None
-    if dpg.does_item_exist(tag):
-        value = dpg.get_value(tag)
+    try:
+        if dpg.does_item_exist(tag):
+            value = dpg.get_value(tag)
+    except (SystemError, RuntimeError):
+        value = None
     return value
+
+
+def dpg_get_item_children(tag, slot=0):
+    try:
+        if dpg.does_item_exist(tag):
+            return dpg.get_item_children(tag, slot=slot)
+    except (SystemError, RuntimeError):
+        pass
+    return []

--- a/tests/unit/test_update_node_info.py
+++ b/tests/unit/test_update_node_info.py
@@ -304,3 +304,52 @@ def test_update_node_info_ignores_stale_connections():
         image_dict,
         result_dict,
     )
+
+
+def test_update_node_info_removes_deleted_node_outputs():
+    node = Mock()
+    node.update.return_value = ('img', {'ok': True})
+    node.get_setting_dict.return_value = {}
+
+    nodes = ['2:ProcessNode']
+    conn_dict = OrderedDict([('2:ProcessNode', [])])
+    editor = FakeEditor(nodes, conn_dict, {'ProcessNode': node})
+
+    image_dict = {
+        '1:OldNode': 'stale',
+        '2:ProcessNode': None,
+    }
+    result_dict = {
+        '1:OldNode': {'stale': True},
+    }
+
+    update_node_info(editor, image_dict, result_dict, mode_async=False)
+
+    assert '1:OldNode' not in image_dict
+    assert '1:OldNode' not in result_dict
+    assert image_dict['2:ProcessNode'] == 'img'
+
+
+def test_update_node_info_skips_inactive_nodes_during_tick():
+    class FakeEditorWithActive(FakeEditor):
+        def __init__(self, nodes, conn_dict, inst_map, active_set):
+            super().__init__(nodes, conn_dict, inst_map)
+            self.active_set = active_set
+
+        def is_node_active(self, node_id_name):
+            return node_id_name in self.active_set
+
+    node = Mock()
+    node.update.return_value = ('img', None)
+    node.get_setting_dict.return_value = {}
+
+    nodes = ['1:NodeA']
+    conn_dict = OrderedDict([('1:NodeA', [])])
+    editor = FakeEditorWithActive(nodes, conn_dict, {'NodeA': node}, active_set=set())
+
+    image_dict = {}
+    result_dict = {}
+
+    update_node_info(editor, image_dict, result_dict, mode_async=False)
+
+    node.update.assert_not_called()

--- a/tests/unit/test_update_node_info.py
+++ b/tests/unit/test_update_node_info.py
@@ -83,7 +83,7 @@ def test_update_node_info_basic(nodes, conn_dict, updates):
         assert inst_map[node_name].update.call_count == 1
 
 
-def test_update_node_info_async_exception():
+def test_update_node_info_async_exception_recovers_without_exit():
     class BadNode:
         def update(self, *args, **kwargs):
             raise ValueError("boom")
@@ -93,10 +93,14 @@ def test_update_node_info_async_exception():
     inst_map = {'TestNode': BadNode()}
     editor = FakeEditor(nodes, conn_dict, inst_map)
 
-    with patch('sys.exit', side_effect=SystemExit) as exit_mock:
-        with pytest.raises(SystemExit):
-            update_node_info(editor, {}, {}, mode_async=True)
-        assert exit_mock.called
+    image_dict = {}
+    result_dict = {}
+    with patch('sys.exit') as exit_mock:
+        update_node_info(editor, image_dict, result_dict, mode_async=True)
+
+    exit_mock.assert_not_called()
+    assert image_dict['1:TestNode'] is None
+    assert result_dict['1:TestNode'] is None
 
 
 def test_update_node_info_sync_exception():
@@ -273,3 +277,30 @@ def test_update_node_info_cleans_cache_for_deleted_nodes():
     )
 
     assert cache_dict == {}
+
+def test_update_node_info_ignores_stale_connections():
+    source_node = Mock()
+    source_node.update.return_value = ('src-img', None)
+    source_node.get_setting_dict.return_value = {}
+
+    process_node = Mock()
+    process_node.update.return_value = ('out-img', None)
+    process_node.get_setting_dict.return_value = {}
+
+    nodes = ['2:ProcessNode']
+    conn_dict = OrderedDict([
+        ('2:ProcessNode', [['1:SourceNode:Image:Output01', '2:ProcessNode:Image:Input01']]),
+    ])
+    editor = FakeEditor(nodes, conn_dict, {'ProcessNode': process_node})
+
+    image_dict = {}
+    result_dict = {}
+
+    update_node_info(editor, image_dict, result_dict, mode_async=False)
+
+    process_node.update.assert_called_once_with(
+        '2',
+        [],
+        image_dict,
+        result_dict,
+    )


### PR DESCRIPTION
### Motivation
- Prevent runtime errors caused by stale connections when nodes are deleted quickly from the graph. 
- Avoid terminating the whole application loop when a node `update()` raised in async mode. 
- Add unit coverage for both stale-connection filtering and async error recovery.

### Description
- Add a helper `_is_valid_connection` inside `update_node_info` and filter each node's `connection_list` to include only links whose source and destination node IDs still exist in the active node list. 
- Change async error handling in `update_node_info` so exceptions no longer call `sys.exit()`; instead the failed node's outputs are set to `None` for that cycle. 
- Update `tests/unit/test_update_node_info.py` to assert the new async recovery behavior and to add a regression test that stale/deleted-node connections are ignored.

### Testing
- Ran `python -m pytest --use-cv2-stub tests/unit/test_update_node_info.py -q` and the file-level tests passed (`9 passed`).
- Ran the full suite with the OpenCV stub: `python -m pytest --use-cv2-stub` and it succeeded (`44 passed, 16 skipped`).
- Running tests without the cv2 stub in this environment fails early due to a missing system OpenCV dependency (`libGL.so.1`); the provided `--use-cv2-stub` command is recommended for CI/headless environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4d8ed0fe88323847316873ad38ef9)