### PR TITLE
Add DeclarativeImageProcessNodeBase and refactor basic image process nodes

### DIFF
--- a/NODE_BASE_CLASS_REFACTOR_PLAN.md
+++ b/NODE_BASE_CLASS_REFACTOR_PLAN.md
@@ -1,0 +1,193 @@
+# Node Base Class Refactor Analysis and Implementation Plan
+
+## Why this is feasible
+
+A metadata-driven base class is highly feasible in this repository because almost every node already follows the same lifecycle and naming conventions:
+
+- All node classes subclass `DpgNodeABC` and implement the same five methods (`add_node`, `update`, `get_setting_dict`, `set_setting_dict`, `close`).
+- Nodes consistently build tag strings as `"{node_id}:{node_tag}:{type}:{port}"` and then derive `...Value` tags.
+- Most visual nodes allocate a black placeholder texture, register it via `dpg.add_raw_texture`, then display/update it with `convert_cv_to_dpg` + `dpg_set_value`.
+- Many nodes repeat connection parsing logic to locate upstream image sources and to forward scalar values.
+- Many nodes repeat optional elapsed-time instrumentation when `use_pref_counter` is enabled.
+
+In short: the current code is already using a de-facto template; it is just duplicated manually.
+
+## What should be in a new base class
+
+A practical refactor is to add a **new, optional convenience base class** (for example `DeclarativeNodeBase`) that still satisfies `DpgNodeABC`, and supports:
+
+1. **Port/field declarations**
+   - Inputs, outputs, and static controls declared in a Python list/dict schema.
+   - Automatic tag generation from declarations.
+
+2. **Default node rendering**
+   - Generic `add_node()` that renders DPG widgets from the declarations.
+   - Built-in preview texture setup for image outputs.
+
+3. **Common update pipeline helpers**
+   - Resolve connected input image(s) and scalar forwarding from links.
+   - Standard elapsed-time wrapper.
+   - Standard output texture update.
+
+4. **Settings persistence helpers**
+   - Save/restore declared control values + node position automatically.
+
+5. **Hook points for one-off behavior**
+   - `before_process(...)`, `process(...)`, `after_process(...)`
+   - Optional override for `build_custom_ui(...)` to inject non-standard controls.
+   - Optional override for connection parsing if a node needs unusual link semantics.
+
+This gives a high-value default while preserving flexibility for unusual nodes.
+
+## What should stay custom (and why)
+
+Some nodes are not purely declarative and should keep custom logic (possibly still inheriting helper utilities):
+
+- **Resource/lifecycle nodes** (e.g., camera/video/model nodes) that hold long-lived external resources and use custom `close()` behavior.
+- **Deep learning nodes** that dynamically initialize model instances/provider choices and maintain internal model caches.
+- **Nodes with bespoke UI interactions** (file dialogs, multiline code editor, record toggles, concat slot controls) where a simple field schema is insufficient.
+- **Output/action nodes** where behavior is side-effect-driven (e.g., writing files), not just transforming an image.
+
+## Recommended architecture
+
+Use a layered approach rather than one giant superclass:
+
+- `DpgNodeABC` (existing): minimal contract.
+- `NodeTagMixin`: tag building/parsing helpers.
+- `NodeSettingMixin`: generic get/set setting serialization for declared controls.
+- `NodePreviewMixin`: image texture create/update helpers.
+- `NodeTimingMixin`: elapsed-time measurement helper.
+- `DeclarativeNodeBase(DpgNodeABC, ...)`: integrates mixins and supports declaration-driven nodes.
+
+This avoids forcing every node into the same mold and minimizes base-class bloat.
+
+## Mixin applicability: what *would not* use each mixin
+
+Your intuition is mostly right: **many basic nodes will use almost all mixins**. The exceptions are mainly non-visual scalar/action nodes and specialized UI/resource nodes.
+
+### 1) `NodeTagMixin`
+Likely non-users: **none** (practically every node should use this).
+
+- Reason: all nodes rely on consistent tag composition/parsing for link/update behavior.
+- Recommendation: make this near-universal and low-risk.
+
+### 2) `NodeSettingMixin`
+Likely non-users: **very few**; mostly nodes with intentionally custom persistence semantics.
+
+- Candidate partial/non-users:
+  - `node/preview_release_node/node_code_exec.py` (multiline code text may need custom migration/version handling).
+  - Any node that stores transient runtime-only handles should keep those out of generic serialized settings.
+- Recommendation: default-on, but allow per-node `serialize_fields` opt-out and custom hooks.
+
+### 3) `NodePreviewMixin` (texture create/update for image previews)
+Likely non-users: nodes without image preview textures.
+
+- Clear non-users/candidates:
+  - Scalar source nodes: `node/input_node/node_int_value.py`, `node/input_node/node_float_value.py`.
+  - Control/toggle nodes: `node/other_node/node_on_off_switch.py`.
+  - Analysis nodes that may output metrics/text only (depends on concrete UI path): `node/analysis_node/node_fps.py`.
+- Partial users:
+  - Nodes with image output but unusual preview sizing/placement can still use the mixin with override hooks.
+
+### 4) `NodeTimingMixin`
+Likely non-users: nodes where elapsed-time output is not rendered/enabled or timing is semantically misleading.
+
+- Candidate non-users:
+  - Scalar/control nodes (`Int/Float/OnOff`).
+  - Nodes doing mainly side effects rather than image transform display timing (for example, writer/toggle-only flows).
+- Recommendation: keep opt-in via declaration flag (e.g., `has_elapsed_output`).
+
+### Bottom line for “basic nodes”
+
+For classic “image in -> small parameter UI -> image out” nodes (blur/brightness/contrast/etc.), you are correct: they should generally use **all four** mixins. The mixin decomposition is mostly for:
+
+- keeping complex nodes from inheriting irrelevant behavior,
+- avoiding base-class growth,
+- making adoption incremental instead of all-or-nothing.
+
+### Quick applicability matrix (pragmatic default)
+
+- **Process nodes (basic filters/transforms):** Tag ✅ / Setting ✅ / Preview ✅ / Timing ✅
+- **Deep-learning visual nodes:** Tag ✅ / Setting ✅ / Preview ✅ / Timing ✅ (with custom process/model lifecycle)
+- **Input image/video/webcam nodes:** Tag ✅ / Setting ✅ / Preview ✅ / Timing optional
+- **Scalar/control nodes (`Int`, `Float`, `OnOff`):** Tag ✅ / Setting ✅ / Preview ❌ / Timing ❌
+- **Action/output side-effect nodes (e.g., VideoWriter):** Tag ✅ / Setting ✅ / Preview optional / Timing optional
+
+## Migration estimate and blast radius
+
+### Candidate groups
+
+1. **Low-risk, high-duplication nodes** (best first wave)
+   - Basic process nodes: blur, brightness, contrast, gamma, threshold, grayscale, etc.
+   - Many of these follow one image input + slider(s) + image output + optional elapsed time.
+
+2. **Medium-risk nodes**
+   - Input nodes with combo/select but still simple frame output.
+   - Draw/analysis nodes with small variations.
+
+3. **High-risk nodes (defer)**
+   - Video writer, code exec, concat/alpha blend, deep-learning nodes, MOT, RTSP-specific controls.
+
+### Practical rollout
+
+- **Phase 1:** Add mixins/base class without changing existing nodes.
+- **Phase 2:** Migrate 3–5 simple process nodes and validate parity.
+- **Phase 3:** Expand to remaining simple/medium nodes incrementally.
+- **Phase 4:** Decide case-by-case whether complex nodes should partially adopt only mixins.
+
+## Compatibility constraints to preserve
+
+- Keep current public node class shape (`class Node(DpgNodeABC): ...`) valid for dynamic discovery.
+- Preserve tag naming scheme because graph connection logic depends on string format.
+- Keep `get_setting_dict`/`set_setting_dict` output compatible with existing import/export JSON.
+- Do not break `node_editor` discovery/update loops.
+
+## Risk register
+
+- **Risk: Base class becomes too feature-heavy.**
+  - Mitigation: split functionality into mixins and keep hook surface small.
+- **Risk: Hidden per-node assumptions in tag naming and connection parsing.**
+  - Mitigation: preserve format exactly and migrate in small batches.
+- **Risk: Regression in import/export settings.**
+  - Mitigation: add/extend tests for serialization parity before broad migration.
+- **Risk: Hard-to-debug GUI regressions.**
+  - Mitigation: test migrated nodes with deterministic unit tests where possible and manual smoke checks.
+
+## Concrete implementation plan
+
+1. Create `node/base/` helpers (`tags.py`, `settings.py`, `preview.py`, `timing.py`).
+2. Add `declarative_node_base.py` implementing:
+   - declaration schema
+   - default `add_node/update/get_setting_dict/set_setting_dict/close`
+   - hook methods for custom behavior.
+3. Add tests for:
+   - tag generation/parsing
+   - settings serialization compatibility
+   - timing wrapper and texture update helper behavior (with stubs/mocks).
+4. Migrate a pilot set of simple nodes (e.g., Brightness, Contrast, Blur).
+5. Validate with `pytest --use-cv2-stub` and quick manual smoke test.
+6. Iterate node-by-node; keep complex nodes on legacy path until clear benefit.
+
+## Suggested declaration shape (example)
+
+```python
+class Node(DeclarativeNodeBase):
+    node_label = "Brightness"
+    node_tag = "Brightness"
+
+    spec = {
+        "inputs": [
+            {"name": "image", "type": "Image", "kind": "input"},
+            {"name": "beta", "type": "Int", "kind": "input", "widget": "slider_int", "min": 0, "max": 255, "default": 0},
+        ],
+        "outputs": [
+            {"name": "image", "type": "Image"},
+            {"name": "elapsed", "type": "TimeMS", "optional": "use_pref_counter"},
+        ],
+    }
+
+    def process(self, frame, values, context):
+        return cv2.convertScaleAbs(frame, alpha=1.0, beta=values["beta"]), None
+```
+
+This addresses your idea directly: most nodes can become declarations + core processing logic, while one-off nodes can override hooks or stay custom.

