### PR TITLE
Add per-node close button and consolidate node deletion logic

### DIFF
--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -47,7 +47,6 @@ class DpgNodeEditor(object):
     _add_node_popup_anchor_tag = _add_node_popup_tag + 'Anchor'
     _node_close_attr_suffix = ':CloseAttr'
     _node_close_button_suffix = ':CloseButton'
-    _pending_node_delete_tag = None
 
     _node_id = 0
     _node_instance_list = {}
@@ -94,7 +93,6 @@ class DpgNodeEditor(object):
         self._port_registry = {}
         self._link_registry = {}
         self._link_by_dest_port = {}
-        self._pending_node_delete_tag = None
         self._use_debug_print = use_debug_print
         self._terminate_flag = False
         self._opencv_setting_dict = opencv_setting_dict
@@ -560,6 +558,11 @@ class DpgNodeEditor(object):
                     callback=self._cntrl_delete_node_by_button,
                     user_data=node_view_tag,
                 )
+        node_children = dpg.get_item_children(node_view_tag, 1)
+        if node_children:
+            first_attribute = node_children[0]
+            if first_attribute != close_attr_tag:
+                dpg.move_item(close_attr_tag, parent=node_view_tag, before=first_attribute)
 
     def _vw_add_link(self, source, destination):
         source_id = source
@@ -1334,13 +1337,15 @@ class DpgNodeEditor(object):
         return reconnect_pairs
 
     def _cntrl_delete_node_by_button(self, sender, data, user_data):
-        self._pending_node_delete_tag = user_data
-        dpg.set_frame_callback(dpg.get_frame_count() + 1, self._cntrl_delete_node_deferred)
+        dpg.set_frame_callback(
+            dpg.get_frame_count() + 1,
+            self._cntrl_delete_node_deferred,
+            user_data,
+        )
 
-    def _cntrl_delete_node_deferred(self, sender, data):
-        node_tag = self._pending_node_delete_tag
-        self._pending_node_delete_tag = None
-        if not node_tag:
+    def _cntrl_delete_node_deferred(self, sender, data, user_data):
+        node_tag = user_data
+        if (not node_tag) or (not dpg.does_item_exist(node_tag)):
             return
 
         reconnect_pairs = self._cntrl_delete_node_by_tag(node_tag)

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -1316,6 +1316,39 @@ class DpgNodeEditor(object):
 
         return reconnect_pairs
 
+    def _cntrl_reconnect_through_deleted_nodes(self, deleted_node_tags):
+        deleted_set = set(deleted_node_tags)
+        if not deleted_set:
+            return []
+
+        incoming_by_type = {}
+        outgoing_by_type = {}
+        for source_tag, dest_tag in self._node_link_list:
+            source_port = self._port_registry.get(source_tag)
+            dest_port = self._port_registry.get(dest_tag)
+            if source_port is None or dest_port is None:
+                continue
+            source_node = source_port.node_ref.node_id_name
+            dest_node = dest_port.node_ref.node_id_name
+            link_type = source_port.data_type
+
+            if source_node not in deleted_set and dest_node in deleted_set:
+                incoming_by_type.setdefault(link_type, []).append(source_tag)
+            elif source_node in deleted_set and dest_node not in deleted_set:
+                outgoing_by_type.setdefault(link_type, []).append(dest_tag)
+
+        reconnect_pairs = []
+        for link_type, outgoing_destinations in outgoing_by_type.items():
+            incoming_sources = incoming_by_type.get(link_type, [])
+            if len(incoming_sources) != 1:
+                continue
+            source_tag = incoming_sources[0]
+            for dest_tag in outgoing_destinations:
+                if source_tag == dest_tag:
+                    continue
+                reconnect_pairs.append((source_tag, dest_tag))
+        return reconnect_pairs
+
     def _cntrl_delete_selected(self, sender, data):
         selected_nodes = dpg.get_selected_nodes(self._node_editor_tag)
         selected_node_tags = [dpg.get_item_alias(node_dpg_id) for node_dpg_id in selected_nodes]
@@ -1323,9 +1356,9 @@ class DpgNodeEditor(object):
         self._cntrl_delete_targets(selected_node_tags, selected_links)
 
     def _cntrl_delete_targets(self, selected_node_tags, selected_link_ids):
-        reconnect_pairs = []
+        reconnect_pairs = self._cntrl_reconnect_through_deleted_nodes(selected_node_tags)
         for node_tag in selected_node_tags:
