### PR TITLE
Replace declarative preview with result node toggles

### DIFF
--- a/node/base/declarative_node_base.py
+++ b/node/base/declarative_node_base.py
@@ -18,7 +18,12 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
     parameters = []
     show_elapsed_time = True
     _cache_toggle_setting_key = '__cache_enabled__'
+    _result_image_toggle_setting_key = '__result_image_enabled__'
+    _result_large_image_toggle_setting_key = '__result_large_image_enabled__'
     _cache_enabled_by_node = {}
+    _result_image_enabled_by_node = {}
+    _result_large_image_enabled_by_node = {}
+    _ui_callback = None
 
     def add_node(
         self,
@@ -37,8 +42,13 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
         elapsed_value_tag = self._value_tag(elapsed_tag)
         cache_toggle_tag = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Cache')
         cache_toggle_value_tag = self._value_tag(cache_toggle_tag)
+        result_image_toggle_tag = self._port_tag(tag_node_name, self.TYPE_TEXT, 'ResultImage')
+        result_image_toggle_value_tag = self._value_tag(result_image_toggle_tag)
+        result_large_image_toggle_tag = self._port_tag(tag_node_name, self.TYPE_TEXT, 'ResultImageLarge')
+        result_large_image_toggle_value_tag = self._value_tag(result_large_image_toggle_tag)
 
         self._opencv_setting_dict = opencv_setting_dict
+        self._ui_callback = callback
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
         use_pref_counter = self._opencv_setting_dict['use_pref_counter']
@@ -74,7 +84,7 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
                 tag=output_image_tag,
                 attribute_type=dpg.mvNode_Attr_Output,
             ):
-                dpg.add_image(output_image_value_tag)
+                pass
 
             for parameter in self.parameters:
                 self._add_parameter_ui(tag_node_name, parameter, small_window_w, callback)
@@ -98,6 +108,32 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
                     user_data=node_id,
                 )
                 self._cache_enabled_by_node[str(node_id)] = True
+
+            with dpg.node_attribute(
+                tag=result_image_toggle_tag,
+                attribute_type=dpg.mvNode_Attr_Static,
+            ):
+                dpg.add_checkbox(
+                    label='Result Image',
+                    tag=result_image_toggle_value_tag,
+                    default_value=False,
+                    callback=self._on_result_image_toggle,
+                    user_data=node_id,
+                )
+                self._result_image_enabled_by_node[str(node_id)] = False
+
+            with dpg.node_attribute(
+                tag=result_large_image_toggle_tag,
+                attribute_type=dpg.mvNode_Attr_Static,
+            ):
+                dpg.add_checkbox(
+                    label='Result Image(Large)',
+                    tag=result_large_image_toggle_value_tag,
+                    default_value=False,
+                    callback=self._on_result_large_image_toggle,
+                    user_data=node_id,
+                )
+                self._result_large_image_enabled_by_node[str(node_id)] = False
 
             if self.show_elapsed_time and use_pref_counter:
                 with dpg.node_attribute(
@@ -205,6 +241,12 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
         setting_dict[self._cache_toggle_setting_key] = bool(
             self._cache_enabled_by_node.get(str(node_id), True)
         )
+        setting_dict[self._result_image_toggle_setting_key] = bool(
+            self._result_image_enabled_by_node.get(str(node_id), False)
+        )
+        setting_dict[self._result_large_image_toggle_setting_key] = bool(
+            self._result_large_image_enabled_by_node.get(str(node_id), False)
+        )
 
         return setting_dict
 
@@ -225,9 +267,29 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
         cache_toggle_value_tag = self._value_tag(
             self._port_tag(tag_node_name, self.TYPE_TEXT, 'Cache')
         )
+        result_image_toggle_value_tag = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'ResultImage')
+        )
+        result_large_image_toggle_value_tag = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'ResultImageLarge')
+        )
         cache_enabled = bool(setting_dict.get(self._cache_toggle_setting_key, True))
+        result_image_enabled = bool(
+            setting_dict.get(self._result_image_toggle_setting_key, False)
+        )
+        result_large_image_enabled = bool(
+            setting_dict.get(self._result_large_image_toggle_setting_key, False)
+        )
         self._cache_enabled_by_node[str(node_id)] = cache_enabled
+        self._result_image_enabled_by_node[str(node_id)] = result_image_enabled
+        self._result_large_image_enabled_by_node[str(node_id)] = result_large_image_enabled
         dpg_set_value(cache_toggle_value_tag, cache_enabled)
+        dpg_set_value(result_image_toggle_value_tag, result_image_enabled)
+        dpg_set_value(result_large_image_toggle_value_tag, result_large_image_enabled)
+        self._emit_result_node_toggle(node_id, 'ResultImage', result_image_enabled)
+        self._emit_result_node_toggle(
+            node_id, 'ResultImageLarge', result_large_image_enabled
+        )
 
         self.on_settings_applied(tag_node_name)
 
@@ -250,6 +312,30 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
     def _on_cache_toggle(self, sender, app_data, user_data):
         del sender
         self._cache_enabled_by_node[str(user_data)] = bool(app_data)