--- a/node/base/__init__.py
+++ b/node/base/__init__.py
@@ -1,0 +1,1 @@
+"""Base helpers for declarative node implementations."""

--- a/node/base/declarative_node_base.py
+++ b/node/base/declarative_node_base.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import time
+from abc import abstractmethod
+
+import dearpygui.dearpygui as dpg
+import numpy as np
+
+from node.node_abc import DpgNodeABC
+from node_editor.util import convert_cv_to_dpg, dpg_get_value, dpg_set_value
+
+
+class DeclarativeImageProcessNodeBase(DpgNodeABC):
+    """Common implementation for simple image process nodes."""
+
+    _opencv_setting_dict = None
+
+    parameters = []
+    show_elapsed_time = True
+
+    def add_node(
+        self,
+        parent,
+        node_id,
+        pos=[0, 0],
+        opencv_setting_dict=None,
+        callback=None,
+    ):
+        del callback
+
+        tag_node_name = self._node_name(node_id)
+        input_image_tag = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
+        input_image_value_tag = self._value_tag(input_image_tag)
+        output_image_tag = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
+        output_image_value_tag = self._value_tag(output_image_tag)
+        elapsed_tag = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
+        elapsed_value_tag = self._value_tag(elapsed_tag)
+
+        self._opencv_setting_dict = opencv_setting_dict
+        small_window_w = self._opencv_setting_dict['process_width']
+        small_window_h = self._opencv_setting_dict['process_height']
+        use_pref_counter = self._opencv_setting_dict['use_pref_counter']
+
+        black_image = np.zeros((small_window_w, small_window_h, 3))
+        black_texture = convert_cv_to_dpg(black_image, small_window_w, small_window_h)
+
+        with dpg.texture_registry(show=False):
+            dpg.add_raw_texture(
+                small_window_w,
+                small_window_h,
+                black_texture,
+                tag=output_image_value_tag,
+                format=dpg.mvFormat_Float_rgb,
+            )
+
+        with dpg.node(
+            tag=tag_node_name,
+            parent=parent,
+            label=self.node_label,
+            pos=pos,
+        ):
+            with dpg.node_attribute(
+                tag=input_image_tag,
+                attribute_type=dpg.mvNode_Attr_Input,
+            ):
+                dpg.add_text(
+                    tag=input_image_value_tag,
+                    default_value='Input BGR image',
+                )
+
+            with dpg.node_attribute(
+                tag=output_image_tag,
+                attribute_type=dpg.mvNode_Attr_Output,
+            ):
+                dpg.add_image(output_image_value_tag)
+
+            for parameter in self.parameters:
+                self._add_parameter_ui(tag_node_name, parameter, small_window_w)
+
+            if self.show_elapsed_time and use_pref_counter:
+                with dpg.node_attribute(
+                    tag=elapsed_tag,
+                    attribute_type=dpg.mvNode_Attr_Output,
+                ):
+                    dpg.add_text(
+                        tag=elapsed_value_tag,
+                        default_value='elapsed time(ms)',
+                    )
+
+        return tag_node_name
+
+    def update(
+        self,
+        node_id,
+        connection_list,
+        node_image_dict,
+        node_result_dict,
+    ):
+        del node_result_dict
+
+        tag_node_name = self._node_name(node_id)
+        output_image_value_tag = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
+        )
+        elapsed_value_tag = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
+        )
+
+        small_window_w = self._opencv_setting_dict['process_width']
+        small_window_h = self._opencv_setting_dict['process_height']
+        use_pref_counter = self._opencv_setting_dict['use_pref_counter']
+
+        connection_info_src = ''
+        self._sync_linked_parameters(connection_list)
+
+        for connection_info in connection_list:
+            connection_type = connection_info[0].split(':')[2]
+            if connection_type == self.TYPE_IMAGE:
+                connection_info_src = ':'.join(connection_info[0].split(':')[:2])
+
+        frame = node_image_dict.get(connection_info_src, None)
+        parameter_values = self._get_parameter_values(tag_node_name)
+
+        start_time = None
+        if frame is not None and use_pref_counter:
+            start_time = time.perf_counter()
+
+        if frame is not None:
+            frame, result = self.process(frame, **parameter_values)
+        else:
+            result = None
+
+        if frame is not None and use_pref_counter and start_time is not None:
+            elapsed_time = int((time.perf_counter() - start_time) * 1000)
+            dpg_set_value(elapsed_value_tag, str(elapsed_time).zfill(4) + 'ms')
+
+        if frame is not None:
+            texture = convert_cv_to_dpg(frame, small_window_w, small_window_h)
+            dpg_set_value(output_image_value_tag, texture)
+
+        return frame, result
+
+    def close(self, node_id):
+        del node_id
+
+    def get_setting_dict(self, node_id):
+        tag_node_name = self._node_name(node_id)
+
+        setting_dict = {
+            'ver': self._ver,
+            'pos': dpg.get_item_pos(tag_node_name),
+        }
+
+        for parameter in self.parameters:
+            parameter_value_tag = self._value_tag(
+                self._port_tag(tag_node_name, parameter['type'], parameter['port'])
+            )
+            setting_dict[parameter_value_tag] = dpg_get_value(parameter_value_tag)
+
+        return setting_dict
+
+    def set_setting_dict(self, node_id, setting_dict):
+        tag_node_name = self._node_name(node_id)
+
+        for parameter in self.parameters:
+            parameter_value_tag = self._value_tag(
+                self._port_tag(tag_node_name, parameter['type'], parameter['port'])
+            )
+            if parameter_value_tag not in setting_dict:
+                continue
+            value = self._cast_parameter_value(parameter, setting_dict[parameter_value_tag])
+            dpg_set_value(parameter_value_tag, value)
+
+    @abstractmethod
+    def process(self, frame, **parameter_values):
+        pass
+
+    def _sync_linked_parameters(self, connection_list):
+        for connection_info in connection_list:
+            connection_type = connection_info[0].split(':')[2]
+            parameter = self._find_parameter_by_type(connection_type)
+            if parameter is None:
+                continue
+
+            source_tag = connection_info[0] + 'Value'
+            destination_tag = connection_info[1] + 'Value'
+            source_value = dpg_get_value(source_tag)
+            if source_value is None:
+                continue
+
+            value = self._cast_parameter_value(parameter, source_value)
+            value = self._clamp_parameter_value(parameter, value)
+            dpg_set_value(destination_tag, value)
+
+    def _get_parameter_values(self, tag_node_name):
+        values = {}
+        for parameter in self.parameters:
+            parameter_value_tag = self._value_tag(
+                self._port_tag(tag_node_name, parameter['type'], parameter['port'])
+            )
+            value = dpg_get_value(parameter_value_tag)
+            value = self._cast_parameter_value(parameter, value)
+            value = self._clamp_parameter_value(parameter, value)
+            values[parameter['name']] = value
+        return values
+
+    def _add_parameter_ui(self, tag_node_name, parameter, width):
+        port_tag = self._port_tag(tag_node_name, parameter['type'], parameter['port'])
+        value_tag = self._value_tag(port_tag)
+
+        with dpg.node_attribute(
+            tag=port_tag,
+            attribute_type=dpg.mvNode_Attr_Input,
+        ):
+            if parameter['widget'] == 'slider_int':
+                dpg.add_slider_int(
+                    tag=value_tag,
+                    label=parameter['label'],
+                    width=width - 80,
+                    default_value=parameter['default'],
+                    min_value=parameter['min'],
+                    max_value=parameter['max'],
+                    callback=None,
+                )
+            elif parameter['widget'] == 'slider_float':
+                dpg.add_slider_float(
+                    tag=value_tag,
+                    label=parameter['label'],
+                    width=width - 80,
+                    default_value=parameter['default'],
+                    min_value=parameter['min'],
+                    max_value=parameter['max'],
+                    callback=None,
+                )
+
+    def _find_parameter_by_type(self, value_type):
+        for parameter in self.parameters:
+            if parameter['type'] == value_type:
+                return parameter
+        return None
+
+    def _cast_parameter_value(self, parameter, value):
+        cast = parameter.get('cast', None)
+        if cast is int:
+            return int(value)
+        if cast is float:
+            value = float(value)
+            precision = parameter.get('precision', None)
+            if precision is not None:
+                value = round(value, precision)
+            return value
+        return value
+
+    def _clamp_parameter_value(self, parameter, value):
+        min_value = parameter.get('min', None)
+        max_value = parameter.get('max', None)
+
+        if min_value is not None:
+            value = max(min_value, value)
+        if max_value is not None:
+            value = min(max_value, value)
+        return value
+
+    def _node_name(self, node_id):
+        return str(node_id) + ':' + self.node_tag
+
+    def _port_tag(self, node_name, value_type, port_name):
+        return f'{node_name}:{value_type}:{port_name}'
+
+    def _value_tag(self, port_tag):
+        return f'{port_tag}Value'

