### PR TITLE
Extract graph runtime into GraphRuntime module; wire into main; add roadmap and tests

### DIFF
--- a/docs/ROADMAP_EXECUTION_PLAN.md
+++ b/docs/ROADMAP_EXECUTION_PLAN.md
@@ -6,10 +6,16 @@ This document consolidates the feature ideas and architecture discussions into a
 
 ## Progress update / 進捗
 
-- ✅ Phase A1 completed: graph runtime extraction into `node_editor/graph_runtime.py`.
-- ✅ Phase A2.A completed: app lifecycle/bootstrap extraction into `node_editor/app_lifecycle.py` (config load, camera/serial setup, DearPyGui setup, shutdown).
-- ✅ Phase A2.B completed: loop orchestration extraction into `node_editor/runtime_controller.py` (async worker + sync/async loop runners).
-- ✅ Phase A2.C completed: menu/editor factory extraction into `node_editor/editor_factory.py` (default menu map, editor creation, startup import helper).
+### Epic A canonical status
+- ✅ A1 completed: graph runtime extraction into `node_editor/graph_runtime.py`.
+- ✅ A2 completed: parity test coverage for runtime behavior.
+- ✅ A3 completed: runtime policy switches added (`cache_enabled`, `cache_source_nodes`) and tested.
+
+### Epic A extraction sub-steps (historical detail)
+- ✅ A2.A completed: app lifecycle/bootstrap extraction into `node_editor/app_lifecycle.py` (config load, camera/serial setup, DearPyGui setup, shutdown).
+- ✅ A2.B completed: loop orchestration extraction into `node_editor/runtime_controller.py` (async worker + sync/async loop runners).
+- ✅ A2.C completed: menu/editor factory extraction into `node_editor/editor_factory.py` (default menu map, editor creation, startup import helper).
+
 - 🔜 Next recommended step: Phase B1 implement auto-reconnect when dropping onto an occupied input port.
 
 ## 1) Goals
@@ -184,26 +190,26 @@ Use this template in local markdown files to track work:
 - Estimate: M
 - Depends on: none
 - Acceptance:
-  - [ ] Runtime logic moved out of `main.py`
-  - [ ] Existing update behavior preserved
-  - [ ] No node API changes required
+  - [x] Runtime logic moved out of `main.py`
+  - [x] Existing update behavior preserved
+  - [x] No node API changes required
 
 ### A2. Runtime behavior parity tests
 - Priority: P0
 - Estimate: M
 - Depends on: A1
 - Acceptance:
-  - [ ] Cache hit/miss parity tests pass
-  - [ ] Deleted-node cleanup tested
-  - [ ] Async exception behavior tested
+  - [x] Cache hit/miss parity tests pass
+  - [x] Deleted-node cleanup tested
+  - [x] Async exception behavior tested
 
 ### A3. Runtime policy switches (optional)
 - Priority: P1
 - Estimate: S
 - Depends on: A1
 - Acceptance:
-  - [ ] Configurable cache enable/disable
-  - [ ] Source-node cache policy explicit
+  - [x] Configurable cache enable/disable
+  - [x] Source-node cache policy explicit
 
 ---
 

--- a/docs/ROADMAP_EXECUTION_PLAN.md
+++ b/docs/ROADMAP_EXECUTION_PLAN.md
@@ -1,0 +1,320 @@
+# Project Roadmap & Execution Plan
+
+This document consolidates the feature ideas and architecture discussions into a practical, implementation-first plan.
+
+---
+
+## 1) Goals
+
+### Product goals
+- Expand core image processing functionality (e.g., sharpen, hue rotation, selective hue adjustment).
+- Make graph editing less finicky (connect/reconnect/swap/insert flows).
+- Enable parameter animation workflows for still images and videos.
+- Add ML-assisted parameter tuning for metric matching and target-image matching.
+
+### Engineering goals
+- Reduce coupling in `main.py` by moving runtime update/caching orchestration into a dedicated runtime layer.
+- Improve testability and maintainability without forcing broad node API changes.
+
+---
+
+## 2) Guiding Principles
+
+- **Ship in small slices:** avoid long-lived mega-refactors.
+- **Behavior-preserving first:** move orchestration before redesigning behavior.
+- **Node compatibility:** keep existing node interface stable unless there is clear ROI.
+- **Async safety:** preserve guarded access patterns and defensive input parsing.
+- **User workflow first:** prioritize friction points in graph editing and parameter workflows.
+
+---
+
+## 3) Phased Plan (Recommended Order)
+
+## Phase A — Runtime refactor (foundation)
+
+### Objective
+Extract update/caching orchestration from `main.py` into a dedicated graph runtime module.
+
+### Scope
+- Create `node_editor/graph_runtime.py`.
+- Move current orchestration responsibilities:
+  - node traversal/update scheduling
+  - cache signature generation
+  - cache hit/miss behavior
+  - stale data cleanup for deleted nodes
+  - exception handling policy for async update loop integration
+- Keep `Node.update(...)` contracts unchanged.
+- Keep existing editor UI behavior unchanged.
+
+### Deliverables
+- New runtime module and wiring from `main.py`.
+- Unit tests for runtime behavior parity.
+- No behavior regressions in existing tests.
+
+### Why first
+- Reduces future feature risk.
+- Makes later graph UX/optimization features easier to implement and test.
+
+---
+
+## Phase B — Graph UX improvements (rewiring quality of life)
+
+### Objective
+Make connecting and modifying pipelines faster and less error-prone.
+
+### Candidate features (MVP first)
+1. **Auto-reconnect on occupied input**
+   - Drop a new source onto an already-connected input to replace old link.
+2. **Insert node into link**
+   - Select link, choose node type, auto-wire source → new node → destination.
+3. **Quick reconnect interaction**
+   - Light-weight connect mode for reduced drag precision.
+4. **Actionable link feedback**
+   - Surface reason for rejected link attempts.
+
+### Stretch goals
+- Replace node type in place (implemented as “safe replace + reconnect”).
+
+---
+
+## Phase C — New processing nodes
+
+### Objective
+Add practical color and sharpening operations you can immediately use.
+
+### Initial node set
+- `Sharpen`
+- `Hue Rotate`
+- `Selective Hue Adjustment` (aka hue-range adjustment / hue-sector adjustment)
+
+### Implementation approach
+- Prefer `DeclarativeImageProcessNodeBase` for consistency and speed.
+- Keep parameters linkable so control nodes can drive them.
+- Add focused unit tests for processing correctness and parameter bounds.
+
+### Optional expansion
+- Advanced sharpen variants (unsharp mask controls).
+- Multi-range selective hue controls.
+
+---
+
+## Phase D — Animation & video parameter workflows
+
+### Objective
+Support “animate a parameter over time” for still images and existing videos.
+
+### Core features
+1. `Frame Index / Time` source node(s)
+2. `Parameter Ramp` (or curve) control node
+3. Connect control output to process node parameters
+4. Export via existing video writer path
+
+### Expected outcomes
+- Parameter sweeps (e.g., hue angle increments over frames)
+- Repeatable, scriptable animation pipelines in the editor
+
+---
+
+## Phase E — ML tuning nodes
+
+### Objective
+Recover/optimize processing parameters from metrics or target images.
+
+### Stage 1 (recommended first)
+- Metric-based tuning node
+- Objective: optimize scalar metric(s)
+- Search methods: random/grid/coarse-to-fine/coordinate descent
+
+### Stage 2
+- Target-image matching node
+- Objective: minimize output-vs-target distance
+- Add optional constraints and warm starts
+
+### Stage 3 (optional)
+- Multi-step reconstruction using intermediate saved images
+- Step-wise fitting with temporal/sequence regularization
+
+### Risks
+- Compute cost grows quickly with parameter dimensionality.
+- Need robust stop criteria and iteration budgets.
+
+---
+
+## 4) Backlog Template (without GitHub Issues)
+
+Use this template in local markdown files to track work:
+
+```md
+## [ID] Title
+- Status: Todo / In Progress / Done
+- Priority: P0 / P1 / P2
+- Estimate: S / M / L
+- Depends on: [IDs]
+
+### Goal
+...
+
+### Acceptance Criteria
+- [ ] ...
+- [ ] ...
+
+### Technical Notes
+...
+
+### Test Plan
+- [ ] ...
+```
+
+---
+
+## 5) Suggested Execution Backlog
+
+## Epic A: Runtime foundation
+
+### A1. Extract graph runtime module
+- Priority: P0
+- Estimate: M
+- Depends on: none
+- Acceptance:
+  - [ ] Runtime logic moved out of `main.py`
+  - [ ] Existing update behavior preserved
+  - [ ] No node API changes required
+
+### A2. Runtime behavior parity tests
+- Priority: P0
+- Estimate: M
+- Depends on: A1
+- Acceptance:
+  - [ ] Cache hit/miss parity tests pass
+  - [ ] Deleted-node cleanup tested
+  - [ ] Async exception behavior tested
+
+### A3. Runtime policy switches (optional)
+- Priority: P1
+- Estimate: S
+- Depends on: A1
+- Acceptance:
+  - [ ] Configurable cache enable/disable
+  - [ ] Source-node cache policy explicit
+
+---
+
+## Epic B: Graph UX
+
+### B1. Replace existing link on occupied input
+- Priority: P0
+- Estimate: M
+- Depends on: A1 preferred
+
+### B2. Insert-node-into-link action
+- Priority: P1
+- Estimate: M
+- Depends on: B1
+
+### B3. Rejected-link reason feedback
+- Priority: P1
+- Estimate: S
+- Depends on: none
+
+### B4. Safe node-type replace workflow
+- Priority: P2
+- Estimate: L
+- Depends on: B1
+
+---
+
+## Epic C: Processing nodes
+
+### C1. Sharpen node
+- Priority: P0
+- Estimate: S
+- Depends on: none
+
+### C2. Hue Rotate node
+- Priority: P0
+- Estimate: S
+- Depends on: none
+
+### C3. Selective Hue Adjustment node
+- Priority: P1
+- Estimate: M
+- Depends on: C2
+
+### C4. Regression tests for new process nodes
+- Priority: P0
+- Estimate: M
+- Depends on: C1, C2, C3
+
+---
+
+## Epic D: Animation
+
+### D1. Frame Index/Time control node
+- Priority: P1
+- Estimate: S
+- Depends on: none
+
+### D2. Parameter Ramp node
+- Priority: P1
+- Estimate: M
+- Depends on: D1
+
+### D3. End-to-end animation pipeline sample
+- Priority: P1
+- Estimate: S
+- Depends on: D2
+
+---
+
+## Epic E: ML tuning
+
+### E1. Metric optimizer node (v1)
+- Priority: P2
+- Estimate: L
+- Depends on: A1 preferred
+
+### E2. Target image matching node (v1)
+- Priority: P2
+- Estimate: L
+- Depends on: E1
+
+### E3. Multi-step reconstruction workflow
+- Priority: P3
+- Estimate: XL
+- Depends on: E2
+
+---
+
+## 6) Milestone plan (example)
+
+### Milestone 1 (2–3 weeks)
+- A1, A2, B1, C1, C2
+
+### Milestone 2 (2–3 weeks)
+- B2, B3, C3, C4, D1
+
+### Milestone 3 (3–4 weeks)
+- D2, D3, E1 prototype
+
+### Milestone 4 (R&D)
+- E2, E3 exploration
+
+---
+
+## 7) Definition of Done
+
+A task is done when:
+- Code is merged with tests (or explicit rationale for no test).
+- Behavior is documented if user-facing.
+- Async safety considerations are reviewed for affected update paths.
+- Import/export compatibility impact is checked.
+
+---
+
+## 8) Practical next step (immediate)
+
+Start with **A1 (runtime extraction)** and **C1/C2 (sharpen + hue rotate)** in parallel branches:
+- Branch 1: architecture foundation
+- Branch 2: user-visible feature delivery
+
+This balances long-term maintainability and near-term feature momentum.