-            reconnect_pairs.extend(self._cntrl_delete_node_by_tag(node_tag))
+            self._cntrl_delete_node_by_tag(node_tag)
 
         for source_tag, dest_tag in reconnect_pairs:
             if self._mdl_add_link(source_tag, dest_tag):
@@ -1358,16 +1391,9 @@ class DpgNodeEditor(object):
 
     def _cntrl_delete_node_by_button(self, sender, data, user_data):
         node_tag = user_data
-
-        def _deferred_delete_node():
-            if not node_tag or not dpg.does_item_exist(node_tag):
-                return
-            self._cntrl_delete_targets([node_tag], [])
-
-        dpg.set_frame_callback(
-            dpg.get_frame_count() + 1,
-            _deferred_delete_node,
-        )
+        if not node_tag or not dpg.does_item_exist(node_tag):
+            return
+        self._cntrl_delete_targets([node_tag], [])
 
     # Public functions
     def get_node_list(self):

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -1289,33 +1289,6 @@ class DpgNodeEditor(object):
         if selected_nodes:
             self._last_pos = dpg.get_item_pos(selected_nodes[0])
 
-    def _cntrl_reconnect_through_node(self, node_id_name):
-        incoming_by_type = {}
-        outgoing_by_type = {}
-
-        for source_tag, dest_tag in self._node_link_list:
-            source_port = self._port_registry.get(source_tag)
-            dest_port = self._port_registry.get(dest_tag)
-            if source_port is None or dest_port is None:
-                continue
-            if dest_port.node_ref.node_id_name == node_id_name:
-                incoming_by_type.setdefault(dest_port.data_type, []).append(source_tag)
-            elif source_port.node_ref.node_id_name == node_id_name:
-                outgoing_by_type.setdefault(source_port.data_type, []).append(dest_tag)
-
-        reconnect_pairs = []
-        for link_type, outgoing_destinations in outgoing_by_type.items():
-            incoming_sources = incoming_by_type.get(link_type, [])
-            if len(incoming_sources) != 1:
-                continue
-            source_tag = incoming_sources[0]
-            for dest_tag in outgoing_destinations:
-                if source_tag == dest_tag:
-                    continue
-                reconnect_pairs.append((source_tag, dest_tag))
-
-        return reconnect_pairs
-
     def _cntrl_reconnect_through_deleted_nodes(self, deleted_node_tags):
         deleted_set = set(deleted_node_tags)
         if not deleted_set:
@@ -1367,6 +1340,8 @@ class DpgNodeEditor(object):
         reconnect_pairs = []
         for _src_tag, dest_tag, source_node, _dest_node, link_type in outgoing_edges:
             incoming_sources = _find_external_sources(source_node, link_type)
+            # Heal only when there is a single unambiguous external source.
+            # If there are 0 or >1 candidates, skip reconnection by design.
             if len(incoming_sources) != 1:
                 continue
             source_tag = next(iter(incoming_sources))
@@ -1409,16 +1384,13 @@ class DpgNodeEditor(object):
             print(f'\tself._node_connection_dict : {self._node_connection_dict}')
 
     def _cntrl_delete_node_by_tag(self, node_tag):
-        reconnect_pairs = self._cntrl_reconnect_through_node(node_tag)
-
         if node_tag not in self._node_list:
-            return []
+            return
 
         self._mdl_delete_node(node_tag)
         self._vw_delete_links_for_node(node_tag)
         if dpg.does_item_exist(node_tag):
             self._vw_delete_item(node_tag)
-        return reconnect_pairs
 
     def _cntrl_delete_node_by_button(self, sender, data, user_data):
         node_tag = user_data

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -183,6 +183,14 @@ class DpgNodeEditor(object):
             dest_port = self._port_registry.get(link_info[1])
             source_node = source_port.node_ref.node_id_name if source_port else ''
             destination_node = dest_port.node_ref.node_id_name if dest_port else ''
+            if not source_node and isinstance(link_info[0], str):
+                source_parts = link_info[0].split(':')
+                if len(source_parts) >= 2:
+                    source_node = f'{source_parts[0]}:{source_parts[1]}'
+            if not destination_node and isinstance(link_info[1], str):
+                dest_parts = link_info[1].split(':')
+                if len(dest_parts) >= 2:
+                    destination_node = f'{dest_parts[0]}:{dest_parts[1]}'
             if source_node == node_id_name or destination_node == node_id_name:
                 self._link_registry.pop((link_info[0], link_info[1]), None)
                 self._link_by_dest_port.pop(link_info[1], None)
