### PR TITLE
Migrate Curves node to declarative base class

### DIFF
--- a/NODE_BASE_CLASS_REFACTOR_PLAN.md
+++ b/NODE_BASE_CLASS_REFACTOR_PLAN.md
@@ -214,11 +214,10 @@ This addresses your idea directly: most nodes can become declarations + core pro
     - safe default fallback when UI values are missing/invalid during async races
   - Declarative test coverage expanded for new behaviors.
 
-- **Wave 3 (this update)**
+- **Wave 3 (completed)**
   - Additional process nodes migrated to declarative base:
     - `GaussianBlur`
     - `Canny`
-    - `Curves`
     - `Resize`
   - Base class enhanced with small extensibility hooks:
     - `normalize_parameter_values(...)` for per-node defensive normalization in `update()`
@@ -226,7 +225,7 @@ This addresses your idea directly: most nodes can become declarations + core pro
     - declarative `input_int` widget support
 
 
-- **Wave 4 (this update)**
+- **Wave 4 (completed)**
   - Migrated additional nodes to declarative base:
     - `Crop`
     - `SimpleFilter`
@@ -235,12 +234,14 @@ This addresses your idea directly: most nodes can become declarations + core pro
     - Crop crossed-bounds normalization behavior
     - SimpleFilter full settings coverage and linked `K` clamp range
 
-### Next suggested wave
 
-- **Wave 5 candidate: `Curves` (hybrid migration)**
-  - Keep drag-point plot UI and callbacks as node-local custom code.
-  - Adopt declarative base only for shared image I/O, timing output, and common settings shell where useful.
-  - Add async-safety hardening in update-reachable paths (prefer guarded DPG helpers and defensive parsing).
+- **Wave 5 (completed)**
+  - Migrated `Curves` to declarative base using a hybrid approach:
+    - kept drag-point plot UI/callbacks as node-local custom logic
+    - adopted shared image I/O and elapsed-time output behavior from base class
+    - persisted/restored curve points via declarative custom-settings hooks
+
+### Next suggested wave
 
 - **Wave 6 candidate: `OmnidirectionalViewer` (stateful migration)**
   - Preserve the node-local internal map cache (`phi/theta`) optimization because recomputation is expensive.
@@ -249,7 +250,6 @@ This addresses your idea directly: most nodes can become declarations + core pro
 
 ### Why these are deferred from simple-wave migrations
 
-- `Curves` has bespoke interactive plot behavior (drag points, hit-testing, add/delete callbacks) that is intentionally not generalized into the base today.
 - `OmnidirectionalViewer` has non-trivial internal state/caching semantics beyond declarative slider-driven transforms.
 
 ### Entry criteria for starting each deferred wave

--- a/NODE_BASE_CLASS_REFACTOR_PLAN.md
+++ b/NODE_BASE_CLASS_REFACTOR_PLAN.md
@@ -218,6 +218,7 @@ This addresses your idea directly: most nodes can become declarations + core pro
   - Additional process nodes migrated to declarative base:
     - `GaussianBlur`
     - `Canny`
+    - `Curves`
     - `Resize`
   - Base class enhanced with small extensibility hooks:
     - `normalize_parameter_values(...)` for per-node defensive normalization in `update()`

--- a/NODE_BASE_CLASS_REFACTOR_PLAN.md
+++ b/NODE_BASE_CLASS_REFACTOR_PLAN.md
@@ -200,7 +200,7 @@ This addresses your idea directly: most nodes can become declarations + core pro
   - Base class introduced at `node/base/declarative_node_base.py`.
   - Pilot nodes migrated: `Brightness`, `Contrast`, `Blur`.
 
-- **Wave 2 (this update)**
+- **Wave 2 (completed)**
   - Additional simple process nodes migrated to declarative base:
     - `Grayscale`
     - `EqualizeHist`
@@ -241,16 +241,20 @@ This addresses your idea directly: most nodes can become declarations + core pro
     - adopted shared image I/O and elapsed-time output behavior from base class
     - persisted/restored curve points via declarative custom-settings hooks
 
+- **Wave 6 (completed)**
+  - Migrated `OmnidirectionalViewer` to declarative base while preserving stateful map caching semantics.
+  - Kept expensive `phi/theta` map generation cached per node id and recomputed only when viewpoint parameters change.
+  - Added explicit cache cleanup in `close(...)` to avoid stale per-node state after node deletion.
+  - Added tests covering cache reuse and close-time cache eviction.
+
 ### Next suggested wave
 
-- **Wave 6 candidate: `OmnidirectionalViewer` (stateful migration)**
-  - Preserve the node-local internal map cache (`phi/theta`) optimization because recomputation is expensive.
-  - Review lifecycle/state cleanup (`close`) and per-node cache invalidation behavior under delete/import races.
-  - Adopt declarative base incrementally after cache/lifecycle semantics are explicitly covered by tests.
+- **Wave 7 candidate: complex resource/deep-learning nodes**
+  - Prioritize nodes with custom lifecycle/resource ownership and migrate incrementally with focused tests.
 
 ### Why these are deferred from simple-wave migrations
 
-- `OmnidirectionalViewer` has non-trivial internal state/caching semantics beyond declarative slider-driven transforms.
+- Resource/deep-learning nodes often own external handles/caches and may require custom close/init semantics beyond declarative slider-driven transforms.
 
 ### Entry criteria for starting each deferred wave
 

--- a/node/base/declarative_node_base.py
+++ b/node/base/declarative_node_base.py
@@ -75,6 +75,13 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
             for parameter in self.parameters:
                 self._add_parameter_ui(tag_node_name, parameter, small_window_w, callback)
 
+            self.build_custom_ui(
+                tag_node_name,
+                node_id,
+                small_window_w,
+                callback,
+            )
+
             if self.show_elapsed_time and use_pref_counter:
                 with dpg.node_attribute(
                     tag=elapsed_tag,
@@ -156,6 +163,8 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
             )
             setting_dict[parameter_value_tag] = dpg_get_value(parameter_value_tag)
 