+
+    def _on_result_image_toggle(self, sender, app_data, user_data):
+        del sender
+        enabled = bool(app_data)
+        self._result_image_enabled_by_node[str(user_data)] = enabled
+        self._emit_result_node_toggle(user_data, 'ResultImage', enabled)
+
+    def _on_result_large_image_toggle(self, sender, app_data, user_data):
+        del sender
+        enabled = bool(app_data)
+        self._result_large_image_enabled_by_node[str(user_data)] = enabled
+        self._emit_result_node_toggle(user_data, 'ResultImageLarge', enabled)
+
+    def _emit_result_node_toggle(self, node_id, result_node_tag, enabled):
+        if self._ui_callback is None:
+            return
+        self._ui_callback(
+            'toggle_result_node',
+            {
+                'source_node_id_name': self._node_name(node_id),
+                'result_node_tag': result_node_tag,
+                'enabled': bool(enabled),
+            },
+        )
 
     def normalize_parameter_values(self, tag_node_name, parameter_values):
         del tag_node_name

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -315,6 +315,7 @@ class DpgNodeEditor(object):
             new_id,
             pos=pos,
             opencv_setting_dict=self._opencv_setting_dict,
+            callback=self._cntrl_node_callback,
         )
 
     def _vw_add_link(self, source, destination):
@@ -431,6 +432,77 @@ class DpgNodeEditor(object):
             print(f'\tuser_data       : {user_data}')
             print(f'\tself._node_list : {", ".join(self._node_list)}')
             print()
+
+    def _cntrl_node_callback(self, event_name, data):
+        if event_name == 'toggle_result_node':
+            if not isinstance(data, dict):
+                return
+            self._cntrl_toggle_result_node(
+                str(data.get('source_node_id_name', '')),
+                str(data.get('result_node_tag', '')),
+                bool(data.get('enabled', False)),
+            )
+
+    def _cntrl_toggle_result_node(
+        self,
+        source_node_id_name,
+        result_node_tag,
+        enabled,
+    ):
+        if ':' not in source_node_id_name:
+            return
+        if result_node_tag not in self._node_instance_list:
+            return
+
+        source_output_tag = self._cntrl_find_node_port(
+            source_node_id_name, 'Image', 'Output'
+        )
+        if source_output_tag is None:
+            return
+
+        existing_result_node = self._cntrl_find_linked_result_node(
+            source_node_id_name,
+            result_node_tag,
+        )
+        if enabled:
+            if existing_result_node is not None:
+                return
+            source_pos = dpg.get_item_pos(source_node_id_name)
+            new_id, new_node_id_name = self._mdl_add_node(result_node_tag)
+            result_pos = [source_pos[0] + 260, source_pos[1]]
+            self._vw_add_node(result_node_tag, new_id, result_pos)
+            self._node_list.append(new_node_id_name)
+            result_input_tag = self._cntrl_find_node_port(
+                new_node_id_name, 'Image', 'Input'
+            )
+            if result_input_tag is None:
+                self._mdl_delete_node(new_node_id_name)
+                self._vw_delete_item(new_node_id_name)
+                return
+            if self._mdl_add_link(source_output_tag, result_input_tag):
+                link_dpg_id = self._vw_add_link(source_output_tag, result_input_tag)
+                self._vw_register_link(source_output_tag, result_input_tag, link_dpg_id)
+            self._mdl_sort_node_graph()
+        else:
+            if existing_result_node is None:
+                return
+            self._mdl_delete_node(existing_result_node)
+            self._vw_delete_links_for_node(existing_result_node)
+            self._vw_delete_item(existing_result_node)
+
+    def _cntrl_find_linked_result_node(self, source_node_id_name, result_node_tag):
+        source_output_tag = self._cntrl_find_node_port(
+            source_node_id_name, 'Image', 'Output'
+        )
+        if source_output_tag is None:
+            return None
+        for source_tag, dest_tag in self._node_link_list:
+            if source_tag != source_output_tag:
+                continue
+            dest_node_id_name = ':'.join(dest_tag.split(':')[:2])
+            if dest_node_id_name.endswith(f':{result_node_tag}'):
+                return dest_node_id_name
+        return None
 
     def _cntrl_get_link_from_dpg_id(self, link_dpg_id):
         link_dpg_config = dpg.get_item_configuration(link_dpg_id)


### PR DESCRIPTION
### Motivation
- Make per-node result previews explicit and detachable by replacing the inline preview in declarative image process nodes with toggles that create/remove separate result nodes. 
- Ensure toggle state survives export/import so UI-driven result nodes are restored when loading settings.

### Description
- Added two static checkboxes to `DeclarativeImageProcessNodeBase`: `Result Image` and `Result Image(Large)`, removed the inline `dpg.add_image` preview slot, and added internal state keys for both toggles in `node/base/declarative_node_base.py`.
- Emit a UI callback (`toggle_result_node` event) from the declarative base when toggles change or when settings are applied, carrying `source_node_id_name`, `result_node_tag`, and `enabled` booleans.
- Wire the node editor to accept node callbacks by passing `callback=self._cntrl_node_callback` when creating nodes and implementing `_cntrl_node_callback`, `_cntrl_toggle_result_node`, and `_cntrl_find_linked_result_node` in `node_editor/node_editor.py` to create, place (to the right of source), auto-link, and remove `ResultImage`/`ResultImageLarge` nodes on toggle changes.
- Persist toggle values in node settings export/import by adding setting keys and restoring them in `set_setting_dict` so toggles re-emit requests on load.

### Testing
- Running `python -m pytest tests/unit/test_declarative_process_nodes.py -q` in this environment failed during import due to a missing OpenCV GUI dependency (`ImportError: libGL.so.1`).
- Running `python -m pytest tests/unit/test_declarative_process_nodes.py -q --use-cv2-stub` succeeded with `27 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a125b4ffe248323a9cc429e43769a7c)