@@ -593,12 +601,17 @@ class DpgNodeEditor(object):
         for source_tag, dest_tag in self._link_view_id_map:
             source_port = self._port_registry.get(source_tag)
             dest_port = self._port_registry.get(dest_tag)
-            if source_port is None or dest_port is None:
-                continue
-            if (
-                source_port.node_ref.node_id_name == node_id_name
-                or dest_port.node_ref.node_id_name == node_id_name
-            ):
+            source_node = source_port.node_ref.node_id_name if source_port else ''
+            destination_node = dest_port.node_ref.node_id_name if dest_port else ''
+            if not source_node and isinstance(source_tag, str):
+                source_parts = source_tag.split(':')
+                if len(source_parts) >= 2:
+                    source_node = f'{source_parts[0]}:{source_parts[1]}'
+            if not destination_node and isinstance(dest_tag, str):
+                dest_parts = dest_tag.split(':')
+                if len(dest_parts) >= 2:
+                    destination_node = f'{dest_parts[0]}:{dest_parts[1]}'
+            if source_node == node_id_name or destination_node == node_id_name:
                 delete_targets.append((source_tag, dest_tag))
 
         for source_tag, dest_tag in delete_targets:
@@ -1251,7 +1264,10 @@ class DpgNodeEditor(object):
                 new_destination = ':'.join(dest_parts)
                 link_dpg_id = self._vw_add_link(new_source, new_destination)
                 self._vw_register_link(new_source, new_destination, link_dpg_id)
-                new_link_list.append([new_source, new_destination])
+                if not self._mdl_add_link(new_source, new_destination):
+                    # Preserve serialized links for compatibility with older
+                    # graph formats (e.g., duplicate destination links).
+                    new_link_list.append([new_source, new_destination])
 
         self._node_link_list.extend(new_link_list)
         self._mdl_sort_node_graph()

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -47,6 +47,7 @@ class DpgNodeEditor(object):
     _add_node_popup_anchor_tag = _add_node_popup_tag + 'Anchor'
     _node_close_attr_suffix = ':CloseAttr'
     _node_close_button_suffix = ':CloseButton'
+    _pending_node_delete_tag = None
 
     _node_id = 0
     _node_instance_list = {}
@@ -93,6 +94,7 @@ class DpgNodeEditor(object):
         self._port_registry = {}
         self._link_registry = {}
         self._link_by_dest_port = {}
+        self._pending_node_delete_tag = None
         self._use_debug_print = use_debug_print
         self._terminate_flag = False
         self._opencv_setting_dict = opencv_setting_dict
@@ -1332,7 +1334,16 @@ class DpgNodeEditor(object):
         return reconnect_pairs
 
     def _cntrl_delete_node_by_button(self, sender, data, user_data):
-        reconnect_pairs = self._cntrl_delete_node_by_tag(user_data)
+        self._pending_node_delete_tag = user_data
+        dpg.set_frame_callback(dpg.get_frame_count() + 1, self._cntrl_delete_node_deferred)
+
+    def _cntrl_delete_node_deferred(self, sender, data):
+        node_tag = self._pending_node_delete_tag
+        self._pending_node_delete_tag = None
+        if not node_tag:
+            return
+
+        reconnect_pairs = self._cntrl_delete_node_by_tag(node_tag)
         for source_tag, dest_tag in reconnect_pairs:
             if self._mdl_add_link(source_tag, dest_tag):
                 link_dpg_id = self._vw_add_link(source_tag, dest_tag)

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -1338,11 +1338,18 @@ class DpgNodeEditor(object):
         return reconnect_pairs
 
     def _cntrl_delete_node_by_button(self, sender, data, user_data):