--- a/docs/ROADMAP_EXECUTION_PLAN.md
+++ b/docs/ROADMAP_EXECUTION_PLAN.md
@@ -8,7 +8,8 @@ This document consolidates the feature ideas and architecture discussions into a
 
 - ✅ Phase A1 completed: graph runtime extraction into `node_editor/graph_runtime.py`.
 - ✅ Phase A2.A completed: app lifecycle/bootstrap extraction into `node_editor/app_lifecycle.py` (config load, camera/serial setup, DearPyGui setup, shutdown).
-- 🔜 Next recommended step: Phase A2.B split loop orchestration into a dedicated runtime controller module.
+- ✅ Phase A2.B completed: loop orchestration extraction into `node_editor/runtime_controller.py` (async worker + sync/async loop runners).
+- 🔜 Next recommended step: Phase A2.C extract menu/editor factory wiring into a dedicated composition helper.
 
 ## 1) Goals
 

--- a/docs/ROADMAP_EXECUTION_PLAN.md
+++ b/docs/ROADMAP_EXECUTION_PLAN.md
@@ -4,6 +4,12 @@ This document consolidates the feature ideas and architecture discussions into a
 
 ---
 
+## Progress update / 進捗
+
+- ✅ Phase A1 completed: graph runtime extraction into `node_editor/graph_runtime.py`.
+- ✅ Phase A2.A completed: app lifecycle/bootstrap extraction into `node_editor/app_lifecycle.py` (config load, camera/serial setup, DearPyGui setup, shutdown).
+- 🔜 Next recommended step: Phase A2.B split loop orchestration into a dedicated runtime controller module.
+
 ## 1) Goals
 
 ### Product goals

--- a/docs/ROADMAP_EXECUTION_PLAN.md
+++ b/docs/ROADMAP_EXECUTION_PLAN.md
@@ -9,7 +9,8 @@ This document consolidates the feature ideas and architecture discussions into a
 - ✅ Phase A1 completed: graph runtime extraction into `node_editor/graph_runtime.py`.
 - ✅ Phase A2.A completed: app lifecycle/bootstrap extraction into `node_editor/app_lifecycle.py` (config load, camera/serial setup, DearPyGui setup, shutdown).
 - ✅ Phase A2.B completed: loop orchestration extraction into `node_editor/runtime_controller.py` (async worker + sync/async loop runners).
-- 🔜 Next recommended step: Phase A2.C extract menu/editor factory wiring into a dedicated composition helper.
+- ✅ Phase A2.C completed: menu/editor factory extraction into `node_editor/editor_factory.py` (default menu map, editor creation, startup import helper).
+- 🔜 Next recommended step: Phase B1 implement auto-reconnect when dropping onto an occupied input port.
 
 ## 1) Goals
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import asyncio
 import argparse
 from collections import OrderedDict
 import os
@@ -10,6 +9,7 @@ import dearpygui.dearpygui as dpg
 try:
     from .node_editor.node_editor import DpgNodeEditor
     from .node_editor.graph_runtime import GraphRuntime, update_node_info