--- a/node/process_node/node_blur.py
+++ b/node/process_node/node_blur.py
@@ -1,216 +1,34 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import time
-
 import cv2
-import numpy as np
-import dearpygui.dearpygui as dpg
 
-from node_editor.util import dpg_get_value, dpg_set_value
-
-from node.node_abc import DpgNodeABC
-from node_editor.util import convert_cv_to_dpg
+from node.base.declarative_node_base import DeclarativeImageProcessNodeBase
 
 
 def image_process(image, kernel_size):
-    image = cv2.blur(image, (kernel_size, kernel_size))
-    return image
+    return cv2.blur(image, (kernel_size, kernel_size))
 
-
-class Node(DpgNodeABC):
+class Node(DeclarativeImageProcessNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Blur'
     node_tag = 'Blur'
 
-    _min_val = 1
-    _max_val = 128
+    parameters = [
+        {
+            'name': 'kernel_size',
+            'type': DeclarativeImageProcessNodeBase.TYPE_INT,
+            'port': 'Input02',
+            'widget': 'slider_int',
+            'label': 'kernel',
+            'default': 5,
+            'min': 1,
+            'max': 128,
+            'cast': int,
+        },
+    ]
 
-    _opencv_setting_dict = None
-
-    def __init__(self):
-        pass
-
-    def add_node(
-        self,
-        parent,
-        node_id,
-        pos=[0, 0],
-        opencv_setting_dict=None,
-        callback=None,
-    ):
-        # タグ名
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        tag_node_input01_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Input01'
-        tag_node_input01_value_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Input01Value'
-        tag_node_input02_name = tag_node_name + ':' + self.TYPE_INT + ':Input02'
-        tag_node_input02_value_name = tag_node_name + ':' + self.TYPE_INT + ':Input02Value'
-        tag_node_output01_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01'
-        tag_node_output01_value_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01Value'
-        tag_node_output02_name = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02'
-        tag_node_output02_value_name = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02Value'
-
-        # OpenCV向け設定
-        self._opencv_setting_dict = opencv_setting_dict
-        small_window_w = self._opencv_setting_dict['process_width']
-        small_window_h = self._opencv_setting_dict['process_height']
-        use_pref_counter = self._opencv_setting_dict['use_pref_counter']
-
-        # 初期化用黒画像
-        black_image = np.zeros((small_window_w, small_window_h, 3))
-        black_texture = convert_cv_to_dpg(
-            black_image,
-            small_window_w,
-            small_window_h,
-        )
-
-        # テクスチャ登録
-        with dpg.texture_registry(show=False):
-            dpg.add_raw_texture(
-                small_window_w,
-                small_window_h,
-                black_texture,
-                tag=tag_node_output01_value_name,
-                format=dpg.mvFormat_Float_rgb,
-            )
-
-        # ノード
-        with dpg.node(
-                tag=tag_node_name,
-                parent=parent,
-                label=self.node_label,
-                pos=pos,
-        ):
-            # 入力端子
-            with dpg.node_attribute(
-                    tag=tag_node_input01_name,
-                    attribute_type=dpg.mvNode_Attr_Input,
-            ):
-                dpg.add_text(
-                    tag=tag_node_input01_value_name,
-                    default_value='Input BGR image',
-                )
-            # 画像
-            with dpg.node_attribute(
-                    tag=tag_node_output01_name,
-                    attribute_type=dpg.mvNode_Attr_Output,
-            ):
-                dpg.add_image(tag_node_output01_value_name)
-            # カーネルサイズ
-            with dpg.node_attribute(
-                    tag=tag_node_input02_name,
-                    attribute_type=dpg.mvNode_Attr_Input,
-            ):
-                dpg.add_slider_int(
-                    tag=tag_node_input02_value_name,
-                    label="kernel",
-                    width=small_window_w - 80,
-                    default_value=5,
-                    min_value=self._min_val,
-                    max_value=self._max_val,
-                    callback=None,
-                )
-            # 処理時間
-            if use_pref_counter:
-                with dpg.node_attribute(
-                        tag=tag_node_output02_name,
-                        attribute_type=dpg.mvNode_Attr_Output,
-                ):
-                    dpg.add_text(
-                        tag=tag_node_output02_value_name,
-                        default_value='elapsed time(ms)',
-                    )
-
-        return tag_node_name
-
-    def update(
-        self,
-        node_id,
-        connection_list,
-        node_image_dict,
-        node_result_dict,
-    ):
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        input_value02_tag = tag_node_name + ':' + self.TYPE_INT + ':Input02Value'
-        output_value01_tag = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01Value'
-        output_value02_tag = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02Value'
-
-        small_window_w = self._opencv_setting_dict['process_width']
-        small_window_h = self._opencv_setting_dict['process_height']
-        use_pref_counter = self._opencv_setting_dict['use_pref_counter']
-
-        # 接続情報確認
-        connection_info_src = ''
-        for connection_info in connection_list:
-            connection_type = connection_info[0].split(':')[2]
-            if connection_type == self.TYPE_INT:
-                # 接続タグ取得
-                source_tag = connection_info[0] + 'Value'
-                destination_tag = connection_info[1] + 'Value'
-                # 値更新
-                input_value = int(dpg_get_value(source_tag))
-                input_value = max([self._min_val, input_value])
-                input_value = min([self._max_val, input_value])
-                dpg_set_value(destination_tag, input_value)
-            if connection_type == self.TYPE_IMAGE:
-                # 画像取得元のノード名(ID付き)を取得
-                connection_info_src = connection_info[0]
-                connection_info_src = connection_info_src.split(':')[:2]
-                connection_info_src = ':'.join(connection_info_src)
-
-        # 画像取得
-        frame = node_image_dict.get(connection_info_src, None)
-
-        # カーネルサイズ
-        kernel_size = int(dpg_get_value(input_value02_tag))
-
-        # 計測開始
-        if frame is not None and use_pref_counter:
-            start_time = time.perf_counter()
-
-        if frame is not None:
-            frame = image_process(frame, kernel_size)
-
-        # 計測終了
-        if frame is not None and use_pref_counter:
-            elapsed_time = time.perf_counter() - start_time
-            elapsed_time = int(elapsed_time * 1000)
-            dpg_set_value(output_value02_tag,
-                          str(elapsed_time).zfill(4) + 'ms')
-
-        # 描画
-        if frame is not None:
-            texture = convert_cv_to_dpg(
-                frame,
-                small_window_w,
-                small_window_h,
-            )
-            dpg_set_value(output_value01_tag, texture)
-
+    def process(self, frame, **parameter_values):
+        kernel_size = parameter_values['kernel_size']
+        frame = image_process(frame, kernel_size)
         return frame, None
-
-    def close(self, node_id):
-        pass
-
-    def get_setting_dict(self, node_id):
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        input_value02_tag = tag_node_name + ':' + self.TYPE_INT + ':Input02Value'
-
-        kernel_size = dpg_get_value(input_value02_tag)
-
-        pos = dpg.get_item_pos(tag_node_name)
-
-        setting_dict = {}
-        setting_dict['ver'] = self._ver
-        setting_dict['pos'] = pos
-        setting_dict[input_value02_tag] = kernel_size
-
-        return setting_dict
-
-    def set_setting_dict(self, node_id, setting_dict):
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        input_value02_tag = tag_node_name + ':' + self.TYPE_INT + ':Input02Value'
-
-        kernel_size = int(setting_dict[input_value02_tag])
-
-        dpg_set_value(input_value02_tag, kernel_size)

--- a/node/process_node/node_brightness.py
+++ b/node/process_node/node_brightness.py
@@ -1,216 +1,34 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import time
-
 import cv2
-import numpy as np
-import dearpygui.dearpygui as dpg
 
-from node_editor.util import dpg_get_value, dpg_set_value
-
-from node.node_abc import DpgNodeABC
-from node_editor.util import convert_cv_to_dpg
+from node.base.declarative_node_base import DeclarativeImageProcessNodeBase
 
 
 def image_process(image, beta):
-    image = cv2.convertScaleAbs(image, alpha=1.0, beta=beta)
-    return image
+    return cv2.convertScaleAbs(image, alpha=1.0, beta=beta)
 
-
-class Node(DpgNodeABC):
+class Node(DeclarativeImageProcessNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Brightness'
     node_tag = 'Brightness'
 
-    _min_val = 0
-    _max_val = 255
+    parameters = [
+        {
+            'name': 'beta',
+            'type': DeclarativeImageProcessNodeBase.TYPE_INT,
+            'port': 'Input02',
+            'widget': 'slider_int',
+            'label': 'beta',
+            'default': 0,
+            'min': 0,
+            'max': 255,
+            'cast': int,
+        },
+    ]
 
-    _opencv_setting_dict = None
-
-    def __init__(self):
-        pass
-
-    def add_node(
-        self,
-        parent,
-        node_id,
-        pos=[0, 0],
-        opencv_setting_dict=None,
-        callback=None,
-    ):
-        # タグ名
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        tag_node_input01_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Input01'
-        tag_node_input01_value_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Input01Value'
-        tag_node_input02_name = tag_node_name + ':' + self.TYPE_INT + ':Input02'
-        tag_node_input02_value_name = tag_node_name + ':' + self.TYPE_INT + ':Input02Value'
-        tag_node_output01_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01'
-        tag_node_output01_value_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01Value'
-        tag_node_output02_name = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02'
-        tag_node_output02_value_name = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02Value'
-
-        # OpenCV向け設定
-        self._opencv_setting_dict = opencv_setting_dict
-        small_window_w = self._opencv_setting_dict['process_width']
-        small_window_h = self._opencv_setting_dict['process_height']
-        use_pref_counter = self._opencv_setting_dict['use_pref_counter']
-
-        # 初期化用黒画像
-        black_image = np.zeros((small_window_w, small_window_h, 3))
-        black_texture = convert_cv_to_dpg(
-            black_image,
-            small_window_w,
-            small_window_h,
-        )
-
-        # テクスチャ登録
-        with dpg.texture_registry(show=False):
-            dpg.add_raw_texture(
-                small_window_w,
-                small_window_h,
-                black_texture,
-                tag=tag_node_output01_value_name,
-                format=dpg.mvFormat_Float_rgb,
-            )
-
-        # ノード
-        with dpg.node(
-                tag=tag_node_name,
-                parent=parent,
-                label=self.node_label,
-                pos=pos,
-        ):
-            # 入力端子
-            with dpg.node_attribute(
-                    tag=tag_node_input01_name,
-                    attribute_type=dpg.mvNode_Attr_Input,
-            ):
-                dpg.add_text(
-                    tag=tag_node_input01_value_name,
-                    default_value='Input BGR image',
-                )
-            # 画像
-            with dpg.node_attribute(
-                    tag=tag_node_output01_name,
-                    attribute_type=dpg.mvNode_Attr_Output,
-            ):
-                dpg.add_image(tag_node_output01_value_name)
-            # カーネルサイズ
-            with dpg.node_attribute(
-                    tag=tag_node_input02_name,
-                    attribute_type=dpg.mvNode_Attr_Input,
-            ):
-                dpg.add_slider_int(
-                    tag=tag_node_input02_value_name,
-                    label="beta",
-                    width=small_window_w - 80,
-                    default_value=0,
-                    min_value=self._min_val,
-                    max_value=self._max_val,
-                    callback=None,
-                )
-            # 処理時間
-            if use_pref_counter:
-                with dpg.node_attribute(
-                        tag=tag_node_output02_name,
-                        attribute_type=dpg.mvNode_Attr_Output,
-                ):
-                    dpg.add_text(
-                        tag=tag_node_output02_value_name,
-                        default_value='elapsed time(ms)',
-                    )
-
-        return tag_node_name
-
-    def update(
-        self,
-        node_id,
-        connection_list,
-        node_image_dict,
-        node_result_dict,
-    ):
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        input_value02_tag = tag_node_name + ':' + self.TYPE_INT + ':Input02Value'
-        output_value01_tag = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01Value'
-        output_value02_tag = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02Value'
-
-        small_window_w = self._opencv_setting_dict['process_width']
-        small_window_h = self._opencv_setting_dict['process_height']
-        use_pref_counter = self._opencv_setting_dict['use_pref_counter']
-
-        # 接続情報確認
-        connection_info_src = ''
-        for connection_info in connection_list:
-            connection_type = connection_info[0].split(':')[2]
-            if connection_type == self.TYPE_INT:
-                # 接続タグ取得
-                source_tag = connection_info[0] + 'Value'
-                destination_tag = connection_info[1] + 'Value'
-                # 値更新
-                input_value = int(dpg_get_value(source_tag))
-                input_value = max([self._min_val, input_value])
-                input_value = min([self._max_val, input_value])
-                dpg_set_value(destination_tag, input_value)
-            if connection_type == self.TYPE_IMAGE:
-                # 画像取得元のノード名(ID付き)を取得
-                connection_info_src = connection_info[0]
-                connection_info_src = connection_info_src.split(':')[:2]
-                connection_info_src = ':'.join(connection_info_src)
-
-        # 画像取得
-        frame = node_image_dict.get(connection_info_src, None)
-
-        # スケールバイアス
-        beta = int(dpg_get_value(input_value02_tag))
-
-        # 計測開始
-        if frame is not None and use_pref_counter:
-            start_time = time.perf_counter()
-
-        if frame is not None:
-            frame = image_process(frame, beta)
-
-        # 計測終了
-        if frame is not None and use_pref_counter:
-            elapsed_time = time.perf_counter() - start_time
-            elapsed_time = int(elapsed_time * 1000)
-            dpg_set_value(output_value02_tag,
-                          str(elapsed_time).zfill(4) + 'ms')
-
-        # 描画
-        if frame is not None:
-            texture = convert_cv_to_dpg(
-                frame,
-                small_window_w,
-                small_window_h,
-            )
-            dpg_set_value(output_value01_tag, texture)
-
+    def process(self, frame, **parameter_values):
+        beta = parameter_values['beta']
+        frame = image_process(frame, beta)
         return frame, None
-
-    def close(self, node_id):
-        pass
-
-    def get_setting_dict(self, node_id):
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        input_value02_tag = tag_node_name + ':' + self.TYPE_INT + ':Input02Value'
-
-        kernel_size = dpg_get_value(input_value02_tag)
-
-        pos = dpg.get_item_pos(tag_node_name)
-
-        setting_dict = {}
-        setting_dict['ver'] = self._ver
-        setting_dict['pos'] = pos
-        setting_dict[input_value02_tag] = kernel_size
-
-        return setting_dict
-
-    def set_setting_dict(self, node_id, setting_dict):
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        input_value02_tag = tag_node_name + ':' + self.TYPE_INT + ':Input02Value'
-
-        kernel_size = int(setting_dict[input_value02_tag])
-
-        dpg_set_value(input_value02_tag, kernel_size)

--- a/node/process_node/node_contrast.py
+++ b/node/process_node/node_contrast.py
@@ -1,216 +1,35 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import time
-
 import cv2
-import numpy as np
-import dearpygui.dearpygui as dpg
 
-from node_editor.util import dpg_get_value, dpg_set_value
-
-from node.node_abc import DpgNodeABC
-from node_editor.util import convert_cv_to_dpg
+from node.base.declarative_node_base import DeclarativeImageProcessNodeBase
 
 
 def image_process(image, alpha):
-    image = cv2.convertScaleAbs(image, alpha=alpha, beta=0)
-    return image
+    return cv2.convertScaleAbs(image, alpha=alpha, beta=0)
 
-
-class Node(DpgNodeABC):
+class Node(DeclarativeImageProcessNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Contrast'
     node_tag = 'Contrast'
 
-    _min_val = 0.0
-    _max_val = 4.0
+    parameters = [
+        {
+            'name': 'alpha',
+            'type': DeclarativeImageProcessNodeBase.TYPE_FLOAT,
+            'port': 'Input02',
+            'widget': 'slider_float',
+            'label': 'alpha',
+            'default': 1.0,
+            'min': 0.0,
+            'max': 4.0,
+            'cast': float,
+            'precision': 3,
+        },
+    ]
 
-    _opencv_setting_dict = None
-
-    def __init__(self):
-        pass
-
-    def add_node(
-        self,
-        parent,
-        node_id,
-        pos=[0, 0],
-        opencv_setting_dict=None,
-        callback=None,
-    ):
-        # タグ名
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        tag_node_input01_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Input01'
-        tag_node_input01_value_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Input01Value'
-        tag_node_input02_name = tag_node_name + ':' + self.TYPE_FLOAT + ':Input02'
-        tag_node_input02_value_name = tag_node_name + ':' + self.TYPE_FLOAT + ':Input02Value'
-        tag_node_output01_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01'
-        tag_node_output01_value_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01Value'
-        tag_node_output02_name = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02'
-        tag_node_output02_value_name = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02Value'
-
-        # OpenCV向け設定
-        self._opencv_setting_dict = opencv_setting_dict
-        small_window_w = self._opencv_setting_dict['process_width']
-        small_window_h = self._opencv_setting_dict['process_height']
-        use_pref_counter = self._opencv_setting_dict['use_pref_counter']
-
-        # 初期化用黒画像
-        black_image = np.zeros((small_window_w, small_window_h, 3))
-        black_texture = convert_cv_to_dpg(
-            black_image,
-            small_window_w,
-            small_window_h,
-        )
-
-        # テクスチャ登録
-        with dpg.texture_registry(show=False):
-            dpg.add_raw_texture(
-                small_window_w,
-                small_window_h,
-                black_texture,
-                tag=tag_node_output01_value_name,
-                format=dpg.mvFormat_Float_rgb,
-            )
-
-        # ノード
-        with dpg.node(
-                tag=tag_node_name,
-                parent=parent,
-                label=self.node_label,
-                pos=pos,
-        ):
-            # 入力端子
-            with dpg.node_attribute(
-                    tag=tag_node_input01_name,
-                    attribute_type=dpg.mvNode_Attr_Input,
-            ):
-                dpg.add_text(
-                    tag=tag_node_input01_value_name,
-                    default_value='Input BGR image',
-                )
-            # 画像
-            with dpg.node_attribute(
-                    tag=tag_node_output01_name,
-                    attribute_type=dpg.mvNode_Attr_Output,
-            ):
-                dpg.add_image(tag_node_output01_value_name)
-            # スケールファクタ
-            with dpg.node_attribute(
-                    tag=tag_node_input02_name,
-                    attribute_type=dpg.mvNode_Attr_Input,
-            ):
-                dpg.add_slider_float(
-                    tag=tag_node_input02_value_name,
-                    label="alpha",
-                    width=small_window_w - 80,
-                    default_value=1.0,
-                    min_value=self._min_val,
-                    max_value=self._max_val,
-                    callback=None,
-                )
-            # 処理時間
-            if use_pref_counter:
-                with dpg.node_attribute(
-                        tag=tag_node_output02_name,
-                        attribute_type=dpg.mvNode_Attr_Output,
-                ):
-                    dpg.add_text(
-                        tag=tag_node_output02_value_name,
-                        default_value='elapsed time(ms)',
-                    )
-
-        return tag_node_name
-
-    def update(
-        self,
-        node_id,
-        connection_list,
-        node_image_dict,
-        node_result_dict,
-    ):
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        input_value02_tag = tag_node_name + ':' + self.TYPE_FLOAT + ':Input02Value'
-        output_value01_tag = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01Value'
-        output_value02_tag = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02Value'
-
-        small_window_w = self._opencv_setting_dict['process_width']
-        small_window_h = self._opencv_setting_dict['process_height']
-        use_pref_counter = self._opencv_setting_dict['use_pref_counter']
-
-        # 接続情報確認
-        connection_info_src = ''
-        for connection_info in connection_list:
-            connection_type = connection_info[0].split(':')[2]
-            if connection_type == self.TYPE_FLOAT:
-                # 接続タグ取得
-                source_tag = connection_info[0] + 'Value'
-                destination_tag = connection_info[1] + 'Value'
-                # 値更新
-                input_value = round(float(dpg_get_value(source_tag)), 3)
-                input_value = max([self._min_val, input_value])
-                input_value = min([self._max_val, input_value])
-                dpg_set_value(destination_tag, input_value)
-            if connection_type == self.TYPE_IMAGE:
-                # 画像取得元のノード名(ID付き)を取得
-                connection_info_src = connection_info[0]
-                connection_info_src = connection_info_src.split(':')[:2]
-                connection_info_src = ':'.join(connection_info_src)
-
-        # 画像取得
-        frame = node_image_dict.get(connection_info_src, None)
-
-        # スケールファクタ
-        alpha = float(dpg_get_value(input_value02_tag))
-
-        # 計測開始
-        if frame is not None and use_pref_counter:
-            start_time = time.perf_counter()
-
-        if frame is not None:
-            frame = image_process(frame, alpha)
-
-        # 計測終了
-        if frame is not None and use_pref_counter:
-            elapsed_time = time.perf_counter() - start_time
-            elapsed_time = int(elapsed_time * 1000)
-            dpg_set_value(output_value02_tag,
-                          str(elapsed_time).zfill(4) + 'ms')
-
-        # 描画
-        if frame is not None:
-            texture = convert_cv_to_dpg(
-                frame,
-                small_window_w,
-                small_window_h,
-            )
-            dpg_set_value(output_value01_tag, texture)
-
+    def process(self, frame, **parameter_values):
+        alpha = parameter_values['alpha']
+        frame = image_process(frame, alpha)
         return frame, None
-
-    def close(self, node_id):
-        pass
-
-    def get_setting_dict(self, node_id):
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        input_value02_tag = tag_node_name + ':' + self.TYPE_FLOAT + ':Input02Value'
-
-        kernel_size = dpg_get_value(input_value02_tag)
-
-        pos = dpg.get_item_pos(tag_node_name)
-
-        setting_dict = {}
-        setting_dict['ver'] = self._ver
-        setting_dict['pos'] = pos
-        setting_dict[input_value02_tag] = kernel_size
-
-        return setting_dict
-
-    def set_setting_dict(self, node_id, setting_dict):
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        input_value02_tag = tag_node_name + ':' + self.TYPE_FLOAT + ':Input02Value'
-
-        kernel_size = float(setting_dict[input_value02_tag])
-
-        dpg_set_value(input_value02_tag, kernel_size)

--- a/tests/integration/test_node_editor_integration.py
+++ b/tests/integration/test_node_editor_integration.py
@@ -14,6 +14,7 @@ from node_editor.node_editor import DpgNodeEditor
 from main import update_node_info
 from node.process_node.node_blur import image_process as blur_image_process
 from node.process_node.node_contrast import image_process as contrast_image_process
+from node.process_node.node_brightness import image_process as brightness_image_process
 
 
 class TestNodeEditorIntegration:
@@ -161,6 +162,88 @@ class TestNodeEditorIntegration:
 
         finally:
             # Cleanup
+            if os.path.exists(image_path):
+                os.unlink(image_path)
+
+
+    @pytest.mark.parametrize("brightness_beta", [0, 32, 96])
+    def test_image_brightness_pipeline(self, brightness_beta, debug_test):
+        """Test image input -> brightness processing pipeline."""
+        test_image = self.create_gradient_image()
+
+        with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as tmp:
+            cv2.imwrite(tmp.name, test_image)
+            image_path = tmp.name
+
+        try:
+            menu_dict = OrderedDict({
+                'InputNode': 'input_node',
+                'ProcessNode': 'process_node',
+            })
+            editor = DpgNodeEditor(
+                width=800,
+                height=600,
+                opencv_setting_dict={
+                    'input_window_width': self.node_width,
+                    'input_window_height': self.node_height,
+                    'process_width': self.node_width,
+                    'process_height': self.node_height,
+                    'use_pref_counter': False
+                },
+                menu_dict=menu_dict,
+                node_dir='node'
+            )
+            self.advance_frames()
+
+            editor._cntrl_add_node(None, None, 'Image')
+            image_node_id = '1:Image'
+
+            editor._last_pos = [self.node_width, self.node_height]
+            editor._cntrl_add_node(None, None, 'Brightness')
+            brightness_node_id = '2:Brightness'
+
+            image_node = editor.get_node_instance('Image')
+            image_node._image_filepath['1'] = image_path
+            image_node._image['1'] = test_image
+
+            brightness_node = editor.get_node_instance('Brightness')
+            beta_tag = brightness_node_id + ':' + brightness_node.TYPE_INT + ':Input02Value'
+            dpg.set_value(beta_tag, brightness_beta)
+
+            image_output_tag = image_node_id + ':' + image_node.TYPE_IMAGE + ':Output01'
+            brightness_input_tag = brightness_node_id + ':' + brightness_node.TYPE_IMAGE + ':Input01'
+
+            image_output_id = dpg.get_alias_id(image_output_tag)
+            brightness_input_id = dpg.get_alias_id(brightness_input_tag)
+            editor._cntrl_link('NodeEditor', [image_output_id, brightness_input_id])
+
+            node_image_dict = {}
+            node_result_dict = {}
+            update_node_info(editor, node_image_dict, node_result_dict)
+
+            assert image_node_id in node_image_dict
+            assert brightness_node_id in node_image_dict
+
+            image_result = node_image_dict[image_node_id]
+            brightness_result = node_image_dict[brightness_node_id]
+
+            assert image_result is not None
+            assert brightness_result is not None
+            assert brightness_result.shape == test_image.shape
+
+            expected_brightness_result = brightness_image_process(test_image, brightness_beta)
+            np.testing.assert_allclose(
+                brightness_result,
+                expected_brightness_result,
+                atol=1,
+                err_msg='Brightness node output differs from direct processing',
+            )
+
+            if debug_test:
+                self.advance_frames()
+                breakpoint()
+
+        finally:
             if os.path.exists(image_path):
                 os.unlink(image_path)
 

--- a/tests/unit/test_declarative_process_nodes.py
+++ b/tests/unit/test_declarative_process_nodes.py
@@ -1,0 +1,107 @@
+import numpy as np
+
+from node.base import declarative_node_base as base_module
+import node.process_node.node_blur as blur_module
+import node.process_node.node_brightness as brightness_module
+import node.process_node.node_contrast as contrast_module
+
+BlurNode = blur_module.Node
+BrightnessNode = brightness_module.Node
+ContrastNode = contrast_module.Node
+
+
+class DpgStub:
+    @staticmethod
+    def get_item_pos(tag):
+        assert tag
+        return [10, 20]
+
+
+def _prepare_node(node):
+    node._opencv_setting_dict = {
+        'process_width': 8,
+        'process_height': 8,
+        'use_pref_counter': False,
+    }
+
+
+def test_blur_node_update_with_parameter_link(monkeypatch):
+    node = BlurNode()
+    _prepare_node(node)
+
+    values = {
+        '1:IntValue:Int:Output01Value': 5,
+        '2:Blur:Int:Input02Value': 1,
+    }
+    written = {}
+
+    monkeypatch.setattr(base_module, 'dpg_get_value', lambda tag: values.get(tag))
+    monkeypatch.setattr(base_module, 'dpg_set_value', lambda tag, value: written.setdefault(tag, value))
+    monkeypatch.setattr(base_module, 'convert_cv_to_dpg', lambda frame, w, h: ('texture', frame.shape, w, h))
+    monkeypatch.setattr(blur_module.cv2, 'blur', lambda f, k: f, raising=False)
+
+    frame = np.full((8, 8, 3), 127, dtype=np.uint8)
+    out_frame, result = node.update(
+        2,
+        [
+            ['1:ImageSource:Image:Output01', '2:Blur:Image:Input01'],
+            ['1:IntValue:Int:Output01', '2:Blur:Int:Input02'],
+        ],
+        {'1:ImageSource': frame},
+        {},
+    )
+
+    assert result is None
+    assert out_frame.shape == frame.shape
+    assert written['2:Blur:Int:Input02Value'] == 5
+    assert written['2:Blur:Image:Output01Value'][0] == 'texture'
+
+
+def test_brightness_node_get_set_settings(monkeypatch):
+    node = BrightnessNode()
+
+    values = {'3:Brightness:Int:Input02Value': 21}
+    writes = {}
+
+    monkeypatch.setattr(base_module, 'dpg_get_value', lambda tag: values.get(tag))
+    monkeypatch.setattr(base_module, 'dpg_set_value', lambda tag, value: writes.setdefault(tag, value))
+    monkeypatch.setattr(base_module, 'dpg', DpgStub())
+
+    setting = node.get_setting_dict(3)
+
+    assert setting['ver'] == node._ver
+    assert setting['pos'] == [10, 20]
+    assert setting['3:Brightness:Int:Input02Value'] == 21
+
+    node.set_setting_dict(3, {'3:Brightness:Int:Input02Value': 44})
+    assert writes['3:Brightness:Int:Input02Value'] == 44
+
+
+def test_contrast_node_clamps_and_rounds_linked_float(monkeypatch):
+    node = ContrastNode()
+    _prepare_node(node)
+
+    values = {
+        '9:FloatValue:Float:Output01Value': 5.9999,
+        '7:Contrast:Float:Input02Value': 0.3,
+    }
+    writes = {}
+
+    monkeypatch.setattr(base_module, 'dpg_get_value', lambda tag: values.get(tag))
+    monkeypatch.setattr(base_module, 'dpg_set_value', lambda tag, value: writes.setdefault(tag, value))
+    monkeypatch.setattr(base_module, 'convert_cv_to_dpg', lambda frame, w, h: frame)
+    monkeypatch.setattr(contrast_module.cv2, 'convertScaleAbs', lambda f, alpha, beta: f, raising=False)
+
+    frame = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    node.update(
+        7,
+        [
+            ['4:ImageSource:Image:Output01', '7:Contrast:Image:Input01'],
+            ['9:FloatValue:Float:Output01', '7:Contrast:Float:Input02'],
+        ],
+        {'4:ImageSource': frame},
+        {},
+    )
+
+    assert writes['7:Contrast:Float:Input02Value'] == 4.0


### PR DESCRIPTION
### Motivation

- Remove heavy duplication across simple image-processing nodes by providing a declarative base that centralizes UI, tag handling, preview texture management, timing, and settings persistence.
- Enable easier, incremental migration to a mixin/base-class architecture and document a concrete refactor plan for future work.

### Description

- Add a design/implementation plan `NODE_BASE_CLASS_REFACTOR_PLAN.md` describing the proposed mixin/layered approach and migration phases.
- Introduce `node/base/declarative_node_base.py` with `DeclarativeImageProcessNodeBase`, which implements a declarative parameter schema, default `add_node`/`update`/`get_setting_dict`/`set_setting_dict` behaviors, preview texture handling, parameter linking, clamping/casting, and a `process(...)` hook for node-specific work.
- Refactor `node/process_node/node_blur.py`, `node/process_node/node_brightness.py`, and `node/process_node/node_contrast.py` to inherit from the new base and declare `parameters` plus a concise `process` implementation, removing duplicated UI and update code.
- Add unit tests `tests/unit/test_declarative_process_nodes.py` to validate parameter linking, settings serialization, clamping/rounding behavior, and texture conversion stubbing, and extend the integration test `tests/integration/test_node_editor_integration.py` to exercise the brightness pipeline.

### Testing

- Ran unit tests for the new declarative behavior with `pytest tests/unit/test_declarative_process_nodes.py`, which passed.
- Exercised the brightness integration scenario with `pytest tests/integration/test_node_editor_integration.py::TestNodeEditorIntegration::test_image_brightness_pipeline`, which passed.
- Ran the full test suite with `pytest -q` to confirm no regressions in affected areas, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4c8afce208323a1568cf6eec56e04)