### PR TITLE
Improve Video node playback timing, last-frame caching, and resource cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ Read the node settings(json file) output by Export<br>
             A node that reads a video (mp4, avi) and outputs an image for each frame<br>
             Open the file dialog with the "Select Movie" button<br>
             Check "Loop" to play the video in a loop<br>
-            "Skip rate" sets the interval for skipping the output image.
+            "Skip rate" sets the interval for skipping the output image.<br>
+            Check "Natural FPS" to follow source FPS timing, or uncheck to read frames in sequential order.
         </td>
     </tr>
     <tr>
@@ -219,6 +220,20 @@ Read the node settings(json file) output by Export<br>
     </tr>
 </table>
 </details>
+
+## Cache toggle and video cache behavior / キャッシュ切替と動画キャッシュ挙動
+
+**English**
+
+- Declarative process nodes include a `Cache` checkbox. Turn it OFF to disable and clear runtime cache entries for that node on subsequent update ticks.
+- During cache replay, node preview images are still refreshed and elapsed time now reflects cached-render cost.
+- Input video decoding itself is not cached by OpenCV in this app; the current speed depends on `VideoCapture` reads/seeks and downstream processing load.
+
+**日本語**
+
+- 宣言的プロセスノードには `Cache` チェックボックスがあります。OFF にすると、そのノードのランタイムキャッシュは次回更新以降で無効化され、保持済みエントリも削除されます。
+- キャッシュ再生中でもノードのプレビュー画像は更新され、elapsed time はキャッシュ再描画コストを表示します。
+- このアプリでは入力動画のデコード自体を OpenCV 側で明示キャッシュしていないため、実行速度は `VideoCapture` の read/seek と下流処理負荷に依存します。
 
 <details>
 <summary>Process Node</summary>

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ Read the node settings(json file) output by Export<br>
             Open the file dialog with the "Select Movie" button<br>
             Check "Loop" to play the video in a loop<br>
             "Skip rate" sets the interval for skipping the output image.<br>
-            Check "Natural FPS" to follow source FPS timing, or uncheck to read frames in sequential order.
+            Check "Natural FPS" to follow source FPS timing, or uncheck to read frames in sequential order.<br>
+            "Cache Source" enables source-node frame cache for this Video node (OFF by default).
         </td>
     </tr>
     <tr>

--- a/node/base/declarative_node_base.py
+++ b/node/base/declarative_node_base.py
@@ -146,6 +146,19 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
 
         return frame, result
 
+    def render_cached_output(self, node_id, frame):
+        if frame is None:
+            return
+
+        tag_node_name = self._node_name(node_id)
+        output_image_value_tag = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
+        )
+        small_window_w = self._opencv_setting_dict['process_width']
+        small_window_h = self._opencv_setting_dict['process_height']
+        texture = convert_cv_to_dpg(frame, small_window_w, small_window_h)
+        dpg_set_value(output_image_value_tag, texture)
+
     def close(self, node_id):
         del node_id
 

--- a/node/base/declarative_node_base.py
+++ b/node/base/declarative_node_base.py
@@ -17,6 +17,8 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
 
     parameters = []
     show_elapsed_time = True
+    _cache_toggle_setting_key = '__cache_enabled__'
+    _cache_enabled_by_node = {}
 
     def add_node(
         self,
@@ -33,6 +35,8 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
         output_image_value_tag = self._value_tag(output_image_tag)
         elapsed_tag = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
         elapsed_value_tag = self._value_tag(elapsed_tag)
+        cache_toggle_tag = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Cache')
+        cache_toggle_value_tag = self._value_tag(cache_toggle_tag)
 
         self._opencv_setting_dict = opencv_setting_dict
         small_window_w = self._opencv_setting_dict['process_width']
@@ -81,6 +85,19 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
                 small_window_w,
                 callback,
             )