-        reconnect_pairs = self._cntrl_delete_node_by_tag(user_data)
-        for source_tag, dest_tag in reconnect_pairs:
-            if self._mdl_add_link(source_tag, dest_tag):
-                link_dpg_id = self._vw_add_link(source_tag, dest_tag)
-                self._vw_register_link(source_tag, dest_tag, link_dpg_id)
+        # Avoid deleting a node while DearPyGui is still executing one of the
+        # node's child-item callbacks. Defer the destructive work to next frame.
+        node_tag = user_data
+
+        def _deferred_delete():
+            reconnect_pairs = self._cntrl_delete_node_by_tag(node_tag)
+            for source_tag, dest_tag in reconnect_pairs:
+                if self._mdl_add_link(source_tag, dest_tag):
+                    link_dpg_id = self._vw_add_link(source_tag, dest_tag)
+                    self._vw_register_link(source_tag, dest_tag, link_dpg_id)
+
+        dpg.set_frame_callback(dpg.get_frame_count() + 1, _deferred_delete)
 
     # Public functions
     def get_node_list(self):

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -45,6 +45,8 @@ class DpgNodeEditor(object):
     _insert_link_popup_anchor_tag = _insert_link_popup_tag + 'Anchor'
     _add_node_popup_tag = _node_editor_tag + 'AddNodePopup'
     _add_node_popup_anchor_tag = _add_node_popup_tag + 'Anchor'
+    _node_close_attr_suffix = ':CloseAttr'
+    _node_close_button_suffix = ':CloseButton'
 
     _node_id = 0
     _node_instance_list = {}
@@ -525,13 +527,37 @@ class DpgNodeEditor(object):
 
     def _vw_add_node(self, node_tag, new_id, pos):
         node = self._node_instance_list[node_tag]
-        node.add_node(
+        node_view_tag = node.add_node(
             self._node_editor_tag,
             new_id,
             pos=pos,
             opencv_setting_dict=self._opencv_setting_dict,
             callback=self._cntrl_node_callback,
         )
+
+        if node_tag == 'ExecPythonCode':
+            return
+
+        close_attr_tag = node_view_tag + self._node_close_attr_suffix
+        close_button_tag = node_view_tag + self._node_close_button_suffix
+        if dpg.does_item_exist(close_attr_tag):
+            dpg.delete_item(close_attr_tag)
+
+        with dpg.node_attribute(
+                parent=node_view_tag,
+                tag=close_attr_tag,
+                attribute_type=dpg.mvNode_Attr_Static,
+        ):
+            with dpg.group(horizontal=True):
+                dpg.add_spacer(width=120)
+                dpg.add_button(
+                    tag=close_button_tag,
+                    label='x',
+                    width=20,
+                    height=20,
+                    callback=self._cntrl_delete_node_by_button,
+                    user_data=node_view_tag,
+                )
 
     def _vw_add_link(self, source, destination):
         source_id = source
@@ -1273,10 +1299,7 @@ class DpgNodeEditor(object):
         reconnect_pairs = []
         for node_dpg_id in selected_nodes:
             node_tag = dpg.get_item_alias(node_dpg_id)
-            reconnect_pairs.extend(self._cntrl_reconnect_through_node(node_tag))
-            self._mdl_delete_node(node_tag)
-            self._vw_delete_links_for_node(node_tag)
-            self._vw_delete_item(node_dpg_id)
+            reconnect_pairs.extend(self._cntrl_delete_node_by_tag(node_tag))
 
         for source_tag, dest_tag in reconnect_pairs:
             if self._mdl_add_link(source_tag, dest_tag):
@@ -1295,6 +1318,25 @@ class DpgNodeEditor(object):
             print(f'\tself._node_list            : {self._node_list}')
             print(f'\tself._node_link_list       : {self._node_link_list}')
             print(f'\tself._node_connection_dict : {self._node_connection_dict}')
+
+    def _cntrl_delete_node_by_tag(self, node_tag):
+        reconnect_pairs = self._cntrl_reconnect_through_node(node_tag)
+
+        if node_tag not in self._node_list:
+            return []
+
+        self._mdl_delete_node(node_tag)
+        self._vw_delete_links_for_node(node_tag)
+        if dpg.does_item_exist(node_tag):
+            self._vw_delete_item(node_tag)
+        return reconnect_pairs
+
+    def _cntrl_delete_node_by_button(self, sender, data, user_data):
+        reconnect_pairs = self._cntrl_delete_node_by_tag(user_data)
+        for source_tag, dest_tag in reconnect_pairs:
+            if self._mdl_add_link(source_tag, dest_tag):
+                link_dpg_id = self._vw_add_link(source_tag, dest_tag)
+                self._vw_register_link(source_tag, dest_tag, link_dpg_id)
 
     # Public functions
     def get_node_list(self):

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -6,7 +6,6 @@ import json
 import platform
 import datetime
 import re
-from functools import partial
 from glob import glob
 from collections import OrderedDict
 from importlib import import_module
@@ -1339,9 +1338,13 @@ class DpgNodeEditor(object):
         return reconnect_pairs
 
     def _cntrl_delete_node_by_button(self, sender, data, user_data):
+        delete_callback = (
+            lambda s=None, d=None, tag=user_data:
+            self._cntrl_delete_node_deferred(s, d, tag)
+        )
         dpg.set_frame_callback(
             dpg.get_frame_count() + 1,
-            partial(self._cntrl_delete_node_deferred, user_data=user_data),
+            delete_callback,
         )
 
     def _cntrl_delete_node_deferred(self, sender, data, user_data):

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -1342,10 +1342,9 @@ class DpgNodeEditor(object):
             lambda s=None, d=None, tag=user_data:
             self._cntrl_delete_node_deferred(s, d, tag)
         )