+        setting_dict.update(self.get_custom_setting_dict(tag_node_name, node_id))
+
         return setting_dict
 
     def set_setting_dict(self, node_id, setting_dict):
@@ -170,7 +179,19 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
             value = self._cast_parameter_value(parameter, setting_dict[parameter_value_tag])
             dpg_set_value(parameter_value_tag, value)
 
+        self.set_custom_setting_dict(tag_node_name, node_id, setting_dict)
+
         self.on_settings_applied(tag_node_name)
+
+    def build_custom_ui(self, tag_node_name, node_id, width, callback):
+        del tag_node_name, node_id, width, callback
+
+    def get_custom_setting_dict(self, tag_node_name, node_id):
+        del tag_node_name, node_id
+        return {}
+
+    def set_custom_setting_dict(self, tag_node_name, node_id, setting_dict):
+        del tag_node_name, node_id, setting_dict
 
     def on_node_added(self, tag_node_name):
         del tag_node_name

--- a/node/process_node/node_curves.py
+++ b/node/process_node/node_curves.py
@@ -1,19 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Curves adjustment node for Image Processing Node Editor."""
-import time
 
 import cv2
 import numpy as np
 import dearpygui.dearpygui as dpg
 
-from node_editor.util import (
-    dpg_get_value,
-    dpg_set_value,
-    dpg_get_item_children,
-    convert_cv_to_dpg,
-)
-from node.node_abc import DpgNodeABC
+from node.base.declarative_node_base import DeclarativeImageProcessNodeBase
+from node_editor.util import dpg_get_value, dpg_get_item_children
 
 
 def image_process(image, points):
@@ -25,74 +19,64 @@ def image_process(image, points):
     return image
 
 
-class Node(DpgNodeABC):
+class Node(DeclarativeImageProcessNodeBase):
     """Curves adjustment node."""
 
-    _ver = "0.0.1"
+    _ver = '0.0.2'
 
-    node_label = "Curves"
-    node_tag = "Curves"
+    node_label = 'Curves'
+    node_tag = 'Curves'
 
     _min_val = 0
     _max_val = 255
     _delete_hit_radius = 6
 
-    _opencv_setting_dict = None
-
-    def __init__(self):
-        pass
-
-    def _get_tag_node_name(self, node_id):
-        return f"{node_id}:{self.node_tag}"
-
     def _get_tag_plot_name(self, node_id):
-        return f"{node_id}:{self.node_tag}:plot"
+        return f'{self._node_name(node_id)}:plot'
 
     def _get_tag_plot_series_name(self, node_id):
-        return f"{node_id}:{self.node_tag}:line"
+        return f'{self._node_name(node_id)}:line'
 
     def _get_drag_points(self, node_id):
         plot_tag = self._get_tag_plot_name(node_id)
         if not dpg.does_item_exist(plot_tag):
-            return [
-                [self._min_val, self._min_val],
-                [self._max_val, self._max_val],
-            ]
-        # Drag points should be only children in slot 0
+            return self._default_points()
+
         point_items = dpg_get_item_children(plot_tag, slot=0)
         points = []
-        for tag in point_items:
-            value = dpg.get_value(tag)
+        for point_tag in point_items:
+            value = dpg_get_value(point_tag)
             if (
-                isinstance(value, (list, tuple)) and
-                len(value) == 2 and
-                value[0] is not None and
-                value[1] is not None
+                isinstance(value, (list, tuple))
+                and len(value) == 2
+                and value[0] is not None
+                and value[1] is not None
             ):
                 points.append([value[0], value[1]])
 
         if len(points) < 2:
-            return [
-                [self._min_val, self._min_val],
-                [self._max_val, self._max_val],
-            ]
+            return self._default_points()
 
         return sorted(points)
 
+    def _default_points(self):
+        return [
+            [self._min_val, self._min_val],
+            [self._max_val, self._max_val],
+        ]
+
     def _callback_add_point(self, sender, app_data, user_data):
-        node_id = user_data[0]
-        static_x = user_data[1]
+        del sender, app_data
+        node_id, static_x = user_data
         plot_tag = self._get_tag_plot_name(node_id)
         if static_x is not None:
-            # For endpoints only, which initially have x = y
             y = x = static_x
         else:
-            # Click must be within plot, so no need to clip to range(?)
             x, y = dpg.get_plot_mouse_pos()
 
         dpg.add_drag_point(
             parent=plot_tag,
-            label="",
+            label='',
             default_value=[x, y],
             delayed=True,
             callback=self._callback_moved_point,
@@ -101,26 +85,30 @@ class Node(DpgNodeABC):
         self._redraw_line(node_id)
 
     def _callback_moved_point(self, sender, app_data, user_data):
-        node_id = user_data[0]
-        static_x = user_data[1]
+        del app_data
+        node_id, static_x = user_data
 
-        x, y = dpg.get_value(sender)
+        point_value = dpg_get_value(sender)
+        if not isinstance(point_value, (list, tuple)) or len(point_value) != 2:
+            return
+
+        x, y = point_value
         if static_x is not None:
             x = static_x
-        # Clip y to range (should be 0-255)
         y = max(self._min_val, min(self._max_val, int(y)))
         dpg.set_value(sender, [x, y])
         self._redraw_line(node_id)
 
     def _callback_delete_point(self, sender, app_data, user_data):
+        del sender, app_data
         node_id = user_data[0]
         plot_tag = self._get_tag_plot_name(node_id)
         point_items = dpg_get_item_children(plot_tag, slot=0)
         mouse_x, mouse_y = dpg.get_plot_mouse_pos()
 
         closest_point_tag = None
-        closest_distance_sq = float("inf")
-        hit_radius_sq = self._delete_hit_radius ** 2
+        closest_distance_sq = float('inf')
+        hit_radius_sq = self._delete_hit_radius**2
 
         for point_tag in point_items:
             point_user_data = dpg.get_item_user_data(point_tag)
@@ -131,7 +119,11 @@ class Node(DpgNodeABC):
             if static_x is not None:
                 continue
 
-            px, py = dpg.get_value(point_tag)
+            point_value = dpg_get_value(point_tag)
+            if not isinstance(point_value, (list, tuple)) or len(point_value) != 2:
+                continue
+
+            px, py = point_value
             distance_sq = ((px - mouse_x) ** 2) + ((py - mouse_y) ** 2)
             if distance_sq > hit_radius_sq:
                 continue
@@ -144,236 +136,84 @@ class Node(DpgNodeABC):
             dpg.delete_item(closest_point_tag)
             self._redraw_line(node_id)
 
-    def _redraw_line(
-        self, 
-        node_id
-    ):
-        # Rebuild curve line series based on current drag points.
-        plot_tag = self._get_tag_plot_name(node_id)
+    def _redraw_line(self, node_id):
         points = self._get_drag_points(node_id)
-        x, y = zip(*points)
+        x_values, y_values = zip(*points)
         series_tag = self._get_tag_plot_series_name(node_id)
-        dpg.set_value(series_tag, [x, y])
+        dpg.set_value(series_tag, [x_values, y_values])
 
-    def add_node(
-        self, 
-        parent, 
-        node_id, 
-        pos=[0, 0], 
-        opencv_setting_dict=None, 
-        callback=None
-    ):
-        # tag names
-        tag_node_name = self._get_tag_node_name(node_id)
-        tag_plot_name = self._get_tag_plot_name(node_id)
-        tag_plot_series_name = self._get_tag_plot_series_name(node_id)
-        tag_node_input_name = f"{tag_node_name}:{self.TYPE_IMAGE}:Input01"
-        tag_node_input_value_name = f"{tag_node_name}:{self.TYPE_IMAGE}:Input01Value"
-        tag_node_output_name = f"{tag_node_name}:{self.TYPE_IMAGE}:Output01"
-        tag_node_output_value_name = f"{tag_node_name}:{self.TYPE_IMAGE}:Output01Value"
-        tag_node_output02_name = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02'
-        tag_node_output02_value_name = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02Value'
-
-        # OpenCV settings
-        self._opencv_setting_dict = opencv_setting_dict
-        small_window_w = self._opencv_setting_dict["process_width"]
-        small_window_h = self._opencv_setting_dict["process_height"]
-        use_pref_counter = self._opencv_setting_dict['use_pref_counter']
-
-        # initial black image
-        black_image = np.zeros((small_window_w, small_window_h, 3))
-        black_texture = convert_cv_to_dpg(
-            black_image, 
-            small_window_w, 
-            small_window_h
-        )
-
-        # texture registration
-        with dpg.texture_registry(show=False):
-            dpg.add_raw_texture(
-                small_window_w,
-                small_window_h,
-                black_texture,
-                tag=tag_node_output_value_name,
-                format=dpg.mvFormat_Float_rgb,
-            )
-
-        # Add node
-        with dpg.node(
-            tag=tag_node_name, 
-            parent=parent, 
-            label=self.node_label, 
-            pos=pos
-        ):
-            # Add input port
-            with dpg.node_attribute(
-                tag=tag_node_input_name, 
-                attribute_type=dpg.mvNode_Attr_Input
-            ):
-                dpg.add_text(
-                    tag=tag_node_input_value_name, 
-                    default_value="Input BGR image"
-                )
-            # Add image
-            with dpg.node_attribute(
-                tag=tag_node_output_name, 
-                attribute_type=dpg.mvNode_Attr_Output
-            ):
-                dpg.add_image(tag_node_output_value_name)
-            # Add curve editor
-            with dpg.node_attribute(
-                attribute_type=dpg.mvNode_Attr_Static
-            ):
-                with dpg.plot(
-                    width=240, 
-                    height=180, 
-                    tag=tag_plot_name, 
-                    no_menus=True
-                ):
-                    dpg.add_plot_axis(
-                        dpg.mvXAxis, 
-                        tag=f"{tag_node_name}:plot_x"
-                    )
-                    dpg.set_axis_limits(
-                        dpg.last_item(), 
-                        self._min_val, 
-                        self._max_val
-                    )
-                    dpg.add_plot_axis(
-                        dpg.mvYAxis, 
-                        tag=f"{tag_node_name}:plot_y"
-                    )
-                    dpg.set_axis_limits(
-                        dpg.last_item(), 
-                        self._min_val, 
-                        self._max_val
-                    )
-                    dpg.add_line_series(
-                        x=[self._min_val, self._max_val],
-                        y=[self._min_val, self._max_val],
-                        parent=f"{tag_node_name}:plot_y",
-                        tag=tag_plot_series_name,
-                    )
-                    handler = dpg.add_item_handler_registry()
-                    dpg.add_item_clicked_handler(
-                        callback=self._callback_add_point,
-                        user_data=(node_id, None),
-                        button=dpg.mvMouseButton_Left,
-                        parent=handler,
-                    )
-                    dpg.add_item_clicked_handler(
-                        callback=self._callback_delete_point,
-                        user_data=(node_id,),
-                        button=dpg.mvMouseButton_Right,
-                        parent=handler,
-                    )
-                    # Add bottom right point
-                    self._callback_add_point(
-                        sender=None, 
-                        app_data=None,
-                        user_data=(node_id, self._min_val)
-                    )
-                    # Add top right point
-                    self._callback_add_point(
-                        sender=None, 
-                        app_data=None,
-                        user_data=(node_id, self._max_val)
-                    )
-                    dpg.bind_item_handler_registry(tag_plot_name, handler)
-            # processing time
-            if use_pref_counter:
-                with dpg.node_attribute(
-                        tag=tag_node_output02_name,
-                        attribute_type=dpg.mvNode_Attr_Output,
-                ):
-                    dpg.add_text(
-                        tag=tag_node_output02_value_name,
-                        default_value='elapsed time(ms)',
-                    )
-        return tag_node_name
-
-    def update(
-        self, 
-        node_id, 
-        connection_list, 
-        node_image_dict, 
-        node_result_dict
-    ):
-        node_id = int(node_id)
-        tag_node_name = f"{node_id}:{self.node_tag}"
-        output_value01_tag = f"{tag_node_name}:{self.TYPE_IMAGE}:Output01Value"
-        output_value02_tag = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02Value'
-        plot_tag = f"{tag_node_name}:plot"
-
-        small_window_w = self._opencv_setting_dict["process_width"]
-        small_window_h = self._opencv_setting_dict["process_height"]
-        use_pref_counter = self._opencv_setting_dict['use_pref_counter']
-
-        # connection check
-        connection_info_src = ''
-        for connection_info in connection_list:
-            if connection_info[0].split(':')[2] == self.TYPE_IMAGE:
-                connection_info_src = connection_info[0]
-                connection_info_src = connection_info_src.split(':')[:2]
-                connection_info_src = ':'.join(connection_info_src)
-
-        # get image
-        frame = node_image_dict.get(connection_info_src, None)
-
-        # get points from curves chart
-        points = self._get_drag_points(node_id)
-
-        # start timer
-        if frame is not None and use_pref_counter:
-            start_time = time.perf_counter()
-
-        # process image
-        if frame is not None:
-            frame = image_process(frame, points)
-
-        # stop timer
-        if frame is not None and use_pref_counter:
-            elapsed_time = time.perf_counter() - start_time
-            elapsed_time = int(elapsed_time * 1000)
-            dpg_set_value(output_value02_tag,
-                          str(elapsed_time).zfill(4) + 'ms')
-
-        # set display image
-        if frame is not None:
-            texture = convert_cv_to_dpg(
-                frame,
-                small_window_w,
-                small_window_h,
-            )
-            dpg_set_value(output_value01_tag, texture)
-
-        return frame, None
-
-    def close(self, node_id):
-        node_id = int(node_id)
-        # Clean here
-
-    def get_setting_dict(self, node_id):
-        node_id = int(node_id)
-        tag_node_name = f"{node_id}:{self.node_tag}"
-        pos = dpg.get_item_pos(tag_node_name)
-        points = self._get_drag_points(node_id)
-        setting_dict = {
-            "ver": self._ver,
-            "pos": pos,
-            "points": points,
-        }
-        return setting_dict
-
-    def set_setting_dict(self, node_id, setting_dict):
+    def _reset_points_from_setting(self, node_id, setting_points):
         plot_tag = self._get_tag_plot_name(node_id)
-        for pt in setting_dict.get("points", []):
-            static_x = pt[0] if pt[0] in [self._min_val, self._max_val] else None
+        existing_points = dpg_get_item_children(plot_tag, slot=0)
+        for point_tag in existing_points:
+            dpg.delete_item(point_tag)
+
+        points_to_add = setting_points if setting_points else self._default_points()
+
+        for point in points_to_add:
+            if not isinstance(point, (list, tuple)) or len(point) != 2:
+                continue
+            x, y = int(point[0]), int(point[1])
+            y = max(self._min_val, min(self._max_val, y))
+            static_x = x if x in [self._min_val, self._max_val] else None
             dpg.add_drag_point(
                 parent=plot_tag,
-                label="",
-                default_value=pt,
+                label='',
+                default_value=[x, y],
+                delayed=True,
                 callback=self._callback_moved_point,
-                user_data=(node_id, static_x)
+                user_data=(node_id, static_x),
             )
+
         self._redraw_line(node_id)
+
+    def build_custom_ui(self, tag_node_name, node_id, width, callback):
+        del tag_node_name, width, callback
+
+        with dpg.node_attribute(attribute_type=dpg.mvNode_Attr_Static):
+            plot_tag = self._get_tag_plot_name(node_id)
+            series_tag = self._get_tag_plot_series_name(node_id)
+            with dpg.plot(width=240, height=180, tag=plot_tag, no_menus=True):
+                dpg.add_plot_axis(dpg.mvXAxis, tag=f'{self._node_name(node_id)}:plot_x')
+                dpg.set_axis_limits(dpg.last_item(), self._min_val, self._max_val)
+                dpg.add_plot_axis(dpg.mvYAxis, tag=f'{self._node_name(node_id)}:plot_y')
+                dpg.set_axis_limits(dpg.last_item(), self._min_val, self._max_val)
+                dpg.add_line_series(
+                    x=[self._min_val, self._max_val],
+                    y=[self._min_val, self._max_val],
+                    parent=f'{self._node_name(node_id)}:plot_y',
+                    tag=series_tag,
+                )
+                handler = dpg.add_item_handler_registry()
+                dpg.add_item_clicked_handler(
+                    callback=self._callback_add_point,
+                    user_data=(node_id, None),
+                    button=dpg.mvMouseButton_Left,
+                    parent=handler,
+                )
+                dpg.add_item_clicked_handler(
+                    callback=self._callback_delete_point,
+                    user_data=(node_id,),
+                    button=dpg.mvMouseButton_Right,
+                    parent=handler,
+                )
+                dpg.bind_item_handler_registry(plot_tag, handler)
+
+            self._reset_points_from_setting(node_id, self._default_points())
+
+    def normalize_parameter_values(self, tag_node_name, parameter_values):
+        node_id = int(str(tag_node_name).split(':', maxsplit=1)[0])
+        parameter_values['points'] = self._get_drag_points(node_id)
+        return parameter_values
+
+    def process(self, frame, **parameter_values):
+        frame = image_process(frame, parameter_values['points'])
+        return frame, None
+
+    def get_custom_setting_dict(self, tag_node_name, node_id):
+        del tag_node_name
+        return {'points': self._get_drag_points(node_id)}
+
+    def set_custom_setting_dict(self, tag_node_name, node_id, setting_dict):
+        del tag_node_name
+        self._reset_points_from_setting(node_id, setting_dict.get('points', []))

--- a/node/process_node/node_omnidirectional_viewer.py
+++ b/node/process_node/node_omnidirectional_viewer.py
@@ -1,15 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import time
 
 import cv2
 import numpy as np
-import dearpygui.dearpygui as dpg
 
-from node_editor.util import dpg_get_value, dpg_set_value
-
-from node.node_abc import DpgNodeABC
-from node_editor.util import convert_cv_to_dpg
+from node.base.declarative_node_base import DeclarativeImageProcessNodeBase
 
 
 def image_process(image, phi, theta):
@@ -86,12 +81,9 @@ def calculate_phi_and_theta(
     y = (a1 * x) + b1
     z = (a2 * x) + b2
 
-    xd = rotation_matrix[0][0] * x + rotation_matrix[0][
-        1] * y + rotation_matrix[0][2] * z
-    yd = rotation_matrix[1][0] * x + rotation_matrix[1][
-        1] * y + rotation_matrix[1][2] * z
-    zd = rotation_matrix[2][0] * x + rotation_matrix[2][
-        1] * y + rotation_matrix[2][2] * z
+    xd = rotation_matrix[0][0] * x + rotation_matrix[0][1] * y + rotation_matrix[0][2] * z
+    yd = rotation_matrix[1][0] * x + rotation_matrix[1][1] * y + rotation_matrix[1][2] * z
+    zd = rotation_matrix[2][0] * x + rotation_matrix[2][1] * y + rotation_matrix[2][2] * z
 
     phi = np.arcsin(zd)
     theta = np.arcsin(yd / np.cos(phi))
@@ -121,223 +113,85 @@ def remap_image(image, phi, theta):
     return output_image
 
 
-class Node(DpgNodeABC):
-    _ver = '0.0.1'
+class Node(DeclarativeImageProcessNodeBase):
+    _ver = '0.0.2'
 
     node_label = 'Omnidirectional Viewer'
     node_tag = 'OmnidirectionalViewer'
 
-    _min_degree = 0
-    _max_degree = 359
-    _min_point = -1.0
-    _max_point = 3.0
-
-    _opencv_setting_dict = None
-
-    _params = {}
     _sensor_size = 0.561
     _output_width = 960
     _output_height = 540
 
+    parameters = [
+        {
+            'name': 'pitch',
+            'type': DeclarativeImageProcessNodeBase.TYPE_INT,
+            'port': 'Input02',
+            'widget': 'slider_int',
+            'label': 'pitch',
+            'default': 0,
+            'min': 0,
+            'max': 359,
+            'cast': int,
+        },
+        {
+            'name': 'yaw',
+            'type': DeclarativeImageProcessNodeBase.TYPE_INT,
+            'port': 'Input03',
+            'widget': 'slider_int',
+            'label': 'yaw',
+            'default': 0,
+            'min': 0,
+            'max': 359,
+            'cast': int,
+        },
+        {
+            'name': 'roll',
+            'type': DeclarativeImageProcessNodeBase.TYPE_INT,
+            'port': 'Input04',
+            'widget': 'slider_int',
+            'label': 'roll',
+            'default': 0,
+            'min': 0,
+            'max': 359,
+            'cast': int,
+        },
+        {
+            'name': 'imagepoint',
+            'type': DeclarativeImageProcessNodeBase.TYPE_FLOAT,
+            'port': 'Input05',
+            'widget': 'slider_float',
+            'label': 'image point',
+            'default': 0.0,
+            'min': -1.0,
+            'max': 3.0,
+            'cast': float,
+            'precision': 3,
+        },
+    ]
+
     def __init__(self):
-        pass
+        self._params = {}
 
-    def add_node(
-        self,
-        parent,
-        node_id,
-        pos=[0, 0],
-        opencv_setting_dict=None,
-        callback=None,
-    ):
-        # タグ名
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        tag_node_input01_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Input01'
-        tag_node_input01_value_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Input01Value'
-        tag_node_input02_name = tag_node_name + ':' + self.TYPE_INT + ':Input02'
-        tag_node_input02_value_name = tag_node_name + ':' + self.TYPE_INT + ':Input02Value'
-        tag_node_input03_name = tag_node_name + ':' + self.TYPE_INT + ':Input03'
-        tag_node_input03_value_name = tag_node_name + ':' + self.TYPE_INT + ':Input03Value'
-        tag_node_input04_name = tag_node_name + ':' + self.TYPE_INT + ':Input04'
-        tag_node_input04_value_name = tag_node_name + ':' + self.TYPE_INT + ':Input04Value'
-        tag_node_input05_name = tag_node_name + ':' + self.TYPE_FLOAT + ':Input05'
-        tag_node_input05_value_name = tag_node_name + ':' + self.TYPE_FLOAT + ':Input05Value'
-        tag_node_output01_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01'
-        tag_node_output01_value_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01Value'
-        tag_node_output02_name = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02'
-        tag_node_output02_value_name = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02Value'
+    def normalize_parameter_values(self, tag_node_name, parameter_values):
+        node_id = int(str(tag_node_name).split(':', maxsplit=1)[0])
+        parameter_values['_node_id'] = node_id
+        return parameter_values
 
-        # OpenCV向け設定
-        self._opencv_setting_dict = opencv_setting_dict
-        small_window_w = self._opencv_setting_dict['process_width']
-        small_window_h = self._opencv_setting_dict['process_height']
-        use_pref_counter = self._opencv_setting_dict['use_pref_counter']
+    def process(self, frame, **parameter_values):
+        node_id = parameter_values.pop('_node_id')
 
-        # 初期化用黒画像
-        black_image = np.zeros((small_window_w, small_window_h, 3))
-        black_texture = convert_cv_to_dpg(
-            black_image,
-            small_window_w,
-            small_window_h,
-        )
-
-        # テクスチャ登録
-        with dpg.texture_registry(show=False):
-            dpg.add_raw_texture(
-                small_window_w,
-                small_window_h,
-                black_texture,
-                tag=tag_node_output01_value_name,
-                format=dpg.mvFormat_Float_rgb,
-            )
-
-        # ノード
-        with dpg.node(
-                tag=tag_node_name,
-                parent=parent,
-                label=self.node_label,
-                pos=pos,
-        ):
-            # 入力端子
-            with dpg.node_attribute(
-                    tag=tag_node_input01_name,
-                    attribute_type=dpg.mvNode_Attr_Input,
-            ):
-                dpg.add_text(
-                    tag=tag_node_input01_value_name,
-                    default_value='Input BGR image',
-                )
-            # 画像
-            with dpg.node_attribute(
-                    tag=tag_node_output01_name,
-                    attribute_type=dpg.mvNode_Attr_Output,
-            ):
-                dpg.add_image(tag_node_output01_value_name)
-            # ピッチ
-            with dpg.node_attribute(
-                    tag=tag_node_input02_name,
-                    attribute_type=dpg.mvNode_Attr_Input,
-            ):
-                dpg.add_slider_int(
-                    tag=tag_node_input02_value_name,
-                    label="pitch",
-                    width=small_window_w - 60,
-                    default_value=0,
-                    min_value=self._min_degree,
-                    max_value=self._max_degree,
-                    callback=None,
-                )
-            # ヨー
-            with dpg.node_attribute(
-                    tag=tag_node_input03_name,
-                    attribute_type=dpg.mvNode_Attr_Input,
-            ):
-                dpg.add_slider_int(
-                    tag=tag_node_input03_value_name,
-                    label="yaw",
-                    width=small_window_w - 60,
-                    default_value=0,
-                    min_value=self._min_degree,
-                    max_value=self._max_degree,
-                    callback=None,
-                )
-            # ロール
-            with dpg.node_attribute(
-                    tag=tag_node_input04_name,
-                    attribute_type=dpg.mvNode_Attr_Input,
-            ):
-                dpg.add_slider_int(
-                    tag=tag_node_input04_value_name,
-                    label="roll",
-                    width=small_window_w - 60,
-                    default_value=0,
-                    min_value=self._min_degree,
-                    max_value=self._max_degree,
-                    callback=None,
-                )
-            # 撮像位置
-            with dpg.node_attribute(
-                    tag=tag_node_input05_name,
-                    attribute_type=dpg.mvNode_Attr_Input,
-            ):
-                dpg.add_slider_float(
-                    tag=tag_node_input05_value_name,
-                    label="image point",
-                    width=small_window_w - 100,
-                    default_value=0,
-                    min_value=self._min_point,
-                    max_value=self._max_point,
-                    callback=None,
-                )
-            # 処理時間
-            if use_pref_counter:
-                with dpg.node_attribute(
-                        tag=tag_node_output02_name,
-                        attribute_type=dpg.mvNode_Attr_Output,
-                ):
-                    dpg.add_text(
-                        tag=tag_node_output02_value_name,
-                        default_value='elapsed time(ms)',
-                    )
-
-        return tag_node_name
-
-    def update(
-        self,
-        node_id,
-        connection_list,
-        node_image_dict,
-        node_result_dict,
-    ):
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        input_value02_tag = tag_node_name + ':' + self.TYPE_INT + ':Input02Value'
-        input_value03_tag = tag_node_name + ':' + self.TYPE_INT + ':Input03Value'
-        input_value04_tag = tag_node_name + ':' + self.TYPE_INT + ':Input04Value'
-        input_value05_tag = tag_node_name + ':' + self.TYPE_FLOAT + ':Input05Value'
-        output_value01_tag = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01Value'
-        output_value02_tag = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02Value'
-
-        small_window_w = self._opencv_setting_dict['process_width']
-        small_window_h = self._opencv_setting_dict['process_height']
-        use_pref_counter = self._opencv_setting_dict['use_pref_counter']
-
-        # 接続情報確認
-        connection_info_src = ''
-        for connection_info in connection_list:
-            connection_type = connection_info[0].split(':')[2]
-            if connection_type == self.TYPE_INT:
-                # 接続タグ取得
-                source_tag = connection_info[0] + 'Value'
-                destination_tag = connection_info[1] + 'Value'
-                # 値更新
-                input_value = int(dpg_get_value(source_tag))
-                input_value = max([self._min_degree, input_value])
-                input_value = min([self._max_degree, input_value])
-                dpg_set_value(destination_tag, input_value)
-            if connection_type == self.TYPE_IMAGE:
-                # 画像取得元のノード名(ID付き)を取得
-                connection_info_src = connection_info[0]
-                connection_info_src = connection_info_src.split(':')[:2]
-                connection_info_src = ':'.join(connection_info_src)
-
-        # 画像取得
-        frame = node_image_dict.get(connection_info_src, None)
-
-        # ピッチ角、ヨー確、ロール確
-        pitch = int(dpg_get_value(input_value02_tag))
-        yaw = int(dpg_get_value(input_value03_tag))
-        roll = int(dpg_get_value(input_value04_tag))
-        imagepoint = float(dpg_get_value(input_value05_tag))
+        pitch = parameter_values['pitch']
+        yaw = parameter_values['yaw']
+        roll = parameter_values['roll']
+        imagepoint = parameter_values['imagepoint']
 
         change_param_flag = False
         if node_id not in self._params:
             change_param_flag = True
         else:
-            prev_pitch = self._params[node_id][0]
-            prev_yaw = self._params[node_id][1]
-            prev_roll = self._params[node_id][2]
-            prev_imagepoint = self._params[node_id][3]
-
+            prev_pitch, prev_yaw, prev_roll, prev_imagepoint = self._params[node_id][:4]
             if prev_pitch != pitch:
                 change_param_flag = True
             if prev_yaw != yaw:
@@ -349,17 +203,14 @@ class Node(DpgNodeABC):
 
         if change_param_flag:
             sensor_width = self._sensor_size
-            sensor_height = self._sensor_size
-            sensor_height *= (self._output_height / self._output_width)
+            sensor_height = self._sensor_size * (self._output_height / self._output_width)
 
-            # 回転行列生成
             rotation_matrix = create_rotation_matrix(
                 roll,
                 pitch,
                 yaw,
             )
 
-            # 角度座標φ, θ算出
             phi, theta = calculate_phi_and_theta(
                 -1.0,
                 imagepoint,
@@ -372,72 +223,12 @@ class Node(DpgNodeABC):
 
             self._params[node_id] = [pitch, yaw, roll, imagepoint, phi, theta]
 
-        # 計測開始
-        if frame is not None and use_pref_counter:
-            start_time = time.perf_counter()
-
-        if frame is not None:
-            phi, theta = self._params[node_id][4], self._params[node_id][5]
-            frame = image_process(frame, phi, theta)
-
-        # 計測終了
-        if frame is not None and use_pref_counter:
-            elapsed_time = time.perf_counter() - start_time
-            elapsed_time = int(elapsed_time * 1000)
-            dpg_set_value(output_value02_tag,
-                          str(elapsed_time).zfill(4) + 'ms')
-
-        # 描画
-        if frame is not None:
-            texture = convert_cv_to_dpg(
-                frame,
-                small_window_w,
-                small_window_h,
-            )
-            dpg_set_value(output_value01_tag, texture)
+        phi, theta = self._params[node_id][4], self._params[node_id][5]
+        frame = image_process(frame, phi, theta)
 
         return frame, None
 
     def close(self, node_id):
-        pass
-
-    def get_setting_dict(self, node_id):
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        input_value02_tag = tag_node_name + ':' + self.TYPE_INT + ':Input02Value'
-        input_value03_tag = tag_node_name + ':' + self.TYPE_INT + ':Input03Value'
-        input_value04_tag = tag_node_name + ':' + self.TYPE_INT + ':Input04Value'
-        input_value05_tag = tag_node_name + ':' + self.TYPE_FLOAT + ':Input05Value'
-
-        pitch = dpg_get_value(input_value02_tag)
-        yaw = dpg_get_value(input_value03_tag)
-        roll = dpg_get_value(input_value04_tag)
-        imagepoint = dpg_get_value(input_value05_tag)
-
-        pos = dpg.get_item_pos(tag_node_name)
-
-        setting_dict = {}
-        setting_dict['ver'] = self._ver
-        setting_dict['pos'] = pos
-        setting_dict[input_value02_tag] = pitch
-        setting_dict[input_value03_tag] = yaw
-        setting_dict[input_value04_tag] = roll
-        setting_dict[input_value05_tag] = imagepoint
-
-        return setting_dict
-
-    def set_setting_dict(self, node_id, setting_dict):
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        input_value02_tag = tag_node_name + ':' + self.TYPE_INT + ':Input02Value'
-        input_value03_tag = tag_node_name + ':' + self.TYPE_INT + ':Input03Value'
-        input_value04_tag = tag_node_name + ':' + self.TYPE_INT + ':Input04Value'
-        input_value05_tag = tag_node_name + ':' + self.TYPE_FLOAT + ':Input05Value'
-
-        pitch = int(setting_dict[input_value02_tag])
-        yaw = int(setting_dict[input_value03_tag])
-        roll = int(setting_dict[input_value04_tag])
-        imagepoint = float(setting_dict[input_value05_tag])
-
-        dpg_set_value(input_value02_tag, pitch)
-        dpg_set_value(input_value03_tag, yaw)
-        dpg_set_value(input_value04_tag, roll)
-        dpg_set_value(input_value05_tag, imagepoint)
+        node_id = int(node_id)
+        if node_id in self._params:
+            del self._params[node_id]

--- a/tests/unit/test_declarative_process_nodes.py
+++ b/tests/unit/test_declarative_process_nodes.py
@@ -12,6 +12,7 @@ import node.process_node.node_resize as resize_module
 import node.process_node.node_gaussian_blur as gaussian_blur_module
 import node.process_node.node_crop as crop_module
 import node.process_node.node_simple_filter as simple_filter_module
+import node.process_node.node_curves as curves_module
 
 BlurNode = blur_module.Node
 BrightnessNode = brightness_module.Node
@@ -23,6 +24,7 @@ ResizeNode = resize_module.Node
 GaussianBlurNode = gaussian_blur_module.Node
 CropNode = crop_module.Node
 SimpleFilterNode = simple_filter_module.Node
+CurvesNode = curves_module.Node
 
 
 class DpgStub:
@@ -409,3 +411,49 @@ def test_simple_filter_linked_k_value_uses_k_range(monkeypatch):
     )
 
     assert writes['80:SimpleFilter:Float:Input11Value'] == 10.0
+
+
+def test_curves_node_uses_custom_points_in_process(monkeypatch):
+    node = CurvesNode()
+    _prepare_node(node)
+
+    monkeypatch.setattr(curves_module.Node, '_get_drag_points', lambda self, node_id: [[0, 0], [128, 200], [255, 255]])
+    monkeypatch.setattr(base_module, 'dpg_get_value', lambda tag: None)
+    monkeypatch.setattr(base_module, 'dpg_set_value', lambda tag, value: None)
+    monkeypatch.setattr(base_module, 'convert_cv_to_dpg', lambda frame, w, h: frame)
+
+    captured = {}
+
+    def _lut_stub(image, points):
+        captured['points'] = points
+        return image
+
+    monkeypatch.setattr(curves_module, 'image_process', _lut_stub)
+
+    frame = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    out_frame, result = node.update(
+        91,
+        [
+            ['3:ImageSource:Image:Output01', '91:Curves:Image:Input01'],
+        ],
+        {'3:ImageSource': frame},
+        {},
+    )
+
+    assert result is None
+    assert out_frame.shape == frame.shape
+    assert captured['points'] == [[0, 0], [128, 200], [255, 255]]
+
+
+def test_curves_node_settings_include_points(monkeypatch):
+    node = CurvesNode()
+
+    monkeypatch.setattr(base_module, 'dpg', DpgStub())
+    monkeypatch.setattr(curves_module.Node, '_get_drag_points', lambda self, node_id: [[0, 0], [64, 80], [255, 255]])
+
+    setting = node.get_setting_dict(92)
+
+    assert setting['ver'] == node._ver
+    assert setting['pos'] == [10, 20]
+    assert setting['points'] == [[0, 0], [64, 80], [255, 255]]

--- a/tests/unit/test_declarative_process_nodes.py
+++ b/tests/unit/test_declarative_process_nodes.py
@@ -13,6 +13,7 @@ import node.process_node.node_gaussian_blur as gaussian_blur_module
 import node.process_node.node_crop as crop_module
 import node.process_node.node_simple_filter as simple_filter_module
 import node.process_node.node_curves as curves_module
+import node.process_node.node_omnidirectional_viewer as omni_module
 
 BlurNode = blur_module.Node
 BrightnessNode = brightness_module.Node
@@ -25,6 +26,7 @@ GaussianBlurNode = gaussian_blur_module.Node
 CropNode = crop_module.Node
 SimpleFilterNode = simple_filter_module.Node
 CurvesNode = curves_module.Node
+OmniNode = omni_module.Node
 
 
 class DpgStub:
@@ -457,3 +459,60 @@ def test_curves_node_settings_include_points(monkeypatch):
     assert setting['ver'] == node._ver
     assert setting['pos'] == [10, 20]
     assert setting['points'] == [[0, 0], [64, 80], [255, 255]]
+
+
+def test_omnidirectional_viewer_reuses_cached_maps(monkeypatch):
+    node = OmniNode()
+    _prepare_node(node)
+
+    values = {
+        '95:OmnidirectionalViewer:Int:Input02Value': 10,
+        '95:OmnidirectionalViewer:Int:Input03Value': 20,
+        '95:OmnidirectionalViewer:Int:Input04Value': 30,
+        '95:OmnidirectionalViewer:Float:Input05Value': 0.2,
+    }
+
+    monkeypatch.setattr(base_module, 'dpg_get_value', lambda tag: values.get(tag))
+    monkeypatch.setattr(base_module, 'dpg_set_value', lambda tag, value: None)
+    monkeypatch.setattr(base_module, 'convert_cv_to_dpg', lambda frame, w, h: frame)
+
+    calls = {'calc': 0}
+
+    monkeypatch.setattr(omni_module, 'create_rotation_matrix', lambda roll, pitch, yaw: 'rotation')
+
+    def _calc_stub(*args, **kwargs):
+        calls['calc'] += 1
+        return np.zeros((2, 2)), np.ones((2, 2))
+
+    monkeypatch.setattr(omni_module, 'calculate_phi_and_theta', _calc_stub)
+    monkeypatch.setattr(omni_module, 'image_process', lambda image, phi, theta: image)
+
+    frame = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    node.update(
+        95,
+        [
+            ['1:ImageSource:Image:Output01', '95:OmnidirectionalViewer:Image:Input01'],
+        ],
+        {'1:ImageSource': frame},
+        {},
+    )
+    node.update(
+        95,
+        [
+            ['1:ImageSource:Image:Output01', '95:OmnidirectionalViewer:Image:Input01'],
+        ],
+        {'1:ImageSource': frame},
+        {},
+    )
+
+    assert calls['calc'] == 1
+
+
+def test_omnidirectional_viewer_close_clears_cache():
+    node = OmniNode()
+    node._params[96] = [0, 0, 0, 0.0, np.zeros((1, 1)), np.zeros((1, 1))]
+
+    node.close(96)
+
+    assert 96 not in node._params


### PR DESCRIPTION
### Motivation
- Reduce duplication by bringing the interactive Curves node into the declarative image-processing pipeline while preserving its custom UI and persisted curve points. 
- Allow nodes with non-parameter widgets to still use the shared add/update/settings lifecycle via small, low-risk extension hooks on the declarative base.

### Description
- Add extensibility hooks to the declarative base at `node/base/declarative_node_base.py`: `build_custom_ui`, `get_custom_setting_dict`, and `set_custom_setting_dict` to let nodes append custom UI and custom settings serialization. 
- Refactor `node/process_node/node_curves.py` to subclass `DeclarativeImageProcessNodeBase` and implement the curve editor as a custom UI in `build_custom_ui`, preserve add/move/delete drag-point interactions, add robust point reset/restore logic, and surface curve points to `process(...)` via `normalize_parameter_values`. 
- Persist and restore curve points through the new custom settings hooks implemented in `node/process_node/node_curves.py`. 
- Update `NODE_BASE_CLASS_REFACTOR_PLAN.md` to mark `Curves` migrated and extend declarative tests by adding Curves-specific unit tests in `tests/unit/test_declarative_process_nodes.py`.

### Testing
- Ran the targeted unit tests: `python -m pytest --use-cv2-stub tests/unit/test_declarative_process_nodes.py` and observed `13 passed`.
- Ran the full test suite with the cv2 stub: `python -m pytest --use-cv2-stub` and observed `59 passed, 19 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abe36579788323a35d09c04a0a7b57)