### PR TITLE
Add Hue/Saturation Adjustment process node

### DIFF
--- a/node/base/declarative_node_base.py
+++ b/node/base/declarative_node_base.py
@@ -250,7 +250,7 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
                     default_value=parameter['default'],
                     min_value=parameter['min'],
                     max_value=parameter['max'],
-                    callback=None,
+                    callback=parameter.get('callback', callback),
                 )
             elif parameter['widget'] == 'slider_float':
                 dpg.add_slider_float(
@@ -260,7 +260,7 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
                     default_value=parameter['default'],
                     min_value=parameter['min'],
                     max_value=parameter['max'],
-                    callback=None,
+                    callback=parameter.get('callback', callback),
                 )
             elif parameter['widget'] == 'input_int':
                 dpg.add_input_int(

--- a/node/process_node/node_hue_saturation_adjustment.py
+++ b/node/process_node/node_hue_saturation_adjustment.py
@@ -33,8 +33,6 @@ def _build_band_weight_lut():
 
 
 _BAND_WEIGHT_LUT = _build_band_weight_lut()
-_HUE_BAND_INDEX_LUT = np.argmax(_BAND_WEIGHT_LUT, axis=1).astype(np.int16)
-
 
 def _active_adjustments(adjustments):
     active = []
@@ -47,7 +45,7 @@ def _active_adjustments(adjustments):
     return active
 
 
-def image_process(image, hue_blend=1.0, **adjustments):
+def image_process(image, blend=1.0, **adjustments):
     if image is None or image.ndim != 3 or image.shape[2] < 3:
         return image
 
@@ -78,18 +76,18 @@ def image_process(image, hue_blend=1.0, **adjustments):
         saturation_delta_by_band[index] = saturation_delta / 100.0
         soft_saturation_scale += band_weight * saturation_delta_by_band[index]
 
-    hue_band_indices = _HUE_BAND_INDEX_LUT[hue_indices]
-    hard_hue_shift = hue_delta_by_band[hue_band_indices]
+    blend = float(np.clip(blend, 0.0, 1.0))
+    sharpness = 1.0 + (1.0 - blend) * 255.0
+    sharpened_weights = np.power(weights, sharpness)
+    sharpened_sum = np.sum(sharpened_weights, axis=2, keepdims=True)
+    sharpened_sum[sharpened_sum == 0.0] = 1.0
+    blend_weights = sharpened_weights / sharpened_sum
 
-    soft_hue_shift = np.zeros_like(hue_channel, dtype=np.float32)
-    for index, _, _ in active_adjustments:
-        soft_hue_shift += weights[:, :, index] * hue_delta_by_band[index]
-
-    hard_saturation_scale = 1.0 + saturation_delta_by_band[hue_band_indices]
-
-    hue_blend = float(np.clip(hue_blend, 0.0, 1.0))
-    hue_shift = (hue_blend * soft_hue_shift) + ((1.0 - hue_blend) * hard_hue_shift)
-    saturation_scale = (hue_blend * soft_saturation_scale) + ((1.0 - hue_blend) * hard_saturation_scale)
+    hue_shift = np.sum(blend_weights * hue_delta_by_band[None, None, :], axis=2)
+    saturation_scale = 1.0 + np.sum(
+        blend_weights * saturation_delta_by_band[None, None, :],
+        axis=2,
+    )
 
     hsv_image[:, :, 0] = np.mod(hue_channel + hue_shift, 180.0)
     hsv_image[:, :, 1] = np.clip(sat_channel * saturation_scale, 0.0, 255.0)
@@ -119,11 +117,11 @@ class Node(DeclarativeImageProcessNodeBase):
 
     parameters = [
         {
-            'name': 'hue_blend',
+            'name': 'blend',
             'type': DeclarativeImageProcessNodeBase.TYPE_FLOAT,
             'port': 'Input02',
             'widget': 'slider_float',
-            'label': 'hue blend',
+            'label': 'blend',
             'default': 1.0,
             'min': 0.0,
             'max': 1.0,

--- a/node/process_node/node_hue_saturation_adjustment.py
+++ b/node/process_node/node_hue_saturation_adjustment.py
@@ -187,6 +187,11 @@ class Node(DeclarativeImageProcessNodeBase):
             )
             dpg.configure_item(slider_tag, callback=self._slider_touched_callback, user_data=node_id)
 
+
+    def _slider_touched_callback(self, sender, app_data, user_data):
+        del app_data
+        self._last_touched_slider_tag_by_node[user_data] = dpg.get_item_alias(sender)
+
     def _nudge_slider(self, sender, app_data, user_data):
         del sender, app_data
         step = int(user_data)

--- a/node/process_node/node_hue_saturation_adjustment.py
+++ b/node/process_node/node_hue_saturation_adjustment.py
@@ -67,14 +67,16 @@ def image_process(image, hue_blend=1.0, **adjustments):
     weights = _BAND_WEIGHT_LUT[hue_indices]
 
     hue_shift = np.zeros_like(hue_channel, dtype=np.float32)
-    saturation_scale = np.ones_like(sat_channel, dtype=np.float32)
+    soft_saturation_scale = np.ones_like(sat_channel, dtype=np.float32)
 
     hue_delta_by_band = np.zeros(len(_BANDS), dtype=np.float32)
+    saturation_delta_by_band = np.zeros(len(_BANDS), dtype=np.float32)
 
     for index, hue_delta_degrees, saturation_delta in active_adjustments:
         band_weight = weights[:, :, index]
         hue_delta_by_band[index] = hue_delta_degrees / 2.0
-        saturation_scale += band_weight * (saturation_delta / 100.0)
+        saturation_delta_by_band[index] = saturation_delta / 100.0
+        soft_saturation_scale += band_weight * saturation_delta_by_band[index]
 
     hue_band_indices = _HUE_BAND_INDEX_LUT[hue_indices]
     hard_hue_shift = hue_delta_by_band[hue_band_indices]
@@ -83,8 +85,11 @@ def image_process(image, hue_blend=1.0, **adjustments):
     for index, _, _ in active_adjustments:
         soft_hue_shift += weights[:, :, index] * hue_delta_by_band[index]
 
+    hard_saturation_scale = 1.0 + saturation_delta_by_band[hue_band_indices]
+
     hue_blend = float(np.clip(hue_blend, 0.0, 1.0))
     hue_shift = (hue_blend * soft_hue_shift) + ((1.0 - hue_blend) * hard_hue_shift)
+    saturation_scale = (hue_blend * soft_saturation_scale) + ((1.0 - hue_blend) * hard_saturation_scale)
 
     hsv_image[:, :, 0] = np.mod(hue_channel + hue_shift, 180.0)
     hsv_image[:, :, 1] = np.clip(sat_channel * saturation_scale, 0.0, 255.0)
@@ -180,14 +185,7 @@ class Node(DeclarativeImageProcessNodeBase):
             slider_tag = self._value_tag(
                 self._port_tag(tag_node_name, parameter['type'], parameter['port'])
             )
-            with dpg.item_handler_registry() as handler_id:
-                dpg.add_item_clicked_handler(callback=self._remember_last_slider, user_data=node_id)
-            dpg.bind_item_handler_registry(slider_tag, handler_id)
-
-    def _remember_last_slider(self, sender, app_data, user_data):
-        del sender, app_data
-        active_item = dpg.get_active_item()
-        self._last_touched_slider_tag_by_node[user_data] = dpg.get_item_alias(active_item)
+            dpg.configure_item(slider_tag, callback=self._slider_touched_callback, user_data=node_id)
 
     def _nudge_slider(self, sender, app_data, user_data):
         del sender, app_data

--- a/node/process_node/node_hue_saturation_adjustment.py
+++ b/node/process_node/node_hue_saturation_adjustment.py
@@ -32,6 +32,7 @@ def _build_band_weight_lut():
 
 
 _BAND_WEIGHT_LUT = _build_band_weight_lut()
+_HUE_BAND_INDEX_LUT = np.argmax(_BAND_WEIGHT_LUT, axis=1).astype(np.int16)
 
 
 def _active_adjustments(adjustments):
@@ -67,10 +68,15 @@ def image_process(image, **adjustments):
     hue_shift = np.zeros_like(hue_channel, dtype=np.float32)
     saturation_scale = np.ones_like(sat_channel, dtype=np.float32)
 
+    hue_delta_by_band = np.zeros(len(_BANDS), dtype=np.float32)
+
     for index, hue_delta_degrees, saturation_delta in active_adjustments:
         band_weight = weights[:, :, index]
-        hue_shift += band_weight * (hue_delta_degrees / 2.0)
+        hue_delta_by_band[index] = hue_delta_degrees / 2.0
         saturation_scale += band_weight * (saturation_delta / 100.0)
+
+    hue_band_indices = _HUE_BAND_INDEX_LUT[hue_indices]
+    hue_shift = hue_delta_by_band[hue_band_indices]
 
     hsv_image[:, :, 0] = np.mod(hue_channel + hue_shift, 180.0)
     hsv_image[:, :, 1] = np.clip(sat_channel * saturation_scale, 0.0, 255.0)

--- a/node/process_node/node_hue_saturation_adjustment.py
+++ b/node/process_node/node_hue_saturation_adjustment.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import cv2
+import dearpygui.dearpygui as dpg
 import numpy as np
 
 from node.base.declarative_node_base import DeclarativeImageProcessNodeBase
@@ -46,7 +47,7 @@ def _active_adjustments(adjustments):
     return active
 
 
-def image_process(image, **adjustments):
+def image_process(image, hue_blend=1.0, **adjustments):
     if image is None or image.ndim != 3 or image.shape[2] < 3:
         return image
 
@@ -76,7 +77,14 @@ def image_process(image, **adjustments):
         saturation_scale += band_weight * (saturation_delta / 100.0)
 
     hue_band_indices = _HUE_BAND_INDEX_LUT[hue_indices]
-    hue_shift = hue_delta_by_band[hue_band_indices]
+    hard_hue_shift = hue_delta_by_band[hue_band_indices]
+
+    soft_hue_shift = np.zeros_like(hue_channel, dtype=np.float32)
+    for index, _, _ in active_adjustments:
+        soft_hue_shift += weights[:, :, index] * hue_delta_by_band[index]
+
+    hue_blend = float(np.clip(hue_blend, 0.0, 1.0))
+    hue_shift = (hue_blend * soft_hue_shift) + ((1.0 - hue_blend) * hard_hue_shift)
 
     hsv_image[:, :, 0] = np.mod(hue_channel + hue_shift, 180.0)
     hsv_image[:, :, 1] = np.clip(sat_channel * saturation_scale, 0.0, 255.0)
@@ -97,18 +105,33 @@ def image_process(image, **adjustments):
 
 
 class Node(DeclarativeImageProcessNodeBase):
-    _ver = '0.0.1'
+    _ver = '0.0.2'
 
     node_label = 'Hue/Saturation Adjustment'
     node_tag = 'HueSaturationAdjustment'
 
-    parameters = []
+    _last_touched_slider_tag_by_node = {}
+
+    parameters = [
+        {
+            'name': 'hue_blend',
+            'type': DeclarativeImageProcessNodeBase.TYPE_FLOAT,
+            'port': 'Input02',
+            'widget': 'slider_float',
+            'label': 'hue blend',
+            'default': 1.0,
+            'min': 0.0,
+            'max': 1.0,
+            'cast': float,
+            'precision': 2,
+        },
+    ]
     for index, (band_name, _) in enumerate(_BANDS):
         parameters.extend([
             {
                 'name': f'{band_name}_hue_shift',
                 'type': DeclarativeImageProcessNodeBase.TYPE_INT,
-                'port': f'Input{(index * 2) + 2:02d}',
+                'port': f'Input{(index * 2) + 3:02d}',
                 'widget': 'slider_int',
                 'label': f'{band_name[:3]} hue',
                 'default': 0,
@@ -119,7 +142,7 @@ class Node(DeclarativeImageProcessNodeBase):
             {
                 'name': f'{band_name}_saturation',
                 'type': DeclarativeImageProcessNodeBase.TYPE_INT,
-                'port': f'Input{(index * 2) + 3:02d}',
+                'port': f'Input{(index * 2) + 4:02d}',
                 'widget': 'slider_int',
                 'label': f'{band_name[:3]} sat',
                 'default': 0,
@@ -132,3 +155,61 @@ class Node(DeclarativeImageProcessNodeBase):
     def process(self, frame, **parameter_values):
         frame = image_process(frame, **parameter_values)
         return frame, None
+
+    def build_custom_ui(self, tag_node_name, node_id, width, callback):
+        del callback
+        with dpg.node_attribute(
+            tag=self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input99'),
+            attribute_type=dpg.mvNode_Attr_Static,
+        ):
+            dpg.add_button(
+                label='Reset all',
+                width=width - 80,
+                callback=self._reset_all_callback,
+                user_data=node_id,
+            )
+
+    def on_node_added(self, tag_node_name):
+        node_id = int(tag_node_name.split(':')[0])
+        if not dpg.does_item_exist('_hsa_arrow_keys'):
+            with dpg.handler_registry(tag='_hsa_arrow_keys'):
+                dpg.add_key_press_handler(dpg.mvKey_Left, callback=self._nudge_slider, user_data=-1)
+                dpg.add_key_press_handler(dpg.mvKey_Right, callback=self._nudge_slider, user_data=1)
+
+        for parameter in self.parameters:
+            slider_tag = self._value_tag(
+                self._port_tag(tag_node_name, parameter['type'], parameter['port'])
+            )
+            with dpg.item_handler_registry() as handler_id:
+                dpg.add_item_clicked_handler(callback=self._remember_last_slider, user_data=node_id)
+            dpg.bind_item_handler_registry(slider_tag, handler_id)
+
+    def _remember_last_slider(self, sender, app_data, user_data):
+        del sender, app_data
+        active_item = dpg.get_active_item()
+        self._last_touched_slider_tag_by_node[user_data] = dpg.get_item_alias(active_item)
+
+    def _nudge_slider(self, sender, app_data, user_data):
+        del sender, app_data
+        step = int(user_data)
+        for slider_tag in self._last_touched_slider_tag_by_node.values():
+            if not slider_tag or not dpg.does_item_exist(slider_tag):
+                continue
+            item_conf = dpg.get_item_configuration(slider_tag)
+            current = dpg.get_value(slider_tag)
+            if isinstance(current, float):
+                next_value = round(current + (0.01 * step), 2)
+            else:
+                next_value = int(current) + step
+            min_value = item_conf.get('min_value', next_value)
+            max_value = item_conf.get('max_value', next_value)
+            dpg.set_value(slider_tag, max(min_value, min(max_value, next_value)))
+
+    def _reset_all_callback(self, sender, app_data, user_data):
+        del sender, app_data
+        tag_node_name = self._node_name(user_data)
+        for parameter in self.parameters:
+            parameter_value_tag = self._value_tag(
+                self._port_tag(tag_node_name, parameter['type'], parameter['port'])
+            )
+            dpg.set_value(parameter_value_tag, parameter['default'])

--- a/node/process_node/node_hue_saturation_adjustment.py
+++ b/node/process_node/node_hue_saturation_adjustment.py
@@ -33,6 +33,26 @@ def _build_band_weight_lut():
 
 
 _BAND_WEIGHT_LUT = _build_band_weight_lut()
+_BLEND_WEIGHT_LUT_CACHE = {}
+
+
+def _get_blend_weight_lut(blend):
+    blend = float(np.clip(blend, 0.0, 1.0))
+    key = int(round(blend * 200.0))
+    if key in _BLEND_WEIGHT_LUT_CACHE:
+        return _BLEND_WEIGHT_LUT_CACHE[key]
+
+    blend_quantized = key / 200.0
+    hardness = (1.0 - blend_quantized) ** 2
+    gamma = 1.0 + (31.0 * hardness)
+
+    weights = np.power(_BAND_WEIGHT_LUT, gamma)
+    total = np.sum(weights, axis=1, keepdims=True)
+    total[total == 0.0] = 1.0
+    weights = (weights / total).astype(np.float32)
+
+    _BLEND_WEIGHT_LUT_CACHE[key] = weights
+    return weights
 
 def _active_adjustments(adjustments):
     active = []
@@ -64,24 +84,14 @@ def image_process(image, blend=1.0, **adjustments):
     hue_indices = np.clip(hue_channel.astype(np.int16), 0, 179)
     weights = _BAND_WEIGHT_LUT[hue_indices]
 
-    hue_shift = np.zeros_like(hue_channel, dtype=np.float32)
-    soft_saturation_scale = np.ones_like(sat_channel, dtype=np.float32)
-
     hue_delta_by_band = np.zeros(len(_BANDS), dtype=np.float32)
     saturation_delta_by_band = np.zeros(len(_BANDS), dtype=np.float32)
 
     for index, hue_delta_degrees, saturation_delta in active_adjustments:
-        band_weight = weights[:, :, index]
         hue_delta_by_band[index] = hue_delta_degrees / 2.0
         saturation_delta_by_band[index] = saturation_delta / 100.0
-        soft_saturation_scale += band_weight * saturation_delta_by_band[index]
 
-    blend = float(np.clip(blend, 0.0, 1.0))
-    sharpness = 1.0 + (1.0 - blend) * 255.0
-    sharpened_weights = np.power(weights, sharpness)
-    sharpened_sum = np.sum(sharpened_weights, axis=2, keepdims=True)
-    sharpened_sum[sharpened_sum == 0.0] = 1.0
-    blend_weights = sharpened_weights / sharpened_sum
+    blend_weights = _get_blend_weight_lut(blend)[hue_indices]
 
     hue_shift = np.sum(blend_weights * hue_delta_by_band[None, None, :], axis=2)
     saturation_scale = 1.0 + np.sum(

--- a/node/process_node/node_hue_saturation_adjustment.py
+++ b/node/process_node/node_hue_saturation_adjustment.py
@@ -15,28 +15,42 @@ _BANDS = (
     ('magenta', 150.0),
 )
 _BAND_HALF_WIDTH = 30.0
+_BAND_NAME_TO_INDEX = {band_name: index for index, (band_name, _) in enumerate(_BANDS)}
 
 
-def _circular_hue_distance(hue_channel, center):
-    delta = np.abs(hue_channel - center)
-    return np.minimum(delta, 180.0 - delta)
+def _build_band_weight_lut():
+    hue_values = np.arange(180, dtype=np.float32)[:, None]
+    centers = np.array([center for _, center in _BANDS], dtype=np.float32)[None, :]
 
+    delta = np.abs(hue_values - centers)
+    distance = np.minimum(delta, 180.0 - delta)
+    weights = np.clip(1.0 - (distance / _BAND_HALF_WIDTH), 0.0, 1.0)
 
-def _build_band_weights(hue_channel):
-    weights = []
-    for _, center in _BANDS:
-        distance = _circular_hue_distance(hue_channel, center)
-        weight = np.clip(1.0 - (distance / _BAND_HALF_WIDTH), 0.0, 1.0)
-        weights.append(weight)
-
-    weights = np.stack(weights, axis=2)
-    total = np.sum(weights, axis=2, keepdims=True)
+    total = np.sum(weights, axis=1, keepdims=True)
     total[total == 0.0] = 1.0
     return weights / total
 
 
+_BAND_WEIGHT_LUT = _build_band_weight_lut()
+
+
+def _active_adjustments(adjustments):
+    active = []
+    for band_name, index in _BAND_NAME_TO_INDEX.items():
+        hue_delta_degrees = float(adjustments.get(f'{band_name}_hue_shift', 0))
+        saturation_delta = float(adjustments.get(f'{band_name}_saturation', 0))
+        if hue_delta_degrees == 0.0 and saturation_delta == 0.0:
+            continue
+        active.append((index, hue_delta_degrees, saturation_delta))
+    return active
+
+
 def image_process(image, **adjustments):
     if image is None or image.ndim != 3 or image.shape[2] < 3:
+        return image
+
+    active_adjustments = _active_adjustments(adjustments)
+    if not active_adjustments:
         return image
 
     bgr_image = image[:, :, :3]
@@ -47,17 +61,16 @@ def image_process(image, **adjustments):
     hue_channel = hsv_image[:, :, 0]
     sat_channel = hsv_image[:, :, 1]
 
-    weights = _build_band_weights(hue_channel)
+    hue_indices = np.clip(hue_channel.astype(np.int16), 0, 179)
+    weights = _BAND_WEIGHT_LUT[hue_indices]
 
     hue_shift = np.zeros_like(hue_channel, dtype=np.float32)
     saturation_scale = np.ones_like(sat_channel, dtype=np.float32)
 
-    for index, (band_name, _) in enumerate(_BANDS):
-        hue_delta_degrees = float(adjustments.get(f'{band_name}_hue_shift', 0))
-        saturation_delta = float(adjustments.get(f'{band_name}_saturation', 0))
-
-        hue_shift += weights[:, :, index] * (hue_delta_degrees / 2.0)
-        saturation_scale += weights[:, :, index] * (saturation_delta / 100.0)
+    for index, hue_delta_degrees, saturation_delta in active_adjustments:
+        band_weight = weights[:, :, index]
+        hue_shift += band_weight * (hue_delta_degrees / 2.0)
+        saturation_scale += band_weight * (saturation_delta / 100.0)
 
     hsv_image[:, :, 0] = np.mod(hue_channel + hue_shift, 180.0)
     hsv_image[:, :, 1] = np.clip(sat_channel * saturation_scale, 0.0, 255.0)

--- a/node/process_node/node_hue_saturation_adjustment.py
+++ b/node/process_node/node_hue_saturation_adjustment.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import cv2
+import numpy as np
+
+from node.base.declarative_node_base import DeclarativeImageProcessNodeBase
+
+
+_BANDS = (
+    ('red', 0.0),
+    ('yellow', 30.0),
+    ('green', 60.0),
+    ('cyan', 90.0),
+    ('blue', 120.0),
+    ('magenta', 150.0),
+)
+_BAND_HALF_WIDTH = 30.0
+
+
+def _circular_hue_distance(hue_channel, center):
+    delta = np.abs(hue_channel - center)
+    return np.minimum(delta, 180.0 - delta)
+
+
+def _build_band_weights(hue_channel):
+    weights = []
+    for _, center in _BANDS:
+        distance = _circular_hue_distance(hue_channel, center)
+        weight = np.clip(1.0 - (distance / _BAND_HALF_WIDTH), 0.0, 1.0)
+        weights.append(weight)
+
+    weights = np.stack(weights, axis=2)
+    total = np.sum(weights, axis=2, keepdims=True)
+    total[total == 0.0] = 1.0
+    return weights / total
+
+
+def image_process(image, **adjustments):
+    if image is None or image.ndim != 3 or image.shape[2] < 3:
+        return image
+
+    bgr_image = image[:, :, :3]
+    alpha_channel = image[:, :, 3] if image.shape[2] == 4 else None
+
+    hsv_image = cv2.cvtColor(bgr_image, cv2.COLOR_BGR2HSV).astype(np.float32)
+
+    hue_channel = hsv_image[:, :, 0]
+    sat_channel = hsv_image[:, :, 1]
+
+    weights = _build_band_weights(hue_channel)
+
+    hue_shift = np.zeros_like(hue_channel, dtype=np.float32)
+    saturation_scale = np.ones_like(sat_channel, dtype=np.float32)
+
+    for index, (band_name, _) in enumerate(_BANDS):
+        hue_delta_degrees = float(adjustments.get(f'{band_name}_hue_shift', 0))
+        saturation_delta = float(adjustments.get(f'{band_name}_saturation', 0))
+
+        hue_shift += weights[:, :, index] * (hue_delta_degrees / 2.0)
+        saturation_scale += weights[:, :, index] * (saturation_delta / 100.0)
+
+    hsv_image[:, :, 0] = np.mod(hue_channel + hue_shift, 180.0)
+    hsv_image[:, :, 1] = np.clip(sat_channel * saturation_scale, 0.0, 255.0)
+
+    adjusted_bgr = cv2.cvtColor(hsv_image.astype(np.uint8), cv2.COLOR_HSV2BGR)
+
+    if alpha_channel is not None:
+        return cv2.merge(
+            (
+                adjusted_bgr[:, :, 0],
+                adjusted_bgr[:, :, 1],
+                adjusted_bgr[:, :, 2],
+                alpha_channel,
+            )
+        )
+
+    return adjusted_bgr
+
+
+class Node(DeclarativeImageProcessNodeBase):
+    _ver = '0.0.1'
+
+    node_label = 'Hue/Saturation Adjustment'
+    node_tag = 'HueSaturationAdjustment'
+
+    parameters = []
+    for index, (band_name, _) in enumerate(_BANDS):
+        parameters.extend([
+            {
+                'name': f'{band_name}_hue_shift',
+                'type': DeclarativeImageProcessNodeBase.TYPE_INT,
+                'port': f'Input{(index * 2) + 2:02d}',
+                'widget': 'slider_int',
+                'label': f'{band_name[:3]} hue',
+                'default': 0,
+                'min': -180,
+                'max': 180,
+                'cast': int,
+            },
+            {
+                'name': f'{band_name}_saturation',
+                'type': DeclarativeImageProcessNodeBase.TYPE_INT,
+                'port': f'Input{(index * 2) + 3:02d}',
+                'widget': 'slider_int',
+                'label': f'{band_name[:3]} sat',
+                'default': 0,
+                'min': -100,
+                'max': 100,
+                'cast': int,
+            },
+        ])
+
+    def process(self, frame, **parameter_values):
+        frame = image_process(frame, **parameter_values)
+        return frame, None

--- a/tests/unit/test_declarative_process_nodes.py
+++ b/tests/unit/test_declarative_process_nodes.py
@@ -752,6 +752,56 @@ def test_hue_saturation_adjustment_process_targets_band_and_preserves_alpha(monk
     assert out_bgra[0, 0, 3] == 77
 
 
+
+
+def test_hue_saturation_adjustment_process_skips_when_all_zero(monkeypatch):
+    node = HueSaturationAdjustmentNode()
+
+    called = {'cvt': 0}
+
+    def _cvt_color_stub(image, code):
+        called['cvt'] += 1
+        return image
+
+    monkeypatch.setattr(hue_saturation_adjustment_module.cv2, 'cvtColor', _cvt_color_stub, raising=False)
+
+    params = {parameter['name']: 0 for parameter in node.parameters}
+    bgr_image = np.array([[[1, 2, 3], [4, 5, 6]]], dtype=np.uint8)
+
+    out, result = node.process(bgr_image, **params)
+
+    assert result is None
+    assert called['cvt'] == 0
+    assert out is bgr_image
+
+
+def test_hue_saturation_adjustment_uses_only_active_band_weights(monkeypatch):
+    node = HueSaturationAdjustmentNode()
+
+    monkeypatch.setattr(hue_saturation_adjustment_module.cv2, 'COLOR_BGR2HSV', 21, raising=False)
+    monkeypatch.setattr(hue_saturation_adjustment_module.cv2, 'COLOR_HSV2BGR', 22, raising=False)
+
+    def _cvt_color_stub(image, code):
+        if code == hue_saturation_adjustment_module.cv2.COLOR_BGR2HSV:
+            hsv = np.zeros_like(image)
+            hsv[:, :, 0] = 0
+            hsv[:, :, 1] = 100
+            hsv[:, :, 2] = 200
+            return hsv
+        return image
+
+    monkeypatch.setattr(hue_saturation_adjustment_module.cv2, 'cvtColor', _cvt_color_stub, raising=False)
+
+    params = {parameter['name']: 0 for parameter in node.parameters}
+    params['red_hue_shift'] = 60
+
+    out, _ = node.process(np.array([[[8, 9, 10]]], dtype=np.uint8), **params)
+
+    assert out[0, 0, 0] == 30
+    assert out[0, 0, 1] == 100
+    assert out[0, 0, 2] == 200
+
+
 def test_hue_saturation_adjustment_update_clamps_linked_values(monkeypatch):
     node = HueSaturationAdjustmentNode()
     _prepare_node(node)

--- a/tests/unit/test_declarative_process_nodes.py
+++ b/tests/unit/test_declarative_process_nodes.py
@@ -802,6 +802,34 @@ def test_hue_saturation_adjustment_uses_only_active_band_weights(monkeypatch):
     assert out[0, 0, 2] == 200
 
 
+
+
+def test_hue_saturation_adjustment_hue_uses_single_band_without_neighbor_bleed(monkeypatch):
+    node = HueSaturationAdjustmentNode()
+
+    monkeypatch.setattr(hue_saturation_adjustment_module.cv2, 'COLOR_BGR2HSV', 21, raising=False)
+    monkeypatch.setattr(hue_saturation_adjustment_module.cv2, 'COLOR_HSV2BGR', 22, raising=False)
+
+    def _cvt_color_stub(image, code):
+        if code == hue_saturation_adjustment_module.cv2.COLOR_BGR2HSV:
+            hsv = np.zeros_like(image)
+            hsv[:, :, 0] = 0
+            hsv[:, :, 1] = 180
+            hsv[:, :, 2] = 200
+            return hsv
+        return image
+
+    monkeypatch.setattr(hue_saturation_adjustment_module.cv2, 'cvtColor', _cvt_color_stub, raising=False)
+
+    params = {parameter['name']: 0 for parameter in node.parameters}
+    params['yellow_hue_shift'] = 120
+    params['magenta_hue_shift'] = -120
+
+    out, _ = node.process(np.array([[[3, 4, 5]]], dtype=np.uint8), **params)
+
+    assert out[0, 0, 0] == 0
+    assert out[0, 0, 1] == 180
+    assert out[0, 0, 2] == 200
 def test_hue_saturation_adjustment_update_clamps_linked_values(monkeypatch):
     node = HueSaturationAdjustmentNode()
     _prepare_node(node)

--- a/tests/unit/test_declarative_process_nodes.py
+++ b/tests/unit/test_declarative_process_nodes.py
@@ -15,6 +15,7 @@ import node.process_node.node_simple_filter as simple_filter_module
 import node.process_node.node_curves as curves_module
 import node.process_node.node_omnidirectional_viewer as omni_module
 import node.process_node.node_hue_rotation as hue_rotation_module
+import node.process_node.node_hue_saturation_adjustment as hue_saturation_adjustment_module
 import node.process_node.node_warmth_tint as warmth_tint_module
 
 BlurNode = blur_module.Node
@@ -30,6 +31,7 @@ SimpleFilterNode = simple_filter_module.Node
 CurvesNode = curves_module.Node
 OmniNode = omni_module.Node
 HueRotationNode = hue_rotation_module.Node
+HueSaturationAdjustmentNode = hue_saturation_adjustment_module.Node
 WarmthTintNode = warmth_tint_module.Node
 
 
@@ -667,6 +669,123 @@ def test_hue_rotation_node_luv_and_rgb_modes(monkeypatch):
     assert calls['rgb'] == 1
     assert out_luv.shape == bgr_pixel.shape
     assert out_rgb.shape == bgr_pixel.shape
+
+
+def test_hue_saturation_adjustment_node_get_set_settings(monkeypatch):
+    node = HueSaturationAdjustmentNode()
+
+    values = {
+        '111:HueSaturationAdjustment:Int:Input02Value': 45,
+        '111:HueSaturationAdjustment:Int:Input03Value': 20,
+        '111:HueSaturationAdjustment:Int:Input04Value': -30,
+        '111:HueSaturationAdjustment:Int:Input05Value': 10,
+        '111:HueSaturationAdjustment:Int:Input06Value': 0,
+        '111:HueSaturationAdjustment:Int:Input07Value': 0,
+        '111:HueSaturationAdjustment:Int:Input08Value': 0,
+        '111:HueSaturationAdjustment:Int:Input09Value': 0,
+        '111:HueSaturationAdjustment:Int:Input10Value': 0,
+        '111:HueSaturationAdjustment:Int:Input11Value': 0,
+        '111:HueSaturationAdjustment:Int:Input12Value': 0,
+        '111:HueSaturationAdjustment:Int:Input13Value': 0,
+    }
+    writes = {}
+
+    monkeypatch.setattr(base_module, 'dpg_get_value', lambda tag: values.get(tag))
+    monkeypatch.setattr(base_module, 'dpg_set_value', lambda tag, value: writes.setdefault(tag, value))
+    monkeypatch.setattr(base_module, 'dpg', DpgStub())
+
+    setting = node.get_setting_dict(111)
+
+    assert setting['ver'] == node._ver
+    assert setting['pos'] == [10, 20]
+    assert setting['111:HueSaturationAdjustment:Int:Input02Value'] == 45
+    assert setting['111:HueSaturationAdjustment:Int:Input03Value'] == 20
+
+    node.set_setting_dict(111, {
+        '111:HueSaturationAdjustment:Int:Input02Value': -60,
+        '111:HueSaturationAdjustment:Int:Input03Value': -40,
+        '111:HueSaturationAdjustment:Int:Input12Value': 75,
+        '111:HueSaturationAdjustment:Int:Input13Value': 55,
+    })
+
+    assert writes['111:HueSaturationAdjustment:Int:Input02Value'] == -60
+    assert writes['111:HueSaturationAdjustment:Int:Input03Value'] == -40
+    assert writes['111:HueSaturationAdjustment:Int:Input12Value'] == 75
+    assert writes['111:HueSaturationAdjustment:Int:Input13Value'] == 55
+
+
+def test_hue_saturation_adjustment_process_targets_band_and_preserves_alpha(monkeypatch):
+    node = HueSaturationAdjustmentNode()
+
+    monkeypatch.setattr(hue_saturation_adjustment_module.cv2, 'COLOR_BGR2HSV', 21, raising=False)
+    monkeypatch.setattr(hue_saturation_adjustment_module.cv2, 'COLOR_HSV2BGR', 22, raising=False)
+
+    def _cvt_color_stub(image, code):
+        if code == hue_saturation_adjustment_module.cv2.COLOR_BGR2HSV:
+            hsv = np.zeros_like(image)
+            hsv[:, :, 0] = 0
+            hsv[:, :, 1] = 100
+            hsv[:, :, 2] = 200
+            return hsv
+        return image
+
+    monkeypatch.setattr(hue_saturation_adjustment_module.cv2, 'cvtColor', _cvt_color_stub, raising=False)
+    monkeypatch.setattr(hue_saturation_adjustment_module.cv2, 'merge', lambda channels: np.stack(channels, axis=-1), raising=False)
+
+    params = {parameter['name']: 0 for parameter in node.parameters}
+    params['red_hue_shift'] = 60
+    params['red_saturation'] = 50
+
+    bgr_pixel = np.array([[[10, 20, 30]]], dtype=np.uint8)
+    out_bgr, result = node.process(bgr_pixel, **params)
+
+    assert result is None
+    assert out_bgr.shape == bgr_pixel.shape
+    assert out_bgr[0, 0, 0] == 30
+    assert out_bgr[0, 0, 1] == 150
+    assert out_bgr[0, 0, 2] == 200
+
+    bgra_pixel = np.array([[[10, 20, 30, 77]]], dtype=np.uint8)
+    out_bgra, _ = node.process(bgra_pixel, **params)
+
+    assert out_bgra.shape == bgra_pixel.shape
+    assert out_bgra[0, 0, 3] == 77
+
+
+def test_hue_saturation_adjustment_update_clamps_linked_values(monkeypatch):
+    node = HueSaturationAdjustmentNode()
+    _prepare_node(node)
+
+    values = {
+        '501:IntValue:Int:Output01Value': 999,
+        '502:IntValue:Int:Output01Value': -180,
+        '601:HueSaturationAdjustment:Int:Input02Value': 0,
+        '601:HueSaturationAdjustment:Int:Input03Value': 0,
+    }
+    writes = {}
+
+    monkeypatch.setattr(base_module, 'dpg_get_value', lambda tag: values.get(tag))
+    monkeypatch.setattr(base_module, 'dpg_set_value', lambda tag, value: writes.setdefault(tag, value))
+    monkeypatch.setattr(base_module, 'convert_cv_to_dpg', lambda frame, w, h: frame)
+    monkeypatch.setattr(hue_saturation_adjustment_module, 'image_process', lambda frame, **kwargs: frame)
+
+    frame = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    out_frame, result = node.update(
+        601,
+        [
+            ['1:ImageSource:Image:Output01', '601:HueSaturationAdjustment:Image:Input01'],
+            ['501:IntValue:Int:Output01', '601:HueSaturationAdjustment:Int:Input02'],
+            ['502:IntValue:Int:Output01', '601:HueSaturationAdjustment:Int:Input03'],
+        ],
+        {'1:ImageSource': frame},
+        {},
+    )
+
+    assert result is None
+    assert out_frame.shape == frame.shape
+    assert writes['601:HueSaturationAdjustment:Int:Input02Value'] == 180
+    assert writes['601:HueSaturationAdjustment:Int:Input03Value'] == -100
 
 
 def test_warmth_tint_node_get_set_settings(monkeypatch):

--- a/tests/unit/test_declarative_process_nodes.py
+++ b/tests/unit/test_declarative_process_nodes.py
@@ -675,9 +675,9 @@ def test_hue_saturation_adjustment_node_get_set_settings(monkeypatch):
     node = HueSaturationAdjustmentNode()
 
     values = {
-        '111:HueSaturationAdjustment:Int:Input02Value': 45,
-        '111:HueSaturationAdjustment:Int:Input03Value': 20,
-        '111:HueSaturationAdjustment:Int:Input04Value': -30,
+        '111:HueSaturationAdjustment:Float:Input02Value': 1.0,
+        '111:HueSaturationAdjustment:Int:Input03Value': 45,
+        '111:HueSaturationAdjustment:Int:Input04Value': 20,
         '111:HueSaturationAdjustment:Int:Input05Value': 10,
         '111:HueSaturationAdjustment:Int:Input06Value': 0,
         '111:HueSaturationAdjustment:Int:Input07Value': 0,
@@ -698,18 +698,18 @@ def test_hue_saturation_adjustment_node_get_set_settings(monkeypatch):
 
     assert setting['ver'] == node._ver
     assert setting['pos'] == [10, 20]
-    assert setting['111:HueSaturationAdjustment:Int:Input02Value'] == 45
-    assert setting['111:HueSaturationAdjustment:Int:Input03Value'] == 20
+    assert setting['111:HueSaturationAdjustment:Float:Input02Value'] == 1.0
+    assert setting['111:HueSaturationAdjustment:Int:Input03Value'] == 45
 
     node.set_setting_dict(111, {
-        '111:HueSaturationAdjustment:Int:Input02Value': -60,
-        '111:HueSaturationAdjustment:Int:Input03Value': -40,
+        '111:HueSaturationAdjustment:Float:Input02Value': 0.0,
+        '111:HueSaturationAdjustment:Int:Input03Value': -60,
         '111:HueSaturationAdjustment:Int:Input12Value': 75,
         '111:HueSaturationAdjustment:Int:Input13Value': 55,
     })
 
-    assert writes['111:HueSaturationAdjustment:Int:Input02Value'] == -60
-    assert writes['111:HueSaturationAdjustment:Int:Input03Value'] == -40
+    assert writes['111:HueSaturationAdjustment:Float:Input02Value'] == 0.0
+    assert writes['111:HueSaturationAdjustment:Int:Input03Value'] == -60
     assert writes['111:HueSaturationAdjustment:Int:Input12Value'] == 75
     assert writes['111:HueSaturationAdjustment:Int:Input13Value'] == 55
 
@@ -837,7 +837,7 @@ def test_hue_saturation_adjustment_update_clamps_linked_values(monkeypatch):
     values = {
         '501:IntValue:Int:Output01Value': 999,
         '502:IntValue:Int:Output01Value': -180,
-        '601:HueSaturationAdjustment:Int:Input02Value': 0,
+        '601:HueSaturationAdjustment:Int:Input04Value': 0,
         '601:HueSaturationAdjustment:Int:Input03Value': 0,
     }
     writes = {}
@@ -853,8 +853,8 @@ def test_hue_saturation_adjustment_update_clamps_linked_values(monkeypatch):
         601,
         [
             ['1:ImageSource:Image:Output01', '601:HueSaturationAdjustment:Image:Input01'],
-            ['501:IntValue:Int:Output01', '601:HueSaturationAdjustment:Int:Input02'],
-            ['502:IntValue:Int:Output01', '601:HueSaturationAdjustment:Int:Input03'],
+            ['501:IntValue:Int:Output01', '601:HueSaturationAdjustment:Int:Input03'],
+            ['502:IntValue:Int:Output01', '601:HueSaturationAdjustment:Int:Input04'],
         ],
         {'1:ImageSource': frame},
         {},
@@ -862,8 +862,8 @@ def test_hue_saturation_adjustment_update_clamps_linked_values(monkeypatch):
 
     assert result is None
     assert out_frame.shape == frame.shape
-    assert writes['601:HueSaturationAdjustment:Int:Input02Value'] == 180
-    assert writes['601:HueSaturationAdjustment:Int:Input03Value'] == -100
+    assert writes['601:HueSaturationAdjustment:Int:Input03Value'] == 180
+    assert writes['601:HueSaturationAdjustment:Int:Input04Value'] == -100
 
 
 def test_warmth_tint_node_get_set_settings(monkeypatch):


### PR DESCRIPTION
### Motivation
- Provide a node to adjust hue and saturation selectively across common color bands so users can tweak tones per-band in pipelines.
- Reuse the existing declarative image-process node pattern to expose per-band sliders and preserve alpha channel behavior.

### Description
- Add a new process node `node/process_node/node_hue_saturation_adjustment.py` that builds six weighted HSV bands (red, yellow, green, cyan, blue, magenta) and applies per-band hue shifts and saturation adjustments using a soft weighting function.
- Expose per-band parameters as sliders (hue shift in degrees and saturation change in percent) via the `DeclarativeImageProcessNodeBase` parameter model so values are automatically cast and clamped.
- Preserve alpha channel when present and perform conversions using `cv2.COLOR_BGR2HSV`/`cv2.COLOR_HSV2BGR`, with hue and saturation conversions aligned with the project’s existing hue representation.
- Integrate the new node into unit tests by importing `node_hue_saturation_adjustment` and adding tests that cover settings persistence, targeted band processing, alpha preservation, and linked-value clamping in `tests/unit/test_declarative_process_nodes.py`.

### Testing
- Running `python -m pytest --use-cv2-stub tests/unit/test_declarative_process_nodes.py` passed and the new node tests were green (single-file run).
- Running `python -m pytest --use-cv2-stub tests/unit` and the full unit suite passed (all unit tests passed with the cv2 stub).
- A bare `python -m pytest` run failed in this environment due to missing `libGL.so.1` when importing the real `cv2`, so the official `--use-cv2-stub` test mode was used for CI-friendly verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69bb74a4af988323ae0bcfe26eef9adb)