+    from .node_editor.runtime_controller import run_editor_main_loop
     from .node_editor.app_lifecycle import (
         load_opencv_settings,
         initialize_camera_resources,
@@ -20,6 +20,7 @@ try:
 except ImportError:
     from node_editor.node_editor import DpgNodeEditor
     from node_editor.graph_runtime import GraphRuntime, update_node_info
+    from node_editor.runtime_controller import run_editor_main_loop
     from node_editor.app_lifecycle import (
         load_opencv_settings,
         initialize_camera_resources,
@@ -54,18 +55,6 @@ def get_args():
 
     return parser.parse_args()
 
-
-def async_main(node_editor, runtime):
-    while not node_editor.get_terminate_flag():
-        try:
-            runtime.step(node_editor, mode_async=True)
-        except Exception as e:
-            print('ERROR: async_main loop exception')
-            print(f'\terror                : {type(e).__name__}: {e}')
-            import traceback
-            traceback.print_exc()
-            print()
-            continue
 
 
 def main():
@@ -129,16 +118,11 @@ def main():
 
     runtime = GraphRuntime()
 
-    print('**** Start Main Event Loop ********')
-    event_loop = None
-    if not unuse_async_draw:
-        event_loop = asyncio.get_event_loop()
-        event_loop.run_in_executor(None, async_main, node_editor, runtime)
-        dpg.start_dearpygui()
-    else:
-        while dpg.is_dearpygui_running():
-            runtime.step(node_editor, mode_async=False)
-            dpg.render_dearpygui_frame()
+    event_loop = run_editor_main_loop(
+        node_editor,
+        runtime,
+        unuse_async_draw=unuse_async_draw,
+    )
 
     shutdown_runtime(
         node_editor,

--- a/main.py
+++ b/main.py
@@ -1,142 +1,99 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import sys
-import json
 import asyncio
 import argparse
 from collections import OrderedDict
 import os
 
-import cv2
 import dearpygui.dearpygui as dpg
 
 try:
-    from .node_editor.util import check_camera_connection
     from .node_editor.node_editor import DpgNodeEditor
     from .node_editor.graph_runtime import GraphRuntime, update_node_info
+    from .node_editor.app_lifecycle import (
+        load_opencv_settings,
+        initialize_camera_resources,
+        initialize_serial_resources,
+        setup_dearpygui,
+        shutdown_runtime,
+    )
 except ImportError:
-    from node_editor.util import check_camera_connection
     from node_editor.node_editor import DpgNodeEditor
     from node_editor.graph_runtime import GraphRuntime, update_node_info
+    from node_editor.app_lifecycle import (
+        load_opencv_settings,
+        initialize_camera_resources,
+        initialize_serial_resources,
+        setup_dearpygui,
+        shutdown_runtime,
+    )
 
 
 def get_args():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "--setting",
+        '--setting',
         type=str,
-        # get abs
         default=os.path.abspath(
-            os.path.join(os.path.dirname(__file__),
-                         'node_editor/setting/setting.json')),
+            os.path.join(
+                os.path.dirname(__file__),
+                'node_editor/setting/setting.json',
+            )
+        ),
     )
-    parser.add_argument("--unuse_async_draw", action="store_true")
-    parser.add_argument("--use_debug_print", action="store_true")
+    parser.add_argument('--unuse_async_draw', action='store_true')
+    parser.add_argument('--use_debug_print', action='store_true')
     parser.add_argument(
-        "-i",
-        "--import_json",
+        '-i',
+        '--import_json',
         type=str,
         default=None,
-        help="Path to a node editor JSON file to import at startup.",
+        help='Path to a node editor JSON file to import at startup.',
     )
 
-    args = parser.parse_args()
-
-    return args
+    return parser.parse_args()
 
 
-def async_main(node_editor, runtime, use_debug_print=False):
-    del use_debug_print
-
-    # メインループ
+def async_main(node_editor, runtime):
     while not node_editor.get_terminate_flag():
         try:
             runtime.step(node_editor, mode_async=True)
         except Exception as e:
             print('ERROR: async_main loop exception')
-            print(f"\terror                : {type(e).__name__}: {e}")
+            print(f'\terror                : {type(e).__name__}: {e}')
             import traceback
             traceback.print_exc()
             print()
             continue
 
-def main():
 
+def main():
     args = get_args()
     setting = args.setting
     unuse_async_draw = args.unuse_async_draw
     use_debug_print = args.use_debug_print
     import_json = args.import_json
 
-    # 動作設定
     print('**** Load Config ********')
-    opencv_setting_dict = None
-    with open(setting) as fp:
-        opencv_setting_dict = json.load(fp)
-    webcam_width = opencv_setting_dict['webcam_width']
-    webcam_height = opencv_setting_dict['webcam_height']
+    opencv_setting_dict = load_opencv_settings(setting)
 
-    # 接続カメラチェック
-    print('**** Check Camera Connection ********')
-    device_no_list = check_camera_connection()
-    camera_capture_list = []
-    for device_no in device_no_list:
-        video_capture = cv2.VideoCapture(device_no)
-        video_capture.set(cv2.CAP_PROP_FRAME_WIDTH, webcam_width)
-        video_capture.set(cv2.CAP_PROP_FRAME_HEIGHT, webcam_height)
-        camera_capture_list.append(video_capture)
+    camera_capture_list = initialize_camera_resources(opencv_setting_dict)
+    serial_connection_list = initialize_serial_resources(opencv_setting_dict)
 
-    # カメラ設定保持
-    opencv_setting_dict['device_no_list'] = device_no_list
-    opencv_setting_dict['camera_capture_list'] = camera_capture_list
-
-    # DearPyGui準備(コンテキスト生成、セットアップ、ビューポート生成)
     editor_width = opencv_setting_dict['editor_width']
     editor_height = opencv_setting_dict['editor_height']
 
-    # Serial接続デバイスチェック
-    serial_device_no_list = []
-    serial_connection_list = []
-    use_serial = opencv_setting_dict['use_serial']
-    if use_serial == True:
-        import serial
-        try:
-            from .node_editor.util import check_serial_connection
-        except:
-            from node_editor.util import check_serial_connection
-        print('**** Check Serial Device Connection ********')
-        serial_device_no_list = check_serial_connection()
-        for serial_device_no in serial_device_no_list:
-            ser = serial.Serial(serial_device_no,115200)
-            serial_connection_list.append(ser)
-        
-    # Serial接続デバイス設定保持
-    opencv_setting_dict['serial_device_no_list'] = serial_device_no_list
-    opencv_setting_dict['serial_connection_list'] = serial_connection_list
-
-    print('**** DearPyGui Setup ********')
-    dpg.create_context()
-    dpg.setup_dearpygui()
-    dpg.create_viewport(
-        title="Image Processing Node Editor",
-        width=editor_width,
-        height=editor_height,
+    current_path = os.path.dirname(os.path.abspath(__file__))
+    setup_dearpygui(
+        editor_width,
+        editor_height,
+        os.path.join(
+            current_path,
+            'node_editor/font/YasashisaAntiqueFont/07YasashisaAntique.otf',
+        ),
     )
 
-    # デフォルトフォント変更
-    # このファイルのパスを取得
-    current_path = os.path.dirname(os.path.abspath(__file__))
-    with dpg.font_registry():
-        with dpg.font(
-                current_path +
-                '/node_editor/font/YasashisaAntiqueFont/07YasashisaAntique.otf',
-                16,
-        ) as default_font:
-            dpg.add_font_range_hint(dpg.mvFontRangeHint_Japanese)
-    dpg.bind_font(default_font)
-
-    # ノードエディター生成
     print('**** Create NodeEditor ********')
     menu_dict = OrderedDict({
         'InputNode': 'input_node',
@@ -147,14 +104,13 @@ def main():
         'OtherNode': 'other_node',
         # 'PreviewReleaseNode': 'preview_release_node'
     })
-    # print
     node_editor = DpgNodeEditor(
         width=editor_width - 15,
         height=editor_height - 40,
         opencv_setting_dict=opencv_setting_dict,
         menu_dict=menu_dict,
         use_debug_print=use_debug_print,
-        node_dir=current_path + '/node',
+        node_dir=os.path.join(current_path, 'node'),
     )
 
     if import_json is not None:
@@ -163,54 +119,33 @@ def main():
             node_editor.import_setting_file(import_json)
         except Exception as e:
             print('ERROR: failed to import startup JSON file')
-            print(f'	path                 : {import_json}')
-            print(f"	error                : {type(e).__name__}: {e}")
+            print(f'\tpath                 : {import_json}')
+            print(f'\terror                : {type(e).__name__}: {e}')
             import traceback
             traceback.print_exc()
             print()
 
-    # ビューポート表示
     dpg.show_viewport()
 
     runtime = GraphRuntime()
 
-    # メインループ
     print('**** Start Main Event Loop ********')
+    event_loop = None
     if not unuse_async_draw:
         event_loop = asyncio.get_event_loop()
-        event_loop.run_in_executor(
-            None,
-            async_main,
-            node_editor,
-            runtime,
-            use_debug_print,
-        )
+        event_loop.run_in_executor(None, async_main, node_editor, runtime)
         dpg.start_dearpygui()
     else:
         while dpg.is_dearpygui_running():
             runtime.step(node_editor, mode_async=False)
             dpg.render_dearpygui_frame()
 
-    # 終了処理
-    print('**** Terminate process ********')
-    # 各ノードの終了処理
-    print('**** Close All Node ********')
-    node_list = node_editor.get_node_list()
-    for node_id_name in node_list:
-        node_id, node_name = node_id_name.split(':')
-        node_instance = node_editor.get_node_instance(node_name)
-        node_instance.close(node_id)
-    # OpenCV関連終了処理
-    print('**** Release All VideoCapture ********')
-    for camera_capture in camera_capture_list:
-        camera_capture.release()
-    # イベントループの停止
-    print('**** Stop Event Loop ********')
-    node_editor.set_terminate_flag()
-    event_loop.stop()
-    # DearPyGuiコンテキスト破棄
-    print('**** Destroy DearPyGui Context ********')
-    dpg.destroy_context()
+    shutdown_runtime(
+        node_editor,
+        camera_capture_list,
+        serial_connection_list,
+        event_loop=event_loop,
+    )
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import argparse
-from collections import OrderedDict
 import os
 
 import dearpygui.dearpygui as dpg
 
 try:
-    from .node_editor.node_editor import DpgNodeEditor
     from .node_editor.graph_runtime import GraphRuntime, update_node_info
     from .node_editor.runtime_controller import run_editor_main_loop
     from .node_editor.app_lifecycle import (
@@ -17,8 +15,11 @@ try:
         setup_dearpygui,
         shutdown_runtime,
     )
+    from .node_editor.editor_factory import (
+        create_node_editor,
+        import_startup_json,
+    )
 except ImportError:
-    from node_editor.node_editor import DpgNodeEditor
     from node_editor.graph_runtime import GraphRuntime, update_node_info
     from node_editor.runtime_controller import run_editor_main_loop
     from node_editor.app_lifecycle import (
@@ -27,6 +28,10 @@ except ImportError:
         initialize_serial_resources,
         setup_dearpygui,
         shutdown_runtime,
+    )
+    from node_editor.editor_factory import (
+        create_node_editor,
+        import_startup_json,
     )
 
 
@@ -56,7 +61,6 @@ def get_args():
     return parser.parse_args()
 
 
-
 def main():
     args = get_args()
     setting = args.setting
@@ -84,35 +88,15 @@ def main():
     )
 
     print('**** Create NodeEditor ********')
-    menu_dict = OrderedDict({
-        'InputNode': 'input_node',
-        'ProcessNode': 'process_node',
-        # 'DeepLearningNode': 'deep_learning_node',
-        'AnalysisNode': 'analysis_node',
-        'DrawNode': 'draw_node',
-        'OtherNode': 'other_node',
-        # 'PreviewReleaseNode': 'preview_release_node'
-    })
-    node_editor = DpgNodeEditor(
-        width=editor_width - 15,
-        height=editor_height - 40,
+    node_editor = create_node_editor(
+        current_path=current_path,
+        editor_width=editor_width,
+        editor_height=editor_height,
         opencv_setting_dict=opencv_setting_dict,
-        menu_dict=menu_dict,
         use_debug_print=use_debug_print,
-        node_dir=os.path.join(current_path, 'node'),
     )
 
-    if import_json is not None:
-        print('**** Import JSON ********')
-        try:
-            node_editor.import_setting_file(import_json)
-        except Exception as e:
-            print('ERROR: failed to import startup JSON file')
-            print(f'\tpath                 : {import_json}')
-            print(f'\terror                : {type(e).__name__}: {e}')
-            import traceback
-            traceback.print_exc()
-            print()
+    import_startup_json(node_editor, import_json)
 
     dpg.show_viewport()
 

--- a/main.py
+++ b/main.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import sys
-import copy
 import json
 import asyncio
 import argparse
-import hashlib
-import pickle
 from collections import OrderedDict
 import os
 
@@ -16,9 +13,11 @@ import dearpygui.dearpygui as dpg
 try:
     from .node_editor.util import check_camera_connection
     from .node_editor.node_editor import DpgNodeEditor
+    from .node_editor.graph_runtime import GraphRuntime, update_node_info
 except ImportError:
     from node_editor.util import check_camera_connection
     from node_editor.node_editor import DpgNodeEditor
+    from node_editor.graph_runtime import GraphRuntime, update_node_info
 
 
 def get_args():
@@ -47,21 +46,13 @@ def get_args():
     return args
 
 
-def async_main(node_editor, use_debug_print=False):
-    # 各ノードの処理結果保持用Dict
-    node_image_dict = {}
-    node_result_dict = {}
-    node_cache_dict = {}
+def async_main(node_editor, runtime, use_debug_print=False):
+    del use_debug_print
 
     # メインループ
     while not node_editor.get_terminate_flag():
         try:
-            update_node_info(
-                node_editor,
-                node_image_dict,
-                node_result_dict,
-                node_cache_dict=node_cache_dict,
-            )
+            runtime.step(node_editor, mode_async=True)
         except Exception as e:
             print('ERROR: async_main loop exception')
             print(f"\terror                : {type(e).__name__}: {e}")
@@ -69,249 +60,6 @@ def async_main(node_editor, use_debug_print=False):
             traceback.print_exc()
             print()
             continue
-
-
-def _freeze_cache_value(value):
-    if isinstance(value, (str, int, float, bool, type(None))):
-        return value
-
-    if isinstance(value, bytes):
-        return hashlib.sha1(value).hexdigest()
-
-    if isinstance(value, (list, tuple)):
-        return tuple(_freeze_cache_value(item) for item in value)
-
-    if isinstance(value, set):
-        return tuple(sorted(_freeze_cache_value(item) for item in value))
-
-    if isinstance(value, dict):
-        return tuple(
-            sorted(
-                (
-                    _freeze_cache_value(key),
-                    _freeze_cache_value(item),
-                )
-                for key, item in value.items()
-            )
-        )
-
-    if (
-        hasattr(value, 'shape') and
-        hasattr(value, 'dtype') and
-        hasattr(value, 'tobytes')
-    ):
-        try:
-            return (
-                'ndarray',
-                tuple(value.shape),
-                str(value.dtype),
-                hashlib.sha1(value.tobytes()).hexdigest(),
-            )
-        except TypeError:
-            pass
-
-    return repr(value)
-
-
-def _build_node_signature(
-    node_id,
-    connection_list,
-    node_image_dict,
-    node_result_dict,
-    node_setting,
-):
-    upstream_values = []
-    for source_tag, _ in connection_list:
-        source_node_id_name = ':'.join(source_tag.split(':')[:2])
-        upstream_values.append((
-            source_tag,
-            _freeze_cache_value(node_image_dict.get(source_node_id_name)),
-            _freeze_cache_value(node_result_dict.get(source_node_id_name)),
-        ))
-
-    signature_payload = {
-        'node_id': node_id,
-        'connection_list': connection_list,
-        'upstream_values': upstream_values,
-        'node_setting': _freeze_cache_value(node_setting),
-    }
-    payload_bytes = pickle.dumps(signature_payload)
-    return hashlib.sha1(payload_bytes).hexdigest()
-
-
-def update_node_info(
-    node_editor,
-    node_image_dict,
-    node_result_dict,
-    node_cache_dict=None,
-    mode_async=True,
-):
-    """
-    Update all nodes in topological order with optional in-memory caching.
-
-    Cache path (connected nodes):
-      1) build a signature from upstream outputs + node settings
-      2) if signature matches previous run, reuse cached output and skip update()
-
-    Non-cache path (source nodes without inbound links):
-      always run update() so UI/callback-driven state changes are picked up.
-    """
-    if node_cache_dict is None:
-        node_cache_dict = {}
-
-    def _is_valid_connection(connection_info, valid_nodes):
-        if len(connection_info) != 2:
-            return False
-
-        source_tag, dest_tag = connection_info
-        source_node_id_name = ':'.join(source_tag.split(':')[:2])
-        dest_node_id_name = ':'.join(dest_tag.split(':')[:2])
-        if source_node_id_name not in valid_nodes:
-            return False
-        if dest_node_id_name not in valid_nodes:
-            return False
-
-        return True
-
-    # ノードリスト取得
-    node_list = list(node_editor.get_node_list())
-    active_node_set = set(node_list)
-    # Remove stale outputs for nodes deleted from the editor.
-    deleted_image_node_id_name_list = [
-        node_id_name for node_id_name in node_image_dict.keys()
-        if node_id_name not in active_node_set
-    ]
-    for deleted_node_id_name in deleted_image_node_id_name_list:
-        del node_image_dict[deleted_node_id_name]
-
-    deleted_result_node_id_name_list = [
-        node_id_name for node_id_name in node_result_dict.keys()
-        if node_id_name not in active_node_set
-    ]
-    for deleted_node_id_name in deleted_result_node_id_name_list:
-        del node_result_dict[deleted_node_id_name]
-
-    # ノード接続情報取得
-    sorted_node_connection_dict = node_editor.get_sorted_node_connection()
-
-    # 各ノードの情報をアップデート
-    for node_id_name in node_list:
-        if node_id_name not in node_image_dict:
-            node_image_dict[node_id_name] = None
-
-        node_id, node_name = node_id_name.split(':')
-
-        # Skip nodes that were deleted in GUI callbacks during this update tick.
-        if hasattr(node_editor, 'is_node_active'):
-            try:
-                if not node_editor.is_node_active(node_id_name):
-                    continue
-            except Exception:
-                pass
-
-        connection_list = sorted_node_connection_dict.get(node_id_name, [])
-        connection_list = [
-            connection_info for connection_info in connection_list
-            if _is_valid_connection(connection_info, active_node_set)
-        ]
-
-        # ノード名からインスタンスを取得
-        node_instance = node_editor.get_node_instance(node_name)
-        if node_instance is None:
-            node_image_dict[node_id_name] = None
-            node_result_dict[node_id_name] = None
-            continue
-        cache_signature = None
-        # Only cache nodes that have inbound links (downstream processors).
-        # Source/input nodes must keep running every frame.
-        use_cache = len(connection_list) > 0
-        node_setting = {}
-        if use_cache and hasattr(node_instance, 'get_setting_dict'):
-            if mode_async:
-                try:
-                    node_setting = node_instance.get_setting_dict(node_id)
-                except Exception as e:
-                    print(
-                        'WARNING: failed to read node settings in '
-                        f'update_node_info ({node_id_name}) '
-                        f'{type(e).__name__}: {e}'
-                    )
-                    import traceback
-                    traceback.print_exc()
-                    use_cache = False
-            else:
-                node_setting = node_instance.get_setting_dict(node_id)
-
-        if use_cache:
-            # Cache-hit path: skip expensive update() when nothing relevant changed.
-            cache_signature = _build_node_signature(
-                node_id,
-                connection_list,
-                node_image_dict,
-                node_result_dict,
-                node_setting,
-            )
-            cached_result = node_cache_dict.get(node_id_name)
-            if (
-                cached_result is not None and
-                cached_result.get('signature') == cache_signature
-            ):
-                node_image_dict[node_id_name] = copy.deepcopy(
-                    cached_result['image']
-                )
-                node_result_dict[node_id_name] = copy.deepcopy(
-                    cached_result['result']
-                )
-                continue
-
-        # 指定ノードの情報を更新
-        if mode_async:
-            try:
-                image, result = node_instance.update(
-                    node_id,
-                    connection_list,
-                    node_image_dict,
-                    node_result_dict,
-                )
-            except Exception as e:
-                print(
-                    'WARNING: node update exception '
-                    f'({node_id_name}) {type(e).__name__}: {e}'
-                )
-                import traceback
-                traceback.print_exc()
-                image, result = None, None
-        else:
-            image, result = node_instance.update(
-                node_id,
-                connection_list,
-                node_image_dict,
-                node_result_dict,
-            )
-        # Cache-miss path (or source node path): run node update and store outputs.
-        node_image_dict[node_id_name] = copy.deepcopy(image)
-        node_result_dict[node_id_name] = copy.deepcopy(result)
-        if use_cache:
-            # Persist latest outputs for the next signature match.
-            node_cache_dict[node_id_name] = {
-                'signature': cache_signature,
-                'image': copy.deepcopy(image),
-                'result': copy.deepcopy(result),
-            }
-        elif node_id_name in node_cache_dict:
-            # Ensure source nodes never keep stale cache entries.
-            del node_cache_dict[node_id_name]
-
-    # Remove cache entries for nodes that were deleted from the graph.
-    deleted_node_id_name_list = [
-        node_id_name for node_id_name in node_cache_dict.keys()
-        if node_id_name not in node_list
-    ]
-    for deleted_node_id_name in deleted_node_id_name_list:
-        del node_cache_dict[deleted_node_id_name]
-
-    return
-
 
 def main():
 
@@ -424,25 +172,23 @@ def main():
     # ビューポート表示
     dpg.show_viewport()
 
+    runtime = GraphRuntime()
+
     # メインループ
     print('**** Start Main Event Loop ********')
     if not unuse_async_draw:
         event_loop = asyncio.get_event_loop()
-        event_loop.run_in_executor(None, async_main, node_editor, use_debug_print)
+        event_loop.run_in_executor(
+            None,
+            async_main,
+            node_editor,
+            runtime,
+            use_debug_print,
+        )
         dpg.start_dearpygui()
     else:
-        # 各ノードの処理結果保持用Dict
-        node_image_dict = {}
-        node_result_dict = {}
-        node_cache_dict = {}
         while dpg.is_dearpygui_running():
-            update_node_info(
-                node_editor,
-                node_image_dict,
-                node_result_dict,
-                node_cache_dict=node_cache_dict,
-                mode_async=False,
-            )
+            runtime.step(node_editor, mode_async=False)
             dpg.render_dearpygui_frame()
 
     # 終了処理

--- a/node_editor/app_lifecycle.py
+++ b/node_editor/app_lifecycle.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import json
+
+import dearpygui.dearpygui as dpg
+
+from node_editor.util import check_camera_connection, check_serial_connection
+
+
+def load_opencv_settings(setting_path):
+    with open(setting_path) as fp:
+        return json.load(fp)
+
+
+def initialize_camera_resources(opencv_setting_dict):
+    import cv2
+
+    webcam_width = opencv_setting_dict['webcam_width']
+    webcam_height = opencv_setting_dict['webcam_height']
+
+    print('**** Check Camera Connection ********')
+    device_no_list = check_camera_connection()
+    camera_capture_list = []
+    for device_no in device_no_list:
+        video_capture = cv2.VideoCapture(device_no)
+        video_capture.set(cv2.CAP_PROP_FRAME_WIDTH, webcam_width)
+        video_capture.set(cv2.CAP_PROP_FRAME_HEIGHT, webcam_height)
+        camera_capture_list.append(video_capture)
+
+    opencv_setting_dict['device_no_list'] = device_no_list
+    opencv_setting_dict['camera_capture_list'] = camera_capture_list
+    return camera_capture_list
+
+
+def initialize_serial_resources(opencv_setting_dict):
+    serial_device_no_list = []
+    serial_connection_list = []
+
+    if opencv_setting_dict.get('use_serial') is True:
+        import serial
+
+        print('**** Check Serial Device Connection ********')
+        serial_device_no_list = check_serial_connection()
+        for serial_device_no in serial_device_no_list:
+            serial_connection_list.append(serial.Serial(serial_device_no, 115200))
+
+    opencv_setting_dict['serial_device_no_list'] = serial_device_no_list
+    opencv_setting_dict['serial_connection_list'] = serial_connection_list
+    return serial_connection_list
+
+
+def setup_dearpygui(editor_width, editor_height, font_path):
+    print('**** DearPyGui Setup ********')
+    dpg.create_context()
+    dpg.setup_dearpygui()
+    dpg.create_viewport(
+        title='Image Processing Node Editor',
+        width=editor_width,
+        height=editor_height,
+    )
+
+    with dpg.font_registry():
+        with dpg.font(font_path, 16) as default_font:
+            dpg.add_font_range_hint(dpg.mvFontRangeHint_Japanese)
+    dpg.bind_font(default_font)
+
+
+def shutdown_runtime(node_editor, camera_capture_list, serial_connection_list, event_loop=None):
+    print('**** Terminate process ********')
+    print('**** Close All Node ********')
+    for node_id_name in node_editor.get_node_list():
+        node_id, node_name = node_id_name.split(':')
+        node_instance = node_editor.get_node_instance(node_name)
+        node_instance.close(node_id)
+
+    print('**** Release All VideoCapture ********')
+    for camera_capture in camera_capture_list:
+        camera_capture.release()
+
+    print('**** Release All Serial Connections ********')
+    for serial_connection in serial_connection_list:
+        serial_connection.close()
+
+    print('**** Stop Event Loop ********')
+    node_editor.set_terminate_flag()
+    if event_loop is not None:
+        event_loop.stop()
+
+    print('**** Destroy DearPyGui Context ********')
+    dpg.destroy_context()

--- a/node_editor/editor_factory.py
+++ b/node_editor/editor_factory.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from collections import OrderedDict
+import os
+
+from node_editor.node_editor import DpgNodeEditor
+
+
+def build_default_menu_dict():
+    return OrderedDict({
+        'InputNode': 'input_node',
+        'ProcessNode': 'process_node',
+        # 'DeepLearningNode': 'deep_learning_node',
+        'AnalysisNode': 'analysis_node',
+        'DrawNode': 'draw_node',
+        'OtherNode': 'other_node',
+        # 'PreviewReleaseNode': 'preview_release_node'
+    })
+
+
+def create_node_editor(current_path, editor_width, editor_height,
+                       opencv_setting_dict, use_debug_print=False,
+                       menu_dict=None):
+    if menu_dict is None:
+        menu_dict = build_default_menu_dict()
+
+    return DpgNodeEditor(
+        width=editor_width - 15,
+        height=editor_height - 40,
+        opencv_setting_dict=opencv_setting_dict,
+        menu_dict=menu_dict,
+        use_debug_print=use_debug_print,
+        node_dir=os.path.join(current_path, 'node'),
+    )
+
+
+def import_startup_json(node_editor, import_json):
+    if import_json is None:
+        return
+
+    print('**** Import JSON ********')
+    try:
+        node_editor.import_setting_file(import_json)
+    except Exception as e:
+        print('ERROR: failed to import startup JSON file')
+        print(f'\tpath                 : {import_json}')
+        print(f'\terror                : {type(e).__name__}: {e}')
+        import traceback
+        traceback.print_exc()
+        print()

--- a/node_editor/graph_runtime.py
+++ b/node_editor/graph_runtime.py
@@ -8,10 +8,12 @@ import pickle
 class GraphRuntime:
     """Owns graph update state (images/results/cache) and executes update ticks."""
 
-    def __init__(self):
+    def __init__(self, cache_enabled=True, cache_source_nodes=False):
         self.node_image_dict = {}
         self.node_result_dict = {}
         self.node_cache_dict = {}
+        self.cache_enabled = cache_enabled
+        self.cache_source_nodes = cache_source_nodes
 
     def step(self, node_editor, mode_async=True):
         update_node_info(
@@ -20,6 +22,8 @@ class GraphRuntime:
             self.node_result_dict,
             node_cache_dict=self.node_cache_dict,
             mode_async=mode_async,
+            cache_enabled=self.cache_enabled,
+            cache_source_nodes=self.cache_source_nodes,
         )
 
 
@@ -97,19 +101,24 @@ def update_node_info(
     node_result_dict,
     node_cache_dict=None,
     mode_async=True,
+    cache_enabled=True,
+    cache_source_nodes=False,
 ):
     """
     Update all nodes in topological order with optional in-memory caching.
 
-    Cache path (connected nodes):
+    Cache path (enabled nodes):
       1) build a signature from upstream outputs + node settings
       2) if signature matches previous run, reuse cached output and skip update()
 
-    Non-cache path (source nodes without inbound links):
+    Non-cache path:
       always run update() so UI/callback-driven state changes are picked up.
     """
     if node_cache_dict is None:
         node_cache_dict = {}
+
+    if not cache_enabled and node_cache_dict:
+        node_cache_dict.clear()
 
     def _is_valid_connection(connection_info, valid_nodes):
         if len(connection_info) != 2:
@@ -170,7 +179,9 @@ def update_node_info(
             continue
 
         cache_signature = None
-        use_cache = len(connection_list) > 0
+        use_cache = cache_enabled and (
+            len(connection_list) > 0 or cache_source_nodes
+        )
         node_setting = {}
         if use_cache and hasattr(node_instance, 'get_setting_dict'):
             if mode_async:

--- a/node_editor/graph_runtime.py
+++ b/node_editor/graph_runtime.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import copy
+import hashlib
+import pickle
+
+
+class GraphRuntime:
+    """Owns graph update state (images/results/cache) and executes update ticks."""
+
+    def __init__(self):
+        self.node_image_dict = {}
+        self.node_result_dict = {}
+        self.node_cache_dict = {}
+
+    def step(self, node_editor, mode_async=True):
+        update_node_info(
+            node_editor,
+            self.node_image_dict,
+            self.node_result_dict,
+            node_cache_dict=self.node_cache_dict,
+            mode_async=mode_async,
+        )
+
+
+def _freeze_cache_value(value):
+    if isinstance(value, (str, int, float, bool, type(None))):
+        return value
+
+    if isinstance(value, bytes):
+        return hashlib.sha1(value).hexdigest()
+
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_cache_value(item) for item in value)
+
+    if isinstance(value, set):
+        return tuple(sorted(_freeze_cache_value(item) for item in value))
+
+    if isinstance(value, dict):
+        return tuple(
+            sorted(
+                (
+                    _freeze_cache_value(key),
+                    _freeze_cache_value(item),
+                )
+                for key, item in value.items()
+            )
+        )
+
+    if (
+        hasattr(value, 'shape') and
+        hasattr(value, 'dtype') and
+        hasattr(value, 'tobytes')
+    ):
+        try:
+            return (
+                'ndarray',
+                tuple(value.shape),
+                str(value.dtype),
+                hashlib.sha1(value.tobytes()).hexdigest(),
+            )
+        except TypeError:
+            pass
+
+    return repr(value)
+
+
+def _build_node_signature(
+    node_id,
+    connection_list,
+    node_image_dict,
+    node_result_dict,
+    node_setting,
+):
+    upstream_values = []
+    for source_tag, _ in connection_list:
+        source_node_id_name = ':'.join(source_tag.split(':')[:2])
+        upstream_values.append((
+            source_tag,
+            _freeze_cache_value(node_image_dict.get(source_node_id_name)),
+            _freeze_cache_value(node_result_dict.get(source_node_id_name)),
+        ))
+
+    signature_payload = {
+        'node_id': node_id,
+        'connection_list': connection_list,
+        'upstream_values': upstream_values,
+        'node_setting': _freeze_cache_value(node_setting),
+    }
+    payload_bytes = pickle.dumps(signature_payload)
+    return hashlib.sha1(payload_bytes).hexdigest()
+
+
+def update_node_info(
+    node_editor,
+    node_image_dict,
+    node_result_dict,
+    node_cache_dict=None,
+    mode_async=True,
+):
+    """
+    Update all nodes in topological order with optional in-memory caching.
+
+    Cache path (connected nodes):
+      1) build a signature from upstream outputs + node settings
+      2) if signature matches previous run, reuse cached output and skip update()
+
+    Non-cache path (source nodes without inbound links):
+      always run update() so UI/callback-driven state changes are picked up.
+    """
+    if node_cache_dict is None:
+        node_cache_dict = {}
+
+    def _is_valid_connection(connection_info, valid_nodes):
+        if len(connection_info) != 2:
+            return False
+
+        source_tag, dest_tag = connection_info
+        source_node_id_name = ':'.join(source_tag.split(':')[:2])
+        dest_node_id_name = ':'.join(dest_tag.split(':')[:2])
+        if source_node_id_name not in valid_nodes:
+            return False
+        if dest_node_id_name not in valid_nodes:
+            return False
+
+        return True
+
+    node_list = list(node_editor.get_node_list())
+    active_node_set = set(node_list)
+
+    deleted_image_node_id_name_list = [
+        node_id_name for node_id_name in node_image_dict.keys()
+        if node_id_name not in active_node_set
+    ]
+    for deleted_node_id_name in deleted_image_node_id_name_list:
+        del node_image_dict[deleted_node_id_name]
+
+    deleted_result_node_id_name_list = [
+        node_id_name for node_id_name in node_result_dict.keys()
+        if node_id_name not in active_node_set
+    ]
+    for deleted_node_id_name in deleted_result_node_id_name_list:
+        del node_result_dict[deleted_node_id_name]
+
+    sorted_node_connection_dict = node_editor.get_sorted_node_connection()
+
+    for node_id_name in node_list:
+        if node_id_name not in node_image_dict:
+            node_image_dict[node_id_name] = None
+
+        node_id, node_name = node_id_name.split(':')
+
+        if hasattr(node_editor, 'is_node_active'):
+            try:
+                if not node_editor.is_node_active(node_id_name):
+                    continue
+            except Exception:
+                pass
+
+        connection_list = sorted_node_connection_dict.get(node_id_name, [])
+        connection_list = [
+            connection_info for connection_info in connection_list
+            if _is_valid_connection(connection_info, active_node_set)
+        ]
+
+        node_instance = node_editor.get_node_instance(node_name)
+        if node_instance is None:
+            node_image_dict[node_id_name] = None
+            node_result_dict[node_id_name] = None
+            continue
+
+        cache_signature = None
+        use_cache = len(connection_list) > 0
+        node_setting = {}
+        if use_cache and hasattr(node_instance, 'get_setting_dict'):
+            if mode_async:
+                try:
+                    node_setting = node_instance.get_setting_dict(node_id)
+                except Exception as e:
+                    print(
+                        'WARNING: failed to read node settings in '
+                        f'update_node_info ({node_id_name}) '
+                        f'{type(e).__name__}: {e}'
+                    )
+                    import traceback
+                    traceback.print_exc()
+                    use_cache = False
+            else:
+                node_setting = node_instance.get_setting_dict(node_id)
+
+        if use_cache:
+            cache_signature = _build_node_signature(
+                node_id,
+                connection_list,
+                node_image_dict,
+                node_result_dict,
+                node_setting,
+            )
+            cached_result = node_cache_dict.get(node_id_name)
+            if (
+                cached_result is not None and
+                cached_result.get('signature') == cache_signature
+            ):
+                node_image_dict[node_id_name] = copy.deepcopy(
+                    cached_result['image']
+                )
+                node_result_dict[node_id_name] = copy.deepcopy(
+                    cached_result['result']
+                )
+                continue
+
+        if mode_async:
+            try:
+                image, result = node_instance.update(
+                    node_id,
+                    connection_list,
+                    node_image_dict,
+                    node_result_dict,
+                )
+            except Exception as e:
+                print(
+                    'WARNING: node update exception '
+                    f'({node_id_name}) {type(e).__name__}: {e}'
+                )
+                import traceback
+                traceback.print_exc()
+                image, result = None, None
+        else:
+            image, result = node_instance.update(
+                node_id,
+                connection_list,
+                node_image_dict,
+                node_result_dict,
+            )
+
+        node_image_dict[node_id_name] = copy.deepcopy(image)
+        node_result_dict[node_id_name] = copy.deepcopy(result)
+        if use_cache:
+            node_cache_dict[node_id_name] = {
+                'signature': cache_signature,
+                'image': copy.deepcopy(image),
+                'result': copy.deepcopy(result),
+            }
+        elif node_id_name in node_cache_dict:
+            del node_cache_dict[node_id_name]
+
+    deleted_node_id_name_list = [
+        node_id_name for node_id_name in node_cache_dict.keys()
+        if node_id_name not in node_list
+    ]
+    for deleted_node_id_name in deleted_node_id_name_list:
+        del node_cache_dict[deleted_node_id_name]
+
+    return

--- a/node_editor/runtime_controller.py
+++ b/node_editor/runtime_controller.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import asyncio
+
+import dearpygui.dearpygui as dpg
+
+
+def async_runtime_worker(node_editor, runtime):
+    while not node_editor.get_terminate_flag():
+        try:
+            runtime.step(node_editor, mode_async=True)
+        except Exception as e:
+            print('ERROR: async_main loop exception')
+            print(f'\terror                : {type(e).__name__}: {e}')
+            import traceback
+            traceback.print_exc()
+            print()
+            continue
+
+
+def run_editor_main_loop(node_editor, runtime, unuse_async_draw):
+    print('**** Start Main Event Loop ********')
+
+    if not unuse_async_draw:
+        event_loop = asyncio.get_event_loop()
+        event_loop.run_in_executor(None, async_runtime_worker, node_editor, runtime)
+        dpg.start_dearpygui()
+        return event_loop
+
+    while dpg.is_dearpygui_running():
+        runtime.step(node_editor, mode_async=False)
+        dpg.render_dearpygui_frame()
+
+    return None

--- a/tests/unit/test_app_lifecycle.py
+++ b/tests/unit/test_app_lifecycle.py
@@ -1,0 +1,67 @@
+import sys
+from unittest.mock import Mock
+
+from node_editor import app_lifecycle
+
+
+def test_initialize_camera_resources_sets_settings(monkeypatch):
+    fake_cv2 = Mock()
+    fake_capture_a = Mock()
+    fake_capture_b = Mock()
+    fake_cv2.VideoCapture.side_effect = [fake_capture_a, fake_capture_b]
+    fake_cv2.CAP_PROP_FRAME_WIDTH = 3
+    fake_cv2.CAP_PROP_FRAME_HEIGHT = 4
+
+    monkeypatch.setitem(sys.modules, 'cv2', fake_cv2)
+    monkeypatch.setattr(app_lifecycle, 'check_camera_connection', lambda: [0, 2])
+
+    settings = {'webcam_width': 320, 'webcam_height': 240}
+    cameras = app_lifecycle.initialize_camera_resources(settings)
+
+    assert settings['device_no_list'] == [0, 2]
+    assert settings['camera_capture_list'] == cameras
+    assert len(cameras) == 2
+    assert fake_cv2.VideoCapture.call_count == 2
+
+
+def test_initialize_serial_resources_sets_settings(monkeypatch):
+    fake_serial_module = Mock()
+    fake_serial_module.Serial.side_effect = ['serA', 'serB']
+
+    monkeypatch.setattr(app_lifecycle, 'check_serial_connection', lambda: ['COM1', 'COM2'])
+    monkeypatch.setitem(sys.modules, 'serial', fake_serial_module)
+
+    settings = {'use_serial': True}
+    serial_connections = app_lifecycle.initialize_serial_resources(settings)
+
+    assert settings['serial_device_no_list'] == ['COM1', 'COM2']
+    assert settings['serial_connection_list'] == serial_connections
+    assert serial_connections == ['serA', 'serB']
+
+
+def test_shutdown_runtime_closes_resources(monkeypatch):
+    fake_dpg = Mock()
+    monkeypatch.setattr(app_lifecycle, 'dpg', fake_dpg)
+
+    node = Mock()
+    editor = Mock()
+    editor.get_node_list.return_value = ['1:NodeA']
+    editor.get_node_instance.return_value = node
+
+    camera = Mock()
+    serial_connection = Mock()
+    loop = Mock()
+
+    app_lifecycle.shutdown_runtime(
+        editor,
+        [camera],
+        [serial_connection],
+        event_loop=loop,
+    )
+
+    node.close.assert_called_once_with('1')
+    camera.release.assert_called_once()
+    serial_connection.close.assert_called_once()
+    editor.set_terminate_flag.assert_called_once()
+    loop.stop.assert_called_once()
+    fake_dpg.destroy_context.assert_called_once()

--- a/tests/unit/test_editor_factory.py
+++ b/tests/unit/test_editor_factory.py
@@ -1,0 +1,55 @@
+from collections import OrderedDict
+from unittest.mock import Mock
+
+from node_editor import editor_factory
+
+
+def test_build_default_menu_dict_returns_expected_order():
+    menu_dict = editor_factory.build_default_menu_dict()
+
+    assert isinstance(menu_dict, OrderedDict)
+    assert list(menu_dict.keys()) == [
+        'InputNode',
+        'ProcessNode',
+        'AnalysisNode',
+        'DrawNode',
+        'OtherNode',
+    ]
+
+
+def test_create_node_editor_uses_default_menu(monkeypatch):
+    fake_editor_class = Mock()
+    fake_editor_instance = Mock()
+    fake_editor_class.return_value = fake_editor_instance
+    monkeypatch.setattr(editor_factory, 'DpgNodeEditor', fake_editor_class)
+
+    editor = editor_factory.create_node_editor(
+        current_path='/tmp/project',
+        editor_width=1280,
+        editor_height=720,
+        opencv_setting_dict={'a': 1},
+        use_debug_print=True,
+    )
+
+    assert editor is fake_editor_instance
+    call_kwargs = fake_editor_class.call_args.kwargs
+    assert call_kwargs['width'] == 1265
+    assert call_kwargs['height'] == 680
+    assert call_kwargs['node_dir'] == '/tmp/project/node'
+    assert isinstance(call_kwargs['menu_dict'], OrderedDict)
+
+
+def test_import_startup_json_calls_import_when_provided():
+    node_editor = Mock()
+
+    editor_factory.import_startup_json(node_editor, '/tmp/sample.json')
+
+    node_editor.import_setting_file.assert_called_once_with('/tmp/sample.json')
+
+
+def test_import_startup_json_skips_when_none():
+    node_editor = Mock()
+
+    editor_factory.import_startup_json(node_editor, None)
+
+    node_editor.import_setting_file.assert_not_called()

--- a/tests/unit/test_graph_runtime.py
+++ b/tests/unit/test_graph_runtime.py
@@ -1,0 +1,49 @@
+from collections import OrderedDict
+from unittest.mock import Mock
+
+from node_editor.graph_runtime import GraphRuntime
+
+
+class FakeEditor:
+    def __init__(self, nodes, conn_dict, inst_map):
+        self.nodes = nodes
+        self.conn_dict = conn_dict
+        self.inst_map = inst_map
+
+    def get_node_list(self):
+        return self.nodes
+
+    def get_sorted_node_connection(self):
+        return self.conn_dict
+
+    def get_node_instance(self, name):
+        return self.inst_map[name]
+
+
+def test_graph_runtime_persists_state_between_steps():
+    source_node = Mock()
+    source_node.update.return_value = ('src-img', {'source': 1})
+
+    process_node = Mock()
+    process_node.update.return_value = ('img1', {'v': 1})
+    process_node.get_setting_dict.return_value = {'alpha': 0.5}
+
+    nodes = ['1:SourceNode', '2:ProcessNode']
+    conn_dict = OrderedDict([
+        ('1:SourceNode', []),
+        ('2:ProcessNode', [['1:SourceNode:Image:Output01', '2:ProcessNode:Image:Input01']]),
+    ])
+    editor = FakeEditor(
+        nodes,
+        conn_dict,
+        {'SourceNode': source_node, 'ProcessNode': process_node},
+    )
+
+    runtime = GraphRuntime()
+    runtime.step(editor, mode_async=False)
+    runtime.step(editor, mode_async=False)
+
+    assert source_node.update.call_count == 2
+    assert process_node.update.call_count == 1
+    assert runtime.node_image_dict['2:ProcessNode'] == 'img1'
+    assert runtime.node_result_dict['2:ProcessNode'] == {'v': 1}

--- a/tests/unit/test_graph_runtime.py
+++ b/tests/unit/test_graph_runtime.py
@@ -47,3 +47,47 @@ def test_graph_runtime_persists_state_between_steps():
     assert process_node.update.call_count == 1
     assert runtime.node_image_dict['2:ProcessNode'] == 'img1'
     assert runtime.node_result_dict['2:ProcessNode'] == {'v': 1}
+
+
+def test_graph_runtime_policy_cache_disabled_runs_every_step():
+    source_node = Mock()
+    source_node.update.return_value = ('src-img', {'source': 1})
+
+    process_node = Mock()
+    process_node.update.return_value = ('img', {'v': 1})
+    process_node.get_setting_dict.return_value = {'alpha': 0.5}
+
+    nodes = ['1:SourceNode', '2:ProcessNode']
+    conn_dict = OrderedDict([
+        ('1:SourceNode', []),
+        ('2:ProcessNode', [['1:SourceNode:Image:Output01', '2:ProcessNode:Image:Input01']]),
+    ])
+    editor = FakeEditor(
+        nodes,
+        conn_dict,
+        {'SourceNode': source_node, 'ProcessNode': process_node},
+    )
+
+    runtime = GraphRuntime(cache_enabled=False)
+    runtime.step(editor, mode_async=False)
+    runtime.step(editor, mode_async=False)
+
+    assert process_node.update.call_count == 2
+    assert runtime.node_cache_dict == {}
+
+
+def test_graph_runtime_policy_cache_source_nodes():
+    source_node = Mock()
+    source_node.update.return_value = ('src-img', {'source': 1})
+    source_node.get_setting_dict.return_value = {'seed': 1}
+
+    nodes = ['1:SourceNode']
+    conn_dict = OrderedDict([('1:SourceNode', [])])
+    editor = FakeEditor(nodes, conn_dict, {'SourceNode': source_node})
+
+    runtime = GraphRuntime(cache_enabled=True, cache_source_nodes=True)
+    runtime.step(editor, mode_async=False)
+    runtime.step(editor, mode_async=False)
+
+    assert source_node.update.call_count == 1
+    assert '1:SourceNode' in runtime.node_cache_dict

--- a/tests/unit/test_runtime_controller.py
+++ b/tests/unit/test_runtime_controller.py
@@ -1,0 +1,63 @@
+from unittest.mock import Mock
+
+from node_editor import runtime_controller
+
+
+def test_async_runtime_worker_continues_after_step_exception():
+    node_editor = Mock()
+    node_editor.get_terminate_flag.side_effect = [False, False, True]
+
+    runtime = Mock()
+    runtime.step.side_effect = [RuntimeError('boom'), None]
+
+    runtime_controller.async_runtime_worker(node_editor, runtime)
+
+    assert runtime.step.call_count == 2
+
+
+def test_run_editor_main_loop_async_mode(monkeypatch):
+    fake_loop = Mock()
+    fake_asyncio = Mock()
+    fake_asyncio.get_event_loop.return_value = fake_loop
+    fake_dpg = Mock()
+
+    monkeypatch.setattr(runtime_controller, 'asyncio', fake_asyncio)
+    monkeypatch.setattr(runtime_controller, 'dpg', fake_dpg)
+
+    node_editor = Mock()
+    runtime = Mock()
+
+    event_loop = runtime_controller.run_editor_main_loop(
+        node_editor,
+        runtime,
+        unuse_async_draw=False,
+    )
+
+    fake_loop.run_in_executor.assert_called_once_with(
+        None,
+        runtime_controller.async_runtime_worker,
+        node_editor,
+        runtime,
+    )
+    fake_dpg.start_dearpygui.assert_called_once()
+    assert event_loop is fake_loop
+
+
+def test_run_editor_main_loop_sync_mode(monkeypatch):
+    fake_dpg = Mock()
+    fake_dpg.is_dearpygui_running.side_effect = [True, True, False]
+    monkeypatch.setattr(runtime_controller, 'dpg', fake_dpg)
+
+    node_editor = Mock()
+    runtime = Mock()
+
+    event_loop = runtime_controller.run_editor_main_loop(
+        node_editor,
+        runtime,
+        unuse_async_draw=True,
+    )
+
+    assert event_loop is None
+    assert runtime.step.call_count == 2
+    runtime.step.assert_called_with(node_editor, mode_async=False)
+    assert fake_dpg.render_dearpygui_frame.call_count == 2

--- a/tests/unit/test_update_node_info.py
+++ b/tests/unit/test_update_node_info.py
@@ -353,3 +353,47 @@ def test_update_node_info_skips_inactive_nodes_during_tick():
     update_node_info(editor, image_dict, result_dict, mode_async=False)
 
     node.update.assert_not_called()
+
+
+def test_update_node_info_can_disable_cache_via_policy_switch():
+    source_node = Mock()
+    source_node.update.return_value = ('src-img', {'source': 1})
+
+    process_node = Mock()
+    process_node.update.return_value = ('img1', {'v': 1})
+    process_node.get_setting_dict.return_value = {'alpha': 0.5}
+
+    nodes = ['1:SourceNode', '2:TestNode']
+    conn_dict = OrderedDict([
+        ('1:SourceNode', []),
+        ('2:TestNode', [['1:SourceNode:image:Output01', '2:TestNode:image:Input01']]),
+    ])
+    editor = FakeEditor(
+        nodes,
+        conn_dict,
+        {'SourceNode': source_node, 'TestNode': process_node},
+    )
+
+    image_dict = {}
+    result_dict = {}
+    cache_dict = {}
+
+    update_node_info(
+        editor,
+        image_dict,
+        result_dict,
+        node_cache_dict=cache_dict,
+        mode_async=False,
+        cache_enabled=False,
+    )
+    update_node_info(
+        editor,
+        image_dict,
+        result_dict,
+        node_cache_dict=cache_dict,
+        mode_async=False,
+        cache_enabled=False,
+    )
+
+    assert process_node.update.call_count == 2
+    assert cache_dict == {}

--- a/tests/unit/test_update_node_info.py
+++ b/tests/unit/test_update_node_info.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 # Local application imports
-from main import update_node_info
+from node_editor.graph_runtime import update_node_info
 
 
 class FakeEditor:


### PR DESCRIPTION
### Motivation

- Separate runtime/update/caching orchestration out of `main.py` to improve maintainability and enable future graph/UX features. 
- Provide a clear execution plan for phased work via a new `docs/ROADMAP_EXECUTION_PLAN.md` file.

### Description

- Move all node traversal, cache-signature generation, cache hit/miss logic, stale-data cleanup, and update exception handling into a new `node_editor/graph_runtime.py` module and introduce the `GraphRuntime` class with a `step()` method. 
- Update `main.py` to instantiate `GraphRuntime`, pass it into the async worker, and call `runtime.step(...)` in both async and sync loops, and remove the inlined orchestration helpers from `main.py`.
- Add unit tests for the runtime in `tests/unit/test_graph_runtime.py` and update `tests/unit/test_update_node_info.py` to import `update_node_info` from the new module. 
- Add a high-level `docs/ROADMAP_EXECUTION_PLAN.md` that outlines product and engineering goals, phased work (runtime, UX, nodes, animation, ML tuning), and an execution/backlog template.

### Testing

- Added `tests/unit/test_graph_runtime.py` which exercises persistence and cache-hit behavior across `GraphRuntime.step()` calls and `tests/unit/test_update_node_info.py` updated to import the function from the new module; these unit tests were run with `pytest` and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b728a96f888323879b02648d329bd5)