### PR TITLE
Add Warmth & Tint process node (LAB-based white-balance control)

### DIFF
--- a/node/process_node/node_warmth_tint.py
+++ b/node/process_node/node_warmth_tint.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import cv2
+import numpy as np
+
+from node.base.declarative_node_base import DeclarativeImageProcessNodeBase
+
+
+def image_process(image, warmth, tint):
+    if image is None or image.ndim != 3 or image.shape[2] < 3:
+        return image
+
+    bgr_image = image[:, :, :3]
+    alpha_channel = image[:, :, 3] if image.shape[2] == 4 else None
+
+    lab_image = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2LAB)
+    lab_image = lab_image.astype(np.int16)
+
+    lab_image[:, :, 1] = np.clip(lab_image[:, :, 1] + int(tint), 0, 255)
+    lab_image[:, :, 2] = np.clip(lab_image[:, :, 2] + int(warmth), 0, 255)
+
+    balanced_bgr = cv2.cvtColor(lab_image.astype(np.uint8), cv2.COLOR_LAB2BGR)
+
+    if alpha_channel is not None:
+        return cv2.merge(
+            (
+                balanced_bgr[:, :, 0],
+                balanced_bgr[:, :, 1],
+                balanced_bgr[:, :, 2],
+                alpha_channel,
+            )
+        )
+
+    return balanced_bgr
+
+
+class Node(DeclarativeImageProcessNodeBase):
+    _ver = '0.0.1'
+
+    node_label = 'Warmth & Tint'
+    node_tag = 'WarmthTint'
+
+    parameters = [
+        {
+            'name': 'warmth',
+            'type': DeclarativeImageProcessNodeBase.TYPE_INT,
+            'port': 'Input02',
+            'widget': 'slider_int',
+            'label': 'warmth',
+            'default': 0,
+            'min': -100,
+            'max': 100,
+            'cast': int,
+        },
+        {
+            'name': 'tint',
+            'type': DeclarativeImageProcessNodeBase.TYPE_INT,
+            'port': 'Input03',
+            'widget': 'slider_int',
+            'label': 'tint',
+            'default': 0,
+            'min': -100,
+            'max': 100,
+            'cast': int,
+        },
+    ]
+
+    def process(self, frame, **parameter_values):
+        warmth = parameter_values['warmth']
+        tint = parameter_values['tint']
+        frame = image_process(frame, warmth, tint)
+        return frame, None

--- a/tests/unit/test_declarative_process_nodes.py
+++ b/tests/unit/test_declarative_process_nodes.py
@@ -15,6 +15,7 @@ import node.process_node.node_simple_filter as simple_filter_module
 import node.process_node.node_curves as curves_module
 import node.process_node.node_omnidirectional_viewer as omni_module
 import node.process_node.node_hue_rotation as hue_rotation_module
+import node.process_node.node_warmth_tint as warmth_tint_module
 
 BlurNode = blur_module.Node
 BrightnessNode = brightness_module.Node
@@ -29,6 +30,7 @@ SimpleFilterNode = simple_filter_module.Node
 CurvesNode = curves_module.Node
 OmniNode = omni_module.Node
 HueRotationNode = hue_rotation_module.Node
+WarmthTintNode = warmth_tint_module.Node
 
 
 class DpgStub:
@@ -665,3 +667,111 @@ def test_hue_rotation_node_luv_and_rgb_modes(monkeypatch):
     assert calls['rgb'] == 1
     assert out_luv.shape == bgr_pixel.shape
     assert out_rgb.shape == bgr_pixel.shape