+
+            with dpg.node_attribute(
+                tag=cache_toggle_tag,
+                attribute_type=dpg.mvNode_Attr_Static,
+            ):
+                dpg.add_checkbox(
+                    label='Cache',
+                    tag=cache_toggle_value_tag,
+                    default_value=True,
+                    callback=self._on_cache_toggle,
+                    user_data=node_id,
+                )
+                self._cache_enabled_by_node[str(node_id)] = True
 
             if self.show_elapsed_time and use_pref_counter:
                 with dpg.node_attribute(
@@ -177,6 +194,9 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
             setting_dict[parameter_value_tag] = dpg_get_value(parameter_value_tag)
 
         setting_dict.update(self.get_custom_setting_dict(tag_node_name, node_id))
+        setting_dict[self._cache_toggle_setting_key] = bool(
+            self._cache_enabled_by_node.get(str(node_id), True)
+        )
 
         return setting_dict
 
@@ -193,6 +213,13 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
             dpg_set_value(parameter_value_tag, value)
 
         self.set_custom_setting_dict(tag_node_name, node_id, setting_dict)
+
+        cache_toggle_value_tag = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Cache')
+        )
+        cache_enabled = bool(setting_dict.get(self._cache_toggle_setting_key, True))
+        self._cache_enabled_by_node[str(node_id)] = cache_enabled
+        dpg_set_value(cache_toggle_value_tag, cache_enabled)
 
         self.on_settings_applied(tag_node_name)
 
@@ -211,6 +238,10 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
 
     def on_settings_applied(self, tag_node_name):
         del tag_node_name
+
+    def _on_cache_toggle(self, sender, app_data, user_data):
+        del sender
+        self._cache_enabled_by_node[str(user_data)] = bool(app_data)
 
     def normalize_parameter_values(self, tag_node_name, parameter_values):
         del tag_node_name

--- a/node/base/declarative_node_base.py
+++ b/node/base/declarative_node_base.py
@@ -167,14 +167,22 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
         if frame is None:
             return
 
+        start_time = time.perf_counter()
         tag_node_name = self._node_name(node_id)
         output_image_value_tag = self._value_tag(
             self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
         )
+        elapsed_value_tag = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
+        )
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
+        use_pref_counter = self._opencv_setting_dict['use_pref_counter']
         texture = convert_cv_to_dpg(frame, small_window_w, small_window_h)
         dpg_set_value(output_image_value_tag, texture)
+        if self.show_elapsed_time and use_pref_counter:
+            elapsed_time = int((time.perf_counter() - start_time) * 1000)
+            dpg_set_value(elapsed_value_tag, str(elapsed_time).zfill(4) + 'ms')
 
     def close(self, node_id):
         del node_id

--- a/node/input_node/node_video_input.py
+++ b/node/input_node/node_video_input.py
@@ -48,6 +48,8 @@ class Node(DpgNodeABC):
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
         tag_node_input03_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Input03')
         tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
+        tag_node_input04_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04')
+        tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
         tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
         tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
         tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
@@ -138,6 +140,17 @@ class Node(DpgNodeABC):
                     max_value=self._max_val,
                     callback=None,
                 )