-        dpg.set_frame_callback(
-            dpg.get_frame_count() + 1,
-            delete_callback,
-        )
+        with dpg.mutex():
+            target_frame = dpg.get_frame_count() + 2
+            dpg.set_frame_callback(target_frame, delete_callback)
 
     def _cntrl_delete_node_deferred(self, sender, data, user_data):
         node_tag = user_data

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -1321,8 +1321,8 @@ class DpgNodeEditor(object):
         if not deleted_set:
             return []
 
-        incoming_by_type = {}
-        outgoing_by_type = {}
+        links_by_dest_node = {}
+        outgoing_edges = []
         for source_tag, dest_tag in self._node_link_list:
             source_port = self._port_registry.get(source_tag)
             dest_port = self._port_registry.get(dest_tag)
@@ -1331,22 +1331,48 @@ class DpgNodeEditor(object):
             source_node = source_port.node_ref.node_id_name
             dest_node = dest_port.node_ref.node_id_name
             link_type = source_port.data_type
+            links_by_dest_node.setdefault(dest_node, []).append(
+                (source_tag, dest_tag, source_node, dest_node, link_type)
+            )
 
-            if source_node not in deleted_set and dest_node in deleted_set:
-                incoming_by_type.setdefault(link_type, []).append(source_tag)
-            elif source_node in deleted_set and dest_node not in deleted_set:
-                outgoing_by_type.setdefault(link_type, []).append(dest_tag)
+            if source_node in deleted_set and dest_node not in deleted_set:
+                outgoing_edges.append(
+                    (source_tag, dest_tag, source_node, dest_node, link_type)
+                )
+
+        def _find_external_sources(start_deleted_node, link_type):
+            stack = [start_deleted_node]
+            visited = set()
+            boundary_sources = set()
+            while stack:
+                current_node = stack.pop()
+                if current_node in visited:
+                    continue
+                visited.add(current_node)
+                for (
+                    src_tag,
+                    _dst_tag,
+                    src_node,
+                    _cur_dest,
+                    cur_type,
+                ) in links_by_dest_node.get(current_node, []):
+                    if cur_type != link_type:
+                        continue
+                    if src_node in deleted_set:
+                        stack.append(src_node)
+                    else:
+                        boundary_sources.add(src_tag)
+            return boundary_sources
 
         reconnect_pairs = []
-        for link_type, outgoing_destinations in outgoing_by_type.items():
-            incoming_sources = incoming_by_type.get(link_type, [])
+        for _src_tag, dest_tag, source_node, _dest_node, link_type in outgoing_edges:
+            incoming_sources = _find_external_sources(source_node, link_type)
             if len(incoming_sources) != 1:
                 continue
-            source_tag = incoming_sources[0]
-            for dest_tag in outgoing_destinations:
-                if source_tag == dest_tag:
-                    continue
-                reconnect_pairs.append((source_tag, dest_tag))
+            source_tag = next(iter(incoming_sources))
+            if source_tag == dest_tag:
+                continue
+            reconnect_pairs.append((source_tag, dest_tag))
         return reconnect_pairs
 
     def _cntrl_delete_selected(self, sender, data):
@@ -1366,7 +1392,12 @@ class DpgNodeEditor(object):
                 self._vw_register_link(source_tag, dest_tag, link_dpg_id)
 
         for link_dpg_id in selected_link_ids:
-            link = self._cntrl_get_link_from_dpg_id(link_dpg_id)
+            if not dpg.does_item_exist(link_dpg_id):
+                continue
+            try:
+                link = self._cntrl_get_link_from_dpg_id(link_dpg_id)
+            except Exception:
+                continue
             self._mdl_delete_link(link)
             self._link_view_id_map.pop(tuple(link), None)
             self._vw_delete_item(link_dpg_id)

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -1338,20 +1338,7 @@ class DpgNodeEditor(object):
         return reconnect_pairs
 
     def _cntrl_delete_node_by_button(self, sender, data, user_data):
-        delete_callback = (
-            lambda s=None, d=None, tag=user_data:
-            self._cntrl_delete_node_deferred(s, d, tag)
-        )
-        with dpg.mutex():
-            target_frame = dpg.get_frame_count() + 2
-            dpg.set_frame_callback(target_frame, delete_callback)
-
-    def _cntrl_delete_node_deferred(self, sender, data, user_data):
-        node_tag = user_data
-        if (not node_tag) or (not dpg.does_item_exist(node_tag)):
-            return
-
-        reconnect_pairs = self._cntrl_delete_node_by_tag(node_tag)
+        reconnect_pairs = self._cntrl_delete_node_by_tag(user_data)
         for source_tag, dest_tag in reconnect_pairs:
             if self._mdl_add_link(source_tag, dest_tag):
                 link_dpg_id = self._vw_add_link(source_tag, dest_tag)

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -1318,9 +1318,13 @@ class DpgNodeEditor(object):
 
     def _cntrl_delete_selected(self, sender, data):
         selected_nodes = dpg.get_selected_nodes(self._node_editor_tag)
+        selected_node_tags = [dpg.get_item_alias(node_dpg_id) for node_dpg_id in selected_nodes]
+        selected_links = dpg.get_selected_links(self._node_editor_tag)
+        self._cntrl_delete_targets(selected_node_tags, selected_links)
+
+    def _cntrl_delete_targets(self, selected_node_tags, selected_link_ids):
         reconnect_pairs = []
-        for node_dpg_id in selected_nodes:
-            node_tag = dpg.get_item_alias(node_dpg_id)
+        for node_tag in selected_node_tags:
             reconnect_pairs.extend(self._cntrl_delete_node_by_tag(node_tag))
 
         for source_tag, dest_tag in reconnect_pairs:
@@ -1328,8 +1332,7 @@ class DpgNodeEditor(object):
                 link_dpg_id = self._vw_add_link(source_tag, dest_tag)
                 self._vw_register_link(source_tag, dest_tag, link_dpg_id)
 
-        selected_links = dpg.get_selected_links(self._node_editor_tag)
-        for link_dpg_id in selected_links:
+        for link_dpg_id in selected_link_ids:
             link = self._cntrl_get_link_from_dpg_id(link_dpg_id)
             self._mdl_delete_link(link)
             self._link_view_id_map.pop(tuple(link), None)
@@ -1354,22 +1357,16 @@ class DpgNodeEditor(object):
         return reconnect_pairs
 
     def _cntrl_delete_node_by_button(self, sender, data, user_data):
-        # Reuse exactly the same deletion path as the Delete key:
-        # 1) make this node the only selected node in the editor
-        # 2) invoke _cntrl_delete_selected on the next frame
         node_tag = user_data
 
-        def _deferred_delete_selected():
+        def _deferred_delete_node():
             if not node_tag or not dpg.does_item_exist(node_tag):
                 return
-            dpg.clear_selected_nodes(self._node_editor_tag)
-            dpg.clear_selected_links(self._node_editor_tag)
-            dpg.select_node(node_tag)
-            self._cntrl_delete_selected(None, None)
+            self._cntrl_delete_targets([node_tag], [])
 
         dpg.set_frame_callback(
             dpg.get_frame_count() + 1,
-            _deferred_delete_selected,
+            _deferred_delete_node,
         )
 
     # Public functions

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -6,6 +6,7 @@ import json
 import platform
 import datetime
 import re
+from functools import partial
 from glob import glob
 from collections import OrderedDict
 from importlib import import_module
@@ -549,7 +550,8 @@ class DpgNodeEditor(object):
                 attribute_type=dpg.mvNode_Attr_Static,
         ):
             with dpg.group(horizontal=True):