+
+
+def test_warmth_tint_node_get_set_settings(monkeypatch):
+    node = WarmthTintNode()
+
+    values = {
+        '101:WarmthTint:Int:Input02Value': 15,
+        '101:WarmthTint:Int:Input03Value': -12,
+    }
+    writes = {}
+
+    monkeypatch.setattr(base_module, 'dpg_get_value', lambda tag: values.get(tag))
+    monkeypatch.setattr(base_module, 'dpg_set_value', lambda tag, value: writes.setdefault(tag, value))
+    monkeypatch.setattr(base_module, 'dpg', DpgStub())
+
+    setting = node.get_setting_dict(101)
+
+    assert setting['ver'] == node._ver
+    assert setting['pos'] == [10, 20]
+    assert setting['101:WarmthTint:Int:Input02Value'] == 15
+    assert setting['101:WarmthTint:Int:Input03Value'] == -12
+
+    node.set_setting_dict(101, {
+        '101:WarmthTint:Int:Input02Value': 24,
+        '101:WarmthTint:Int:Input03Value': -18,
+    })
+
+    assert writes['101:WarmthTint:Int:Input02Value'] == 24
+    assert writes['101:WarmthTint:Int:Input03Value'] == -18
+
+
+def test_warmth_tint_node_process_adjusts_lab_and_preserves_alpha(monkeypatch):
+    node = WarmthTintNode()
+
+    monkeypatch.setattr(warmth_tint_module.cv2, 'COLOR_BGR2LAB', 11, raising=False)
+    monkeypatch.setattr(warmth_tint_module.cv2, 'COLOR_LAB2BGR', 12, raising=False)
+
+    calls = []
+
+    def _cvt_color_stub(image, code):
+        calls.append(code)
+        if code == warmth_tint_module.cv2.COLOR_BGR2LAB:
+            lab = np.zeros_like(image)
+            lab[:, :, 0] = 40
+            lab[:, :, 1] = 128
+            lab[:, :, 2] = 128
+            return lab
+
+        out = np.zeros_like(image)
+        out[:, :, 0] = image[:, :, 2]
+        out[:, :, 1] = image[:, :, 1]
+        out[:, :, 2] = image[:, :, 0]
+        return out
+
+    monkeypatch.setattr(warmth_tint_module.cv2, 'cvtColor', _cvt_color_stub, raising=False)
+    monkeypatch.setattr(warmth_tint_module.cv2, 'merge', lambda channels: np.stack(channels, axis=-1), raising=False)
+
+    bgr_pixel = np.array([[[10, 20, 30]]], dtype=np.uint8)
+    out_bgr, result = node.process(bgr_pixel, warmth=25, tint=-15)
+
+    assert result is None
+    assert calls == [11, 12]
+    assert out_bgr.shape == bgr_pixel.shape
+    assert out_bgr[0, 0, 0] == 153
+    assert out_bgr[0, 0, 1] == 113
+    assert out_bgr[0, 0, 2] == 40
+
+    bgra_pixel = np.array([[[10, 20, 30, 99]]], dtype=np.uint8)
+    out_bgra, _ = node.process(bgra_pixel, warmth=25, tint=-15)
+
+    assert out_bgra.shape == bgra_pixel.shape
+    assert out_bgra[0, 0, 3] == 99
+
+
+def test_warmth_tint_node_update_clamps_linked_values(monkeypatch):
+    node = WarmthTintNode()
+    _prepare_node(node)
+
+    values = {
+        '201:IntValue:Int:Output01Value': 130,
+        '202:IntValue:Int:Output01Value': -150,
+        '301:WarmthTint:Int:Input02Value': 0,
+        '301:WarmthTint:Int:Input03Value': 0,
+    }
+    writes = {}
+
+    monkeypatch.setattr(base_module, 'dpg_get_value', lambda tag: values.get(tag))
+    monkeypatch.setattr(base_module, 'dpg_set_value', lambda tag, value: writes.setdefault(tag, value))
+    monkeypatch.setattr(base_module, 'convert_cv_to_dpg', lambda frame, w, h: frame)
+    monkeypatch.setattr(warmth_tint_module, 'image_process', lambda frame, warmth, tint: frame)
+
+    frame = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    out_frame, result = node.update(
+        301,
+        [
+            ['1:ImageSource:Image:Output01', '301:WarmthTint:Image:Input01'],
+            ['201:IntValue:Int:Output01', '301:WarmthTint:Int:Input02'],
+            ['202:IntValue:Int:Output01', '301:WarmthTint:Int:Input03'],
+        ],
+        {'1:ImageSource': frame},
+        {},
+    )
+
+    assert result is None
+    assert out_frame.shape == frame.shape
+    assert writes['301:WarmthTint:Int:Input02Value'] == 100
+    assert writes['301:WarmthTint:Int:Input03Value'] == -100


### PR DESCRIPTION
### Motivation
- Provide user controls for adjusting image warmth and tint together as paired white-balance-style sliders, following the repository's declarative process-node pattern.

### Description
- Add a new process node `WarmthTint` implemented at `node/process_node/node_warmth_tint.py` that exposes two integer sliders: `warmth` and `tint` (range `-100..100`).
- Perform adjustments in LAB color space so `tint` modifies the a* axis (green↔magenta) and `warmth` modifies the b* axis (blue↔yellow), then convert back to BGR.
- Preserve alpha channels for BGRA input by leaving the alpha plane untouched and re-merging it after color adjustments.
- Extend `tests/unit/test_declarative_process_nodes.py` to import the new node and add unit tests that cover settings persistence, LAB processing behavior and alpha preservation, and linked-parameter clamping.

### Testing
- Ran `python -m pytest --use-cv2-stub tests/unit/test_declarative_process_nodes.py` and the targeted unit tests passed.
- Ran the full suite with stubbing via `python -m pytest --use-cv2-stub` and all tests passed (`81 passed, 19 skipped`).
- Note: running the tests without the `--use-cv2-stub` flag failed in this environment due to missing system OpenCV dependencies (e.g. `libGL.so.1`), so CI should use the provided stub or have OpenCV system libs installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb6f2500388323ade655c8fa794036)