+            # 再生モード
+            with dpg.node_attribute(
+                    tag=tag_node_input04_name,
+                    attribute_type=dpg.mvNode_Attr_Static,
+            ):
+                dpg.add_checkbox(
+                    label='Natural FPS',
+                    tag=tag_node_input04_value_name,
+                    callback=None,
+                    default_value=True,
+                )
             # 処理時間
             if use_pref_counter:
                 with dpg.node_attribute(
@@ -161,6 +174,7 @@ class Node(DpgNodeABC):
         tag_node_name = self._node_name(node_id)
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
         tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
+        tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
         output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
         output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
 
@@ -201,10 +215,12 @@ class Node(DpgNodeABC):
         loop_flag = dpg_get_value(tag_node_input02_value_name)
         # スキップ割合
         skip_rate = int(dpg_get_value(tag_node_input03_value_name))
+        natural_fps_mode = bool(dpg_get_value(tag_node_input04_value_name))
 
         # 計測開始
+        decode_start_time = None
         if video_capture is not None and use_pref_counter:
-            start_time = time.perf_counter()
+            decode_start_time = time.perf_counter()
 
         # 画像取得
         frame = None
@@ -214,31 +230,45 @@ class Node(DpgNodeABC):
             if source_fps <= 0:
                 source_fps = 30.0
 
-            now = time.perf_counter()
-            start_time = self._playback_start_time.get(str(node_id), now)
-            elapsed_sec = max(0.0, now - start_time)
-            elapsed_frame = int(elapsed_sec * source_fps)
-            target_frame_pos = elapsed_frame * skip_rate
+            if natural_fps_mode:
+                now = time.perf_counter()
+                playback_start_time = self._playback_start_time.get(str(node_id), now)
+                elapsed_sec = max(0.0, now - playback_start_time)
+                elapsed_frame = int(elapsed_sec * source_fps)
+                target_frame_pos = elapsed_frame * skip_rate
 
-            if total_frame > 0 and loop_flag:
-                target_frame_pos = target_frame_pos % total_frame
-            elif total_frame > 0:
-                target_frame_pos = min(target_frame_pos, total_frame - 1)
+                if total_frame > 0 and loop_flag:
+                    target_frame_pos = target_frame_pos % total_frame
+                elif total_frame > 0:
+                    target_frame_pos = min(target_frame_pos, total_frame - 1)
 
-            current_frame_pos = int(video_capture.get(cv2.CAP_PROP_POS_FRAMES))
-            if target_frame_pos != current_frame_pos:
-                video_capture.set(cv2.CAP_PROP_POS_FRAMES, target_frame_pos)
+                current_frame_pos = int(video_capture.get(cv2.CAP_PROP_POS_FRAMES))
+                if target_frame_pos != current_frame_pos:
+                    video_capture.set(cv2.CAP_PROP_POS_FRAMES, target_frame_pos)
 
-            ret, frame = video_capture.read()
-            if not ret:
-                if loop_flag:
-                    video_capture.set(cv2.CAP_PROP_POS_FRAMES, 0)
+                ret, frame = video_capture.read()
+                if not ret:
+                    if loop_flag:
+                        video_capture.set(cv2.CAP_PROP_POS_FRAMES, 0)
+                        ret, frame = video_capture.read()
+                        self._playback_start_time[str(node_id)] = now
+                        self._frame_count[str(node_id)] = 0
+                    else:
+                        frame = self._last_output_frame.get(str(node_id), None)
+            else:
+                while True:
                     ret, frame = video_capture.read()
-                    self._playback_start_time[str(node_id)] = now
-                    self._playback_start_frame[str(node_id)] = 0
-                    self._frame_count[str(node_id)] = 0
-                else:
-                    frame = self._last_output_frame.get(str(node_id), None)
+                    if not ret:
+                        if loop_flag:
+                            video_capture.set(cv2.CAP_PROP_POS_FRAMES, 0)
+                            _, frame = video_capture.read()
+                        else:
+                            frame = self._last_output_frame.get(str(node_id), None)
+                        break
+
+                    self._frame_count[str(node_id)] += 1
+                    if (self._frame_count[str(node_id)] % skip_rate) == 0:
+                        break
 
             if frame is not None:
                 self._frame_count[str(node_id)] = int(
@@ -247,8 +277,8 @@ class Node(DpgNodeABC):
                 self._last_output_frame[str(node_id)] = frame.copy()
 
         # 計測終了
-        if video_capture is not None and use_pref_counter:
-            elapsed_time = time.perf_counter() - start_time
+        if video_capture is not None and use_pref_counter and decode_start_time is not None:
+            elapsed_time = time.perf_counter() - decode_start_time
             elapsed_time = int(elapsed_time * 1000)
             dpg_set_value(output_value02_tag,
                           str(elapsed_time).zfill(4) + 'ms')
@@ -290,17 +320,20 @@ class Node(DpgNodeABC):
         tag_node_name = self._node_name(node_id)
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
         tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
+        tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
 
         pos = dpg.get_item_pos(tag_node_name)
 
         loop_flag = dpg_get_value(tag_node_input02_value_name)
         skip_rate = int(dpg_get_value(tag_node_input03_value_name))
+        natural_fps_mode = bool(dpg_get_value(tag_node_input04_value_name))
 
         setting_dict = {}
         setting_dict['ver'] = self._ver
         setting_dict['pos'] = pos
         setting_dict[tag_node_input02_value_name] = loop_flag
         setting_dict[tag_node_input03_value_name] = skip_rate
+        setting_dict[tag_node_input04_value_name] = natural_fps_mode
 
         return setting_dict
 
@@ -308,12 +341,15 @@ class Node(DpgNodeABC):
         tag_node_name = self._node_name(node_id)
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
         tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
+        tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
 
         loop_flag = setting_dict[tag_node_input02_value_name]
         skip_rate = int(setting_dict[tag_node_input03_value_name])
+        natural_fps_mode = setting_dict.get(tag_node_input04_value_name, True)
 
         dpg_set_value(tag_node_input02_value_name, loop_flag)
         dpg_set_value(tag_node_input03_value_name, skip_rate)
+        dpg_set_value(tag_node_input04_value_name, natural_fps_mode)
 
     def _callback_file_select(self, sender, data):
         if data['file_name'] != '.':

--- a/node/input_node/node_video_input.py
+++ b/node/input_node/node_video_input.py
@@ -23,6 +23,9 @@ class Node(DpgNodeABC):
     _movie_filepath = {}
     _prev_movie_filepath = {}
     _frame_count = {}
+    _playback_start_time = {}
+    _playback_start_frame = {}
+    _last_output_frame = {}
 
     _min_val = 1
     _max_val = 10
@@ -188,6 +191,9 @@ class Node(DpgNodeABC):
             self._video_capture[str(node_id)] = cv2.VideoCapture(movie_path)
             self._prev_movie_filepath[str(node_id)] = movie_path
             self._frame_count[str(node_id)] = 0
+            self._playback_start_time[str(node_id)] = time.perf_counter()
+            self._playback_start_frame[str(node_id)] = 0
+            self._last_output_frame.pop(str(node_id), None)
 
         video_capture = self._video_capture.get(str(node_id), None)
 
@@ -203,24 +209,42 @@ class Node(DpgNodeABC):
         # 画像取得
         frame = None
         if video_capture is not None:
-            while True:
-                ret, frame = video_capture.read()
-                if not ret:
-                    if loop_flag:
-                        video_capture.set(cv2.CAP_PROP_POS_FRAMES, 0)
-                        _, frame = video_capture.read()
-                    else:
-                        video_capture.release()
-                        video_capture = None
-                        self._movie_filepath.pop(str(node_id))
-                        self._prev_movie_filepath.pop(str(node_id))
-                        self._video_capture.pop(str(node_id))
+            total_frame = int(video_capture.get(cv2.CAP_PROP_FRAME_COUNT))
+            source_fps = float(video_capture.get(cv2.CAP_PROP_FPS))
+            if source_fps <= 0:
+                source_fps = 30.0
 
-                        break
+            now = time.perf_counter()
+            start_time = self._playback_start_time.get(str(node_id), now)
+            elapsed_sec = max(0.0, now - start_time)
+            elapsed_frame = int(elapsed_sec * source_fps)
+            target_frame_pos = elapsed_frame * skip_rate
 
-                self._frame_count[str(node_id)] += 1
-                if (self._frame_count[str(node_id)] % skip_rate) == 0:
-                    break
+            if total_frame > 0 and loop_flag:
+                target_frame_pos = target_frame_pos % total_frame
+            elif total_frame > 0:
+                target_frame_pos = min(target_frame_pos, total_frame - 1)
+
+            current_frame_pos = int(video_capture.get(cv2.CAP_PROP_POS_FRAMES))
+            if target_frame_pos != current_frame_pos:
+                video_capture.set(cv2.CAP_PROP_POS_FRAMES, target_frame_pos)
+
+            ret, frame = video_capture.read()
+            if not ret:
+                if loop_flag:
+                    video_capture.set(cv2.CAP_PROP_POS_FRAMES, 0)
+                    ret, frame = video_capture.read()
+                    self._playback_start_time[str(node_id)] = now
+                    self._playback_start_frame[str(node_id)] = 0
+                    self._frame_count[str(node_id)] = 0
+                else:
+                    frame = self._last_output_frame.get(str(node_id), None)
+
+            if frame is not None:
+                self._frame_count[str(node_id)] = int(
+                    video_capture.get(cv2.CAP_PROP_POS_FRAMES)
+                )
+                self._last_output_frame[str(node_id)] = frame.copy()
 
         # 計測終了
         if video_capture is not None and use_pref_counter:
@@ -241,7 +265,18 @@ class Node(DpgNodeABC):
         return frame, None
 
     def close(self, node_id):
-        pass
+        str_node_id = str(node_id)
+        video_capture = self._video_capture.get(str_node_id, None)
+        if video_capture is not None:
+            video_capture.release()
+
+        self._video_capture.pop(str_node_id, None)
+        self._movie_filepath.pop(str_node_id, None)
+        self._prev_movie_filepath.pop(str_node_id, None)
+        self._frame_count.pop(str_node_id, None)
+        self._playback_start_time.pop(str_node_id, None)
+        self._playback_start_frame.pop(str_node_id, None)
+        self._last_output_frame.pop(str_node_id, None)
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)

--- a/node/input_node/node_video_input.py
+++ b/node/input_node/node_video_input.py
@@ -51,6 +51,8 @@ class Node(DpgNodeABC):
         tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
         tag_node_input04_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04')
         tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
+        tag_node_input05_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05')
+        tag_node_input05_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05'))
         tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
         tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
         tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
@@ -152,6 +154,17 @@ class Node(DpgNodeABC):
                     callback=None,
                     default_value=True,
                 )