-                dpg.add_spacer(width=120)
+                dpg.add_text(' ')
+                dpg.add_spacer(width=180)
                 dpg.add_button(
                     tag=close_button_tag,
                     label='x',
@@ -1339,8 +1341,7 @@ class DpgNodeEditor(object):
     def _cntrl_delete_node_by_button(self, sender, data, user_data):
         dpg.set_frame_callback(
             dpg.get_frame_count() + 1,
-            self._cntrl_delete_node_deferred,
-            user_data,
+            partial(self._cntrl_delete_node_deferred, user_data=user_data),
         )
 
     def _cntrl_delete_node_deferred(self, sender, data, user_data):

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -1338,18 +1338,23 @@ class DpgNodeEditor(object):
         return reconnect_pairs
 
     def _cntrl_delete_node_by_button(self, sender, data, user_data):
-        # Avoid deleting a node while DearPyGui is still executing one of the
-        # node's child-item callbacks. Defer the destructive work to next frame.
+        # Reuse exactly the same deletion path as the Delete key:
+        # 1) make this node the only selected node in the editor
+        # 2) invoke _cntrl_delete_selected on the next frame
         node_tag = user_data
 
-        def _deferred_delete():
-            reconnect_pairs = self._cntrl_delete_node_by_tag(node_tag)
-            for source_tag, dest_tag in reconnect_pairs:
-                if self._mdl_add_link(source_tag, dest_tag):
-                    link_dpg_id = self._vw_add_link(source_tag, dest_tag)
-                    self._vw_register_link(source_tag, dest_tag, link_dpg_id)
+        def _deferred_delete_selected():
+            if not node_tag or not dpg.does_item_exist(node_tag):
+                return
+            dpg.clear_selected_nodes(self._node_editor_tag)
+            dpg.clear_selected_links(self._node_editor_tag)
+            dpg.select_node(node_tag)
+            self._cntrl_delete_selected(None, None)
 
-        dpg.set_frame_callback(dpg.get_frame_count() + 1, _deferred_delete)
+        dpg.set_frame_callback(
+            dpg.get_frame_count() + 1,
+            _deferred_delete_selected,
+        )
 
     # Public functions
     def get_node_list(self):

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -529,3 +529,27 @@ def test_delete_multiple_nodes_heals_external_path(editor_and_dpg):
     assert '2:TestNode' not in editor._node_list
     assert '3:TestNode' not in editor._node_list
     assert ['1:TestNode:Int:Output01', '4:TestNode:Int:Input01'] in editor._node_link_list
+
+
+def test_delete_multiple_nodes_heals_two_independent_paths(editor_and_dpg):
+    editor, dpg = editor_and_dpg
+    dpg.does_item_exist.return_value = True
+    for _ in range(8):
+        editor._cntrl_add_node(None, None, 'TestNode')
+
+    editor._mdl_add_link('1:TestNode:Int:Output01', '2:TestNode:Int:Input01')
+    editor._mdl_add_link('2:TestNode:Int:Output01', '3:TestNode:Int:Input01')
+    editor._mdl_add_link('3:TestNode:Int:Output01', '4:TestNode:Int:Input01')
+
+    editor._mdl_add_link('5:TestNode:Int:Output01', '6:TestNode:Int:Input01')
+    editor._mdl_add_link('6:TestNode:Int:Output01', '7:TestNode:Int:Input01')
+    editor._mdl_add_link('7:TestNode:Int:Output01', '8:TestNode:Int:Input01')
+
+    dpg.get_selected_nodes.return_value = [
+        '2:TestNode', '3:TestNode', '6:TestNode', '7:TestNode'
+    ]
+    dpg.get_selected_links.return_value = []
+    editor._cntrl_delete_selected(None, None)
+
+    assert ['1:TestNode:Int:Output01', '4:TestNode:Int:Input01'] in editor._node_link_list
+    assert ['5:TestNode:Int:Output01', '8:TestNode:Int:Input01'] in editor._node_link_list

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -553,3 +553,14 @@ def test_delete_multiple_nodes_heals_two_independent_paths(editor_and_dpg):
 
     assert ['1:TestNode:Int:Output01', '4:TestNode:Int:Input01'] in editor._node_link_list
     assert ['5:TestNode:Int:Output01', '8:TestNode:Int:Input01'] in editor._node_link_list
+
+
+def test_delete_selected_ignores_stale_selected_link_ids(editor_and_dpg):
+    editor, dpg = editor_and_dpg
+    dpg.get_selected_nodes.return_value = []
+    dpg.get_selected_links.return_value = [273]
+    dpg.does_item_exist.return_value = False
+
+    editor._cntrl_delete_selected(None, None)
+
+    assert editor._node_link_list == []

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -508,3 +508,24 @@ def test_set_get_terminate_flag(editor_and_dpg):
     assert editor.get_terminate_flag() is True
     editor.set_terminate_flag(False)
     assert editor.get_terminate_flag() is False
+
+
+def test_delete_multiple_nodes_heals_external_path(editor_and_dpg):
+    editor, dpg = editor_and_dpg
+    dpg.does_item_exist.return_value = True
+    editor._cntrl_add_node(None, None, 'TestNode')  # 1
+    editor._cntrl_add_node(None, None, 'TestNode')  # 2
+    editor._cntrl_add_node(None, None, 'TestNode')  # 3
+    editor._cntrl_add_node(None, None, 'TestNode')  # 4
+
+    editor._mdl_add_link('1:TestNode:Int:Output01', '2:TestNode:Int:Input01')
+    editor._mdl_add_link('2:TestNode:Int:Output01', '3:TestNode:Int:Input01')
+    editor._mdl_add_link('3:TestNode:Int:Output01', '4:TestNode:Int:Input01')
+
+    dpg.get_selected_nodes.return_value = ['2:TestNode', '3:TestNode']
+    dpg.get_selected_links.return_value = []
+    editor._cntrl_delete_selected(None, None)
+
+    assert '2:TestNode' not in editor._node_list
+    assert '3:TestNode' not in editor._node_list
+    assert ['1:TestNode:Int:Output01', '4:TestNode:Int:Input01'] in editor._node_link_list

--- a/tests/unit/test_node_editor_import_export.py
+++ b/tests/unit/test_node_editor_import_export.py
@@ -482,3 +482,37 @@ class TestDpgNodeEditorImportExport:
         # and it should connect the two imported IDs
         src_id, dst_id = [int(x.split(':')[0]) for x in imported_links[0]]
         assert {src_id, dst_id} == set(new_ids)
+
+    def test_delete_linked_node_after_import_with_missing_port_registry(
+        self,
+        node_editor,
+        mock_dpg,
+        mock_node_instance,
+        tmp_path,
+    ):
+        imported = {
+            'node_list': ['1:test_node', '2:test_node'],
+            'link_list': [['1:test_node:output', '2:test_node:input']],
+            '1:test_node': {
+                'id': '1', 'name': 'test_node',
+                'setting': {'ver': '1.0.0', 'pos': [10, 20]}
+            },
+            '2:test_node': {
+                'id': '2', 'name': 'test_node',
+                'setting': {'ver': '1.0.0', 'pos': [30, 40]}
+            }
+        }
+        path = tmp_path / "legacy_links.json"
+        path.write_text(json.dumps(imported))
+        node_editor._cntrl_file_import(
+            None, {'file_name': path.name, 'file_path_name': str(path)}
+        )
+
+        node_editor._port_registry.clear()
+        mock_dpg.get_selected_nodes.return_value = ['1:test_node']
+        mock_dpg.get_selected_links.return_value = []
+        node_editor._cntrl_delete_selected(None, None)
+
+        assert '1:test_node' not in node_editor._node_list
+        assert node_editor._node_link_list == []
+        assert node_editor._link_registry == {}


### PR DESCRIPTION
### Motivation
- Provide a UI affordance to close/delete individual nodes from the node editor and centralize deletion behavior to avoid duplicated logic and errors when items don't exist.

### Description
- Added new suffix constants `_node_close_attr_suffix` and `_node_close_button_suffix` for close-button element tags.
- Updated `_vw_add_node` to capture the created `node_view_tag`, skip adding a close button for the `ExecPythonCode` node, remove any pre-existing close attribute element, and add a static node attribute containing a small close `button` with callback `._cntrl_delete_node_by_button`.
- Replaced inline deletion logic in `_cntrl_delete_selected` with a call to the new helper `._cntrl_delete_node_by_tag` that computes reconnection pairs and performs model and view deletions safely (checking for existence before deleting).
- Added `._cntrl_delete_node_by_button` which invokes `._cntrl_delete_node_by_tag` for the clicked node and re-creates any necessary reconnect links via existing model/view link helpers.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1346aa9790832387911ef5032e0b9f)