### PR TITLE
Add CLI `--import_json` and programmatic node-editor import handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -411,7 +411,15 @@ def main():
 
     if import_json is not None:
         print('**** Import JSON ********')
-        node_editor.import_setting_file(import_json)
+        try:
+            node_editor.import_setting_file(import_json)
+        except Exception as e:
+            print('ERROR: failed to import startup JSON file')
+            print(f'	path                 : {import_json}')
+            print(f"	error                : {type(e).__name__}: {e}")
+            import traceback
+            traceback.print_exc()
+            print()
 
     # ビューポート表示
     dpg.show_viewport()

--- a/main.py
+++ b/main.py
@@ -34,6 +34,13 @@ def get_args():
     )
     parser.add_argument("--unuse_async_draw", action="store_true")
     parser.add_argument("--use_debug_print", action="store_true")
+    parser.add_argument(
+        "-i",
+        "--import_json",
+        type=str,
+        default=None,
+        help="Path to a node editor JSON file to import at startup.",
+    )
 
     args = parser.parse_args()
 
@@ -312,6 +319,7 @@ def main():
     setting = args.setting
     unuse_async_draw = args.unuse_async_draw
     use_debug_print = args.use_debug_print
+    import_json = args.import_json
 
     # 動作設定
     print('**** Load Config ********')
@@ -400,6 +408,10 @@ def main():
         use_debug_print=use_debug_print,
         node_dir=current_path + '/node',
     )
+
+    if import_json is not None:
+        print('**** Import JSON ********')
+        node_editor.import_setting_file(import_json)
 
     # ビューポート表示
     dpg.show_viewport()

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -378,12 +378,16 @@ class DpgNodeEditor(object):
         self._vw_show_file_import()
 
     def import_setting_file(self, file_path):
+        """Public helper for startup/programmatic imports."""
+        return self._cntrl_import_setting_file(file_path)
+
+    def _cntrl_import_setting_file(self, file_path):
         with open(file_path) as fp:
             setting_dict = json.load(fp)
-        self._import_setting_dict(setting_dict)
+        self._cntrl_import_setting_dict(setting_dict)
         return setting_dict
 
-    def _import_setting_dict(self, setting_dict):
+    def _cntrl_import_setting_dict(self, setting_dict):
         if setting_dict is None:
             return
 
@@ -443,7 +447,7 @@ class DpgNodeEditor(object):
     def _cntrl_file_import(self, sender, data):
         if data['file_name'] == '.':
             return
-        setting_dict = self.import_setting_file(data['file_path_name'])
+        setting_dict = self._cntrl_import_setting_file(data['file_path_name'])
 
         if self._use_debug_print:
             print('**** _cntrl_file_import ****')

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -377,11 +377,18 @@ class DpgNodeEditor(object):
     def _cntrl_file_import_menu(self, sender, data, user_data):
         self._vw_show_file_import()
 
-    def _cntrl_file_import(self, sender, data):
-        if data['file_name'] == '.':
-            return
-        with open(data['file_path_name']) as fp:
+    def import_setting_file(self, file_path):
+        with open(file_path) as fp:
             setting_dict = json.load(fp)
+        self._import_setting_dict(setting_dict)
+        return setting_dict
+
+    def _import_setting_dict(self, setting_dict):
+        if setting_dict is None:
+            return
+
+        if 'node_list' not in setting_dict or 'link_list' not in setting_dict:
+            raise KeyError('Invalid node editor setting file format.')
 
         id_map = {}
         new_node_list = []
@@ -432,6 +439,11 @@ class DpgNodeEditor(object):
 
         self._node_link_list.extend(new_link_list)
         self._mdl_sort_node_graph()
+
+    def _cntrl_file_import(self, sender, data):
+        if data['file_name'] == '.':
+            return
+        setting_dict = self.import_setting_file(data['file_path_name'])
 
         if self._use_debug_print:
             print('**** _cntrl_file_import ****')


### PR DESCRIPTION
### Motivation

- Provide a way to load a node editor configuration at startup from a JSON file via the command line.
- Centralize and expose the existing file-import logic so import can be invoked programmatically and validated.

### Description

- Add a new CLI option `-i/--import_json` in `get_args()` and propagate `import_json` in `main()` to call `node_editor.import_setting_file(import_json)` at startup when provided.
- Introduce `import_setting_file()` and a helper `_import_setting_dict()` in `node_editor` to encapsulate loading, validation, ID remapping, node creation, and link recreation from a settings dict, and raise `KeyError` when the format is invalid.
- Replace the original UI file-import handler to reuse the new `import_setting_file()` implementation so file-import and programmatic import share the same logic.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a62ea724c08323b7113e4a5e149117)