+            # キャッシュ要否(ソースノード向け)
+            with dpg.node_attribute(
+                    tag=tag_node_input05_name,
+                    attribute_type=dpg.mvNode_Attr_Static,
+            ):
+                dpg.add_checkbox(
+                    label='Cache Source',
+                    tag=tag_node_input05_value_name,
+                    callback=None,
+                    default_value=False,
+                )
             # 処理時間
             if use_pref_counter:
                 with dpg.node_attribute(
@@ -176,6 +189,7 @@ class Node(DpgNodeABC):
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
         tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
         tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
+        tag_node_input05_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05'))
         output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
         output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
 
@@ -217,6 +231,7 @@ class Node(DpgNodeABC):
         # スキップ割合
         skip_rate = int(dpg_get_value(tag_node_input03_value_name))
         natural_fps_mode = bool(dpg_get_value(tag_node_input04_value_name))
+        cache_source = bool(dpg_get_value(tag_node_input05_value_name))
 
         # 計測開始
         decode_start_time = None
@@ -336,6 +351,8 @@ class Node(DpgNodeABC):
         setting_dict[tag_node_input02_value_name] = loop_flag
         setting_dict[tag_node_input03_value_name] = skip_rate
         setting_dict[tag_node_input04_value_name] = natural_fps_mode
+        setting_dict[tag_node_input05_value_name] = cache_source
+        setting_dict['__cache_source_enabled__'] = cache_source
 
         return setting_dict
 
@@ -344,6 +361,7 @@ class Node(DpgNodeABC):
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
         tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
         tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
+        tag_node_input05_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05'))
 
         movie_path = setting_dict.get('movie_path', None)
         node_id = str(node_id)
@@ -360,10 +378,17 @@ class Node(DpgNodeABC):
         loop_flag = setting_dict[tag_node_input02_value_name]
         skip_rate = int(setting_dict[tag_node_input03_value_name])
         natural_fps_mode = setting_dict.get(tag_node_input04_value_name, True)
+        cache_source = bool(
+            setting_dict.get(
+                tag_node_input05_value_name,
+                setting_dict.get('__cache_source_enabled__', False),
+            )
+        )
 
         dpg_set_value(tag_node_input02_value_name, loop_flag)
         dpg_set_value(tag_node_input03_value_name, skip_rate)
         dpg_set_value(tag_node_input04_value_name, natural_fps_mode)
+        dpg_set_value(tag_node_input05_value_name, cache_source)
 
     def _callback_file_select(self, sender, data):
         if data['file_name'] != '.':

--- a/node/input_node/node_video_input.py
+++ b/node/input_node/node_video_input.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import os
 import time
 import cv2
 import numpy as np
@@ -331,6 +332,7 @@ class Node(DpgNodeABC):
         setting_dict = {}
         setting_dict['ver'] = self._ver
         setting_dict['pos'] = pos
+        setting_dict['movie_path'] = self._movie_filepath.get(str(node_id), None)
         setting_dict[tag_node_input02_value_name] = loop_flag
         setting_dict[tag_node_input03_value_name] = skip_rate
         setting_dict[tag_node_input04_value_name] = natural_fps_mode
@@ -342,6 +344,18 @@ class Node(DpgNodeABC):
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
         tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
         tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
+
+        movie_path = setting_dict.get('movie_path', None)
+        node_id = str(node_id)
+        if movie_path is not None:
+            if os.path.isfile(movie_path):
+                self._movie_filepath[node_id] = movie_path
+            else:
+                self._movie_filepath.pop(node_id, None)
+                self._prev_movie_filepath.pop(node_id, None)
+                self._video_capture.pop(node_id, None)
+                self._last_output_frame.pop(node_id, None)
+                print(f'WARNING : Movie file not found ({movie_path})')
 
         loop_flag = setting_dict[tag_node_input02_value_name]
         skip_rate = int(setting_dict[tag_node_input03_value_name])

--- a/node/input_node/node_video_input.py
+++ b/node/input_node/node_video_input.py
@@ -262,7 +262,15 @@ class Node(DpgNodeABC):
             )
             dpg_set_value(output_value01_tag, texture)
 
-        return frame, None
+        stream_id = self._movie_filepath.get(str(node_id), None)
+        frame_index = self._frame_count.get(str(node_id), 0)
+        result = {
+            '__cache_stream__': stream_id,
+            '__cache_frame__': frame_index,
+            '__cache_kind__': 'video_frame',
+        }
+
+        return frame, result
 
     def close(self, node_id):
         str_node_id = str(node_id)

--- a/node_editor/graph_runtime.py
+++ b/node_editor/graph_runtime.py
@@ -301,6 +301,14 @@ def update_node_info(
                         node_result_dict[node_id_name] = copy.deepcopy(
                             frame_cached_result['result']
                         )
+                        if hasattr(node_instance, 'render_cached_output'):
+                            try:
+                                node_instance.render_cached_output(
+                                    node_id,
+                                    node_image_dict[node_id_name],
+                                )
+                            except Exception:
+                                pass
                         continue
             elif (
                 cached_result is not None and
@@ -312,6 +320,14 @@ def update_node_info(
                 node_result_dict[node_id_name] = copy.deepcopy(
                     cached_result['result']
                 )
+                if hasattr(node_instance, 'render_cached_output'):
+                    try:
+                        node_instance.render_cached_output(
+                            node_id,
+                            node_image_dict[node_id_name],
+                        )
+                    except Exception:
+                        pass
                 continue
 
         if mode_async:

--- a/node_editor/graph_runtime.py
+++ b/node_editor/graph_runtime.py
@@ -267,6 +267,13 @@ def update_node_info(
             if node_setting.get('__cache_enabled__') is False:
                 use_cache = False
 
+        if (
+            cache_enabled and
+            isinstance(node_setting, dict) and
+            node_setting.get('__cache_source_enabled__') is True
+        ):
+            use_cache = True
+
         if use_cache:
             for source_tag, _ in connection_list:
                 source_node_id_name = ':'.join(source_tag.split(':')[:2])

--- a/node_editor/graph_runtime.py
+++ b/node_editor/graph_runtime.py
@@ -77,22 +77,52 @@ def _build_node_signature(
     node_setting,
 ):
     upstream_values = []
+    upstream_frame_tokens = []
     for source_tag, _ in connection_list:
         source_node_id_name = ':'.join(source_tag.split(':')[:2])
+        source_result = node_result_dict.get(source_node_id_name)
+        frame_token = _extract_frame_token(source_result)
+        if frame_token is not None:
+            upstream_frame_tokens.append((source_tag, frame_token))
         upstream_values.append((
             source_tag,
             _freeze_cache_value(node_image_dict.get(source_node_id_name)),
-            _freeze_cache_value(node_result_dict.get(source_node_id_name)),
+            _freeze_cache_value(_strip_cache_meta(source_result)),
         ))
 
     signature_payload = {
         'node_id': node_id,
         'connection_list': connection_list,
         'upstream_values': upstream_values,
+        'upstream_frame_tokens': upstream_frame_tokens,
         'node_setting': _freeze_cache_value(node_setting),
     }
     payload_bytes = pickle.dumps(signature_payload)
     return hashlib.sha1(payload_bytes).hexdigest()
+
+
+def _extract_frame_token(result):
+    if not isinstance(result, dict):
+        return None
+
+    if result.get('__cache_kind__') != 'video_frame':
+        return None
+
+    return (
+        result.get('__cache_stream__'),
+        result.get('__cache_frame__'),
+    )
+
+
+def _strip_cache_meta(result):
+    if not isinstance(result, dict):
+        return result
+
+    return {
+        key: value
+        for key, value in result.items()
+        if not str(key).startswith('__cache_')
+    }
 
 
 def update_node_info(

--- a/node_editor/graph_runtime.py
+++ b/node_editor/graph_runtime.py
@@ -263,6 +263,10 @@ def update_node_info(
             else:
                 node_setting = node_instance.get_setting_dict(node_id)
 
+        if use_cache and isinstance(node_setting, dict):
+            if node_setting.get('__cache_enabled__') is False:
+                use_cache = False
+
         if use_cache:
             for source_tag, _ in connection_list:
                 source_node_id_name = ':'.join(source_tag.split(':')[:2])

--- a/node_editor/graph_runtime.py
+++ b/node_editor/graph_runtime.py
@@ -101,6 +101,39 @@ def _build_node_signature(
     return hashlib.sha1(payload_bytes).hexdigest()
 
 
+def _build_pipeline_signature_for_video(
+    node_id,
+    connection_list,
+    upstream_frame_tokens,
+    node_result_dict,
+    node_setting,
+):
+    """
+    Build a stable signature for video pipelines that is invariant to frame index.
+    """
+    upstream_result_values = []
+    for source_tag, _ in connection_list:
+        source_node_id_name = ':'.join(source_tag.split(':')[:2])
+        source_result = node_result_dict.get(source_node_id_name)
+        upstream_result_values.append((
+            source_tag,
+            _freeze_cache_value(_strip_cache_meta(source_result)),
+        ))
+
+    signature_payload = {
+        'node_id': node_id,
+        'connection_list': connection_list,
+        'upstream_result_values': upstream_result_values,
+        'upstream_stream_tokens': [
+            (source_tag, stream_id)
+            for source_tag, (stream_id, _) in upstream_frame_tokens
+        ],
+        'node_setting': _freeze_cache_value(node_setting),
+    }
+    payload_bytes = pickle.dumps(signature_payload)
+    return hashlib.sha1(payload_bytes).hexdigest()
+
+
 def _extract_frame_token(result):
     if not isinstance(result, dict):
         return None
@@ -209,6 +242,7 @@ def update_node_info(
             continue
 
         cache_signature = None
+        upstream_frame_tokens = []
         use_cache = cache_enabled and (
             len(connection_list) > 0 or cache_source_nodes
         )
@@ -230,6 +264,13 @@ def update_node_info(
                 node_setting = node_instance.get_setting_dict(node_id)
 
         if use_cache:
+            for source_tag, _ in connection_list:
+                source_node_id_name = ':'.join(source_tag.split(':')[:2])
+                source_result = node_result_dict.get(source_node_id_name)
+                frame_token = _extract_frame_token(source_result)
+                if frame_token is not None:
+                    upstream_frame_tokens.append((source_tag, frame_token))
+
             cache_signature = _build_node_signature(
                 node_id,
                 connection_list,
@@ -238,7 +279,30 @@ def update_node_info(
                 node_setting,
             )
             cached_result = node_cache_dict.get(node_id_name)
-            if (
+            if upstream_frame_tokens:
+                pipeline_signature = _build_pipeline_signature_for_video(
+                    node_id,
+                    connection_list,
+                    upstream_frame_tokens,
+                    node_result_dict,
+                    node_setting,
+                )
+                frame_key = tuple(upstream_frame_tokens)
+                if (
+                    cached_result is not None and
+                    cached_result.get('pipeline_signature') == pipeline_signature
+                ):
+                    cached_frame_results = cached_result.get('frame_results', {})
+                    frame_cached_result = cached_frame_results.get(frame_key)
+                    if frame_cached_result is not None:
+                        node_image_dict[node_id_name] = copy.deepcopy(
+                            frame_cached_result['image']
+                        )
+                        node_result_dict[node_id_name] = copy.deepcopy(
+                            frame_cached_result['result']
+                        )
+                        continue
+            elif (
                 cached_result is not None and
                 cached_result.get('signature') == cache_signature
             ):
@@ -277,11 +341,32 @@ def update_node_info(
         node_image_dict[node_id_name] = copy.deepcopy(image)
         node_result_dict[node_id_name] = copy.deepcopy(result)
         if use_cache:
-            node_cache_dict[node_id_name] = {
-                'signature': cache_signature,
-                'image': copy.deepcopy(image),
-                'result': copy.deepcopy(result),
-            }
+            if upstream_frame_tokens:
+                pipeline_signature = _build_pipeline_signature_for_video(
+                    node_id,
+                    connection_list,
+                    upstream_frame_tokens,
+                    node_result_dict,
+                    node_setting,
+                )
+                frame_key = tuple(upstream_frame_tokens)
+                cache_entry = node_cache_dict.get(node_id_name, {})
+                if cache_entry.get('pipeline_signature') != pipeline_signature:
+                    cache_entry = {
+                        'pipeline_signature': pipeline_signature,
+                        'frame_results': {},
+                    }
+                cache_entry['frame_results'][frame_key] = {
+                    'image': copy.deepcopy(image),
+                    'result': copy.deepcopy(result),
+                }
+                node_cache_dict[node_id_name] = cache_entry
+            else:
+                node_cache_dict[node_id_name] = {
+                    'signature': cache_signature,
+                    'image': copy.deepcopy(image),
+                    'result': copy.deepcopy(result),
+                }
         elif node_id_name in node_cache_dict:
             del node_cache_dict[node_id_name]
 


### PR DESCRIPTION
### Motivation

- Replace the previous frame-read loop with time-based seeking to sync playback with real time and respect the `skip_rate` setting. 
- Ensure stable behavior when videos end by providing loop support and caching the last output frame to avoid dropping output. 
- Properly release and clear per-node resources when a node is closed to avoid leaked `VideoCapture` handles.

### Description

- Added per-node state fields: `_playback_start_time`, `_playback_start_frame`, and `_last_output_frame`, and initialize them when a new movie is opened. 
- Reworked frame acquisition to compute a `target_frame_pos` from `time.perf_counter()` and the source `FPS`, apply `skip_rate`, and seek with `cv2.CAP_PROP_POS_FRAMES` instead of reading in a while-loop. 
- When reads fail, the node either restarts playback (if looping) or returns the cached last frame, and frame counters are updated and the last output is cached via `.copy()`. 
- Implemented `close()` to release any open `VideoCapture` and to pop all per-node entries from internal dicts to ensure cleanup.

### Testing

- Ran a local smoke test script that imports the module and opens a short test video to exercise loop and non-loop playback scenarios, and the script completed without errors. 
- Verified that seeking respects different source `FPS` values and that `skip_rate` affects the delivered frame position as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbddad4e08323a16465cf04727fa7)