### PR TITLE
Add typed Node/Port registries and robust link handling with import compatibility

### DIFF
--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -10,8 +10,28 @@ from glob import glob
 from collections import OrderedDict
 from importlib import import_module
 from pathlib import Path
+from dataclasses import dataclass
 
 import dearpygui.dearpygui as dpg
+
+
+@dataclass(frozen=True)
+class NodeRef:
+    node_id: str
+    node_tag: str
+
+    @property
+    def node_id_name(self):
+        return f'{self.node_id}:{self.node_tag}'
+
+
+@dataclass(frozen=True)
+class PortRef:
+    node_ref: NodeRef
+    direction: str
+    data_type: str
+    index: int
+    dpg_tag: str
 
 
 class DpgNodeEditor(object):
@@ -66,6 +86,10 @@ class DpgNodeEditor(object):
         self._pending_insert_link_dpg_id = None
         self._pending_add_from_output_tag = None
         self._node_port_capabilities = {}
+        self._node_registry = {}
+        self._port_registry = {}
+        self._link_registry = {}
+        self._link_by_dest_port = {}
         self._use_debug_print = use_debug_print
         self._terminate_flag = False
         self._opencv_setting_dict = opencv_setting_dict
@@ -75,16 +99,59 @@ class DpgNodeEditor(object):
         new_node_id_name = f"{self._node_id}:{node_tag}"
         return self._node_id, new_node_id_name
 
+    def _mdl_register_node_ref(self, node_ref):
+        self._node_registry[node_ref.node_id_name] = node_ref
+
+    def _mdl_get_node_ref(self, node_id_name):
+        return self._node_registry.get(node_id_name)
+
+    def _cntrl_parse_port_tag(self, port_tag):
+        if not isinstance(port_tag, str):
+            return None
+        if port_tag in self._port_registry:
+            return self._port_registry[port_tag]
+        parts = port_tag.split(':')
+        if len(parts) < 4:
+            return None
+        node_ref = NodeRef(parts[0], parts[1])
+        port_name = parts[3]
+        if port_name.startswith('Input'):
+            direction = 'Input'
+            index_text = port_name[len('Input'):]
+        elif port_name.startswith('Output'):
+            direction = 'Output'
+            index_text = port_name[len('Output'):]
+        else:
+            return None
+        try:
+            index = int(index_text)
+        except ValueError:
+            return None
+        parsed = PortRef(node_ref, direction, parts[2], index, port_tag)
+        self._port_registry[port_tag] = parsed
+        if node_ref.node_id_name not in self._node_registry:
+            self._mdl_register_node_ref(node_ref)
+        return parsed
+
     def _mdl_add_link(self, source_tag, dest_tag):
-        if any(dest_tag == d_tag for _, d_tag in self._node_link_list):
+        source_port = self._cntrl_parse_port_tag(source_tag)
+        dest_port = self._cntrl_parse_port_tag(dest_tag)
+        existing_link = self._mdl_get_link_by_destination(dest_tag)
+        if existing_link is not None:
             return False
         self._node_link_list.append([source_tag, dest_tag])
+        if source_port is not None and dest_port is not None:
+            self._link_registry[(source_tag, dest_tag)] = (source_port, dest_port)
+            self._link_by_dest_port[dest_tag] = source_tag
         return True
 
     def _mdl_get_link_by_destination(self, dest_tag):
-        for link in self._node_link_list:
-            if link[1] == dest_tag:
-                return link
+        source_tag = self._link_by_dest_port.get(dest_tag)
+        if source_tag is not None:
+            return [source_tag, dest_tag]
+        for source_tag, link_dest_tag in self._node_link_list:
+            if link_dest_tag == dest_tag:
+                return [source_tag, link_dest_tag]
         return None
 
     def _mdl_get_export_settings(self):
@@ -112,13 +179,23 @@ class DpgNodeEditor(object):
 
         copy_node_link_list = copy.deepcopy(self._node_link_list)
         for link_info in copy_node_link_list:
-            source_node = ':'.join(link_info[0].split(':')[:2])
-            destination_node = ':'.join(link_info[1].split(':')[:2])
+            source_port = self._port_registry.get(link_info[0])
+            dest_port = self._port_registry.get(link_info[1])
+            source_node = source_port.node_ref.node_id_name if source_port else \
+                ':'.join(link_info[0].split(':')[:2])
+            destination_node = dest_port.node_ref.node_id_name if dest_port else \
+                ':'.join(link_info[1].split(':')[:2])
             if source_node == node_id_name or destination_node == node_id_name:
+                self._link_registry.pop((link_info[0], link_info[1]), None)
+                self._link_by_dest_port.pop(link_info[1], None)
                 self._node_link_list.remove(link_info)
+        self._node_registry.pop(node_id_name, None)
         self._mdl_sort_node_graph()
 
     def _mdl_delete_link(self, link):
+        source_tag, dest_tag = link
+        self._link_registry.pop((source_tag, dest_tag), None)
+        self._link_by_dest_port.pop(dest_tag, None)
         self._node_link_list.remove(link)
         self._mdl_sort_node_graph()
 
@@ -463,9 +540,13 @@ class DpgNodeEditor(object):
     def _vw_delete_links_for_node(self, node_id_name):
         delete_targets = []
         for source_tag, dest_tag in self._link_view_id_map:
-            source_node = ':'.join(source_tag.split(':')[:2])
-            dest_node = ':'.join(dest_tag.split(':')[:2])
-            if source_node == node_id_name or dest_node == node_id_name:
+            source_port = self._port_registry.get(source_tag)
+            dest_port = self._port_registry.get(dest_tag)
+            source_node_id_name = source_port.node_ref.node_id_name if source_port else \
+                ':'.join(source_tag.split(':')[:2])
+            dest_node_id_name = dest_port.node_ref.node_id_name if dest_port else \
+                ':'.join(dest_tag.split(':')[:2])
+            if source_node_id_name == node_id_name or dest_node_id_name == node_id_name:
                 delete_targets.append((source_tag, dest_tag))
 
         for source_tag, dest_tag in delete_targets:
@@ -559,6 +640,7 @@ class DpgNodeEditor(object):
 
     def _cntrl_add_node(self, sender, data, user_data):
         new_id, new_node_id_name = self._mdl_add_node(user_data)
+        self._mdl_register_node_ref(NodeRef(str(new_id), user_data))
         pos = [0, 0]
         if self._last_pos is not None:
             pos = [self._last_pos[0] + 30, self._last_pos[1] + 30]
@@ -611,6 +693,7 @@ class DpgNodeEditor(object):
                 return
             source_pos = dpg.get_item_pos(source_node_id_name)
             new_id, new_node_id_name = self._mdl_add_node(result_node_tag)
+            self._mdl_register_node_ref(NodeRef(str(new_id), result_node_tag))
             result_pos = [source_pos[0] + 260, source_pos[1]]
             self._vw_add_node(result_node_tag, new_id, result_pos)
             self._node_list.append(new_node_id_name)
@@ -641,9 +724,9 @@ class DpgNodeEditor(object):
         for source_tag, dest_tag in self._node_link_list:
             if source_tag != source_output_tag:
                 continue
-            dest_node_id_name = ':'.join(dest_tag.split(':')[:2])
-            if dest_node_id_name.endswith(f':{result_node_tag}'):
-                return dest_node_id_name
+            dest_port = self._port_registry.get(dest_tag)
+            if dest_port and dest_port.node_ref.node_tag == result_node_tag:
+                return dest_port.node_ref.node_id_name
         return None
 
     def _cntrl_get_link_from_dpg_id(self, link_dpg_id):
@@ -661,8 +744,10 @@ class DpgNodeEditor(object):
         if output_port_tag is not None:
             self._pending_insert_link_dpg_id = None
             self._vw_hide_insert_link_popup()
-            source_type = output_port_tag.split(':')[2]
-            self._vw_populate_append_popup_menu(source_type)
+            source_port = self._cntrl_parse_port_tag(output_port_tag)
+            self._vw_populate_append_popup_menu(
+                source_port.data_type if source_port else ''
+            )
             mouse_pos = dpg.get_mouse_pos(local=False)
             window_pos = dpg.get_item_pos(self._window_tag)
             popup_pos = [
@@ -677,10 +762,14 @@ class DpgNodeEditor(object):
         self._pending_insert_link_dpg_id = link_dpg_id
         if link_dpg_id is not None:
             source_tag, dest_tag = self._cntrl_get_link_from_dpg_id(link_dpg_id)
-            source_parts = source_tag.split(':')
-            dest_parts = dest_tag.split(':')
-            if len(source_parts) >= 4 and len(dest_parts) >= 4 and source_parts[2] == dest_parts[2]:
-                self._vw_populate_insert_popup_menu(source_parts[2])
+            source_port = self._cntrl_parse_port_tag(source_tag)
+            dest_port = self._cntrl_parse_port_tag(dest_tag)
+            if (
+                source_port is not None
+                and dest_port is not None
+                and source_port.data_type == dest_port.data_type
+            ):
+                self._vw_populate_insert_popup_menu(source_port.data_type)
             else:
                 self._vw_populate_insert_popup_menu('')
             mouse_pos = dpg.get_mouse_pos(local=False)
@@ -773,14 +862,15 @@ class DpgNodeEditor(object):
             self._vw_set_link_feedback('Create from output requires a hovered output port.')
             return
 
-        source_parts = source_tag.split(':')
-        if len(source_parts) < 4:
+        source_port = self._cntrl_parse_port_tag(source_tag)
+        if source_port is None:
             self._vw_set_link_feedback('Cannot create from output: invalid source port tag format.')
             return
 
-        link_type = source_parts[2]
+        link_type = source_port.data_type
         new_id, new_node_id_name = self._mdl_add_node(user_data)
-        source_node = ':'.join(source_tag.split(':')[:2])
+        self._mdl_register_node_ref(NodeRef(str(new_id), user_data))
+        source_node = source_port.node_ref.node_id_name
         source_pos = dpg.get_item_pos(source_node)
         new_pos = [source_pos[0] + 260, source_pos[1]]
         self._vw_add_node(user_data, new_id, new_pos)
@@ -821,16 +911,16 @@ class DpgNodeEditor(object):
         source_tag, dest_tag = self._cntrl_get_link_from_dpg_id(
             selected_link_dpg_id
         )
-        source_parts = source_tag.split(':')
-        dest_parts = dest_tag.split(':')
-        if len(source_parts) < 4 or len(dest_parts) < 4:
+        source_port = self._cntrl_parse_port_tag(source_tag)
+        dest_port = self._cntrl_parse_port_tag(dest_tag)
+        if source_port is None or dest_port is None:
             self._vw_set_link_feedback(
                 'Cannot insert node into link: invalid port tag format.'
             )
             return
 
-        link_type = source_parts[2]
-        if link_type != dest_parts[2]:
+        link_type = source_port.data_type
+        if link_type != dest_port.data_type:
             self._vw_set_link_feedback(
                 'Cannot insert node into link: source and destination '
                 'types do not match.'
@@ -838,6 +928,7 @@ class DpgNodeEditor(object):
             return
 
         new_id, new_node_id_name = self._mdl_add_node(user_data)
+        self._mdl_register_node_ref(NodeRef(str(new_id), user_data))
         insert_pos = self._cntrl_get_insert_node_pos(source_tag, dest_tag)
         self._vw_add_node(user_data, new_id, insert_pos)
         self._node_list.append(new_node_id_name)
@@ -902,16 +993,16 @@ class DpgNodeEditor(object):
             )
             return
 
-        source_parts = source_tag.split(':')
-        dest_parts = dest_tag.split(':')
-        if len(source_parts) < 4 or len(dest_parts) < 4:
+        source_port = self._cntrl_parse_port_tag(source_tag)
+        dest_port = self._cntrl_parse_port_tag(dest_tag)
+        if source_port is None or dest_port is None:
             self._vw_set_link_feedback(
                 'Link rejected: invalid port tag format.'
             )
             return
 
-        source_type = source_parts[2]
-        dest_type = dest_parts[2]
+        source_type = source_port.data_type
+        dest_type = dest_port.data_type
 
         if source_type != dest_type:
             self._vw_set_link_feedback(
@@ -993,6 +1084,7 @@ class DpgNodeEditor(object):
             node = self._node_instance_list[node_name]
 
             new_id, _ = self._mdl_add_node(node_name)
+            self._mdl_register_node_ref(NodeRef(str(new_id), node_name))
             id_map[old_id] = str(new_id)
 
             ver = setting_dict[node_id_name]['setting']['ver']
@@ -1028,11 +1120,19 @@ class DpgNodeEditor(object):
                 dest_parts[0] = id_map[dest_parts[0]]
                 new_source = ':'.join(source_parts)
                 new_destination = ':'.join(dest_parts)
-                link_dpg_id = self._vw_add_link(new_source, new_destination)
-                self._vw_register_link(new_source, new_destination, link_dpg_id)
-                new_link_list.append([new_source, new_destination])
+                if self._mdl_add_link(new_source, new_destination):
+                    link_dpg_id = self._vw_add_link(new_source, new_destination)
+                    self._vw_register_link(new_source, new_destination, link_dpg_id)
+                    new_link_list.append([new_source, new_destination])
+                elif [new_source, new_destination] not in self._node_link_list:
+                    # Backward compatibility:
+                    # preserve serialized links even when they violate the
+                    # editor's single-input runtime constraint.
+                    self._node_link_list.append([new_source, new_destination])
+                    link_dpg_id = self._vw_add_link(new_source, new_destination)
+                    self._vw_register_link(new_source, new_destination, link_dpg_id)
+                    new_link_list.append([new_source, new_destination])
 
-        self._node_link_list.extend(new_link_list)
         self._mdl_sort_node_graph()
 
     def _cntrl_file_import(self, sender, data):
@@ -1057,17 +1157,14 @@ class DpgNodeEditor(object):
         outgoing_by_type = {}
 
         for source_tag, dest_tag in self._node_link_list:
-            dest_node = ':'.join(dest_tag.split(':')[:2])
-            source_node = ':'.join(source_tag.split(':')[:2])
-
-            if dest_node == node_id_name:
-                parts = dest_tag.split(':')
-                if len(parts) >= 4:
-                    incoming_by_type.setdefault(parts[2], []).append(source_tag)
-            elif source_node == node_id_name:
-                parts = source_tag.split(':')
-                if len(parts) >= 4:
-                    outgoing_by_type.setdefault(parts[2], []).append(dest_tag)
+            source_port = self._port_registry.get(source_tag)
+            dest_port = self._port_registry.get(dest_tag)
+            if source_port is None or dest_port is None:
+                continue
+            if dest_port.node_ref.node_id_name == node_id_name:
+                incoming_by_type.setdefault(dest_port.data_type, []).append(source_tag)
+            elif source_port.node_ref.node_id_name == node_id_name:
+                outgoing_by_type.setdefault(source_port.data_type, []).append(dest_tag)
 
         reconnect_pairs = []
         for link_type, outgoing_destinations in outgoing_by_type.items():

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -23,7 +23,15 @@ class DummyNode:
     node_tag = 'TestNode'
     node_label = 'Test Node'
 
-    def add_node(self, parent, node_id, pos=None, opencv_setting_dict=None):
+    def add_node(
+        self,
+        parent,
+        node_id,
+        pos=None,
+        opencv_setting_dict=None,
+        callback=None,
+    ):
+        del callback
         return f"{node_id}:{self.node_tag}"
 
     def update(self, node_id, connection_list, img_dict, res_dict):
@@ -106,7 +114,36 @@ def test_link_callback_basic(editor_and_dpg):
     link_ids = [101, 102]
     editor._cntrl_link('NodeEditor', link_ids)
     assert editor._node_link_list == [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
+    assert ('1:TestNode:Int:Output01', '2:TestNode:Int:Input01') in editor._link_registry
+    assert editor._link_by_dest_port['2:TestNode:Int:Input01'] == '1:TestNode:Int:Output01'
     dpg.add_node_link.assert_called_once_with(101, 102, parent='NodeEditor')
+
+
+def test_parse_port_tag_returns_typed_metadata(editor_and_dpg):
+    editor, _ = editor_and_dpg
+    port = editor._cntrl_parse_port_tag('7:TestNode:Float:Input03')
+    assert port is not None
+    assert port.node_ref.node_id == '7'
+    assert port.node_ref.node_tag == 'TestNode'
+    assert port.node_ref.node_id_name == '7:TestNode'
+    assert port.direction == 'Input'
+    assert port.data_type == 'Float'
+    assert port.index == 3
+    assert editor._port_registry['7:TestNode:Float:Input03'] == port
+
+
+def test_delete_link_updates_typed_registries(editor_and_dpg):
+    editor, _ = editor_and_dpg
+    source_tag = '1:TestNode:Int:Output01'
+    dest_tag = '2:TestNode:Int:Input01'
+    assert editor._mdl_add_link(source_tag, dest_tag) is True
+    assert editor._mdl_get_link_by_destination(dest_tag) == [source_tag, dest_tag]
+
+    editor._mdl_delete_link([source_tag, dest_tag])
+
+    assert editor._mdl_get_link_by_destination(dest_tag) is None
+    assert (source_tag, dest_tag) not in editor._link_registry
+    assert dest_tag not in editor._link_by_dest_port
 
 
 def test_link_prevents_duplicate_dest(editor_and_dpg):
@@ -215,13 +252,24 @@ def test_insert_node_into_selected_link(editor_and_dpg):
         102: '2:TestNode:Int:Input01',
     }.get
     dpg.get_selected_links.return_value = ['existing-link']
-    dpg.get_item_configuration.return_value = {'attr_1': 101, 'attr_2': 102}
+    def config_side_effect(tag):
+        if tag == 'existing-link':
+            return {'attr_1': 101, 'attr_2': 102}
+        if tag == '3:TestNode:Int:Input01':
+            return {'attribute_type': dpg.mvNode_Attr_Input}
+        if tag == '3:TestNode:Int:Output01':
+            return {'attribute_type': dpg.mvNode_Attr_Output}
+        return {}
+
+    dpg.get_item_configuration.side_effect = config_side_effect
     dpg.get_item_pos.side_effect = {
         '1:TestNode': [0, 0],
         '2:TestNode': [120, 60],
     }.get
     dpg.does_item_exist.side_effect = (
         lambda tag: tag in {
+            '1:TestNode:Int:Output01',
+            '2:TestNode:Int:Input01',
             '3:TestNode:Int:Input01',
             '3:TestNode:Int:Output01',
         }
@@ -230,7 +278,7 @@ def test_insert_node_into_selected_link(editor_and_dpg):
 
     editor._cntrl_add_node(None, None, 'TestNode')
     editor._cntrl_add_node(None, None, 'TestNode')
-    editor._node_link_list = [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
+    editor._mdl_add_link('1:TestNode:Int:Output01', '2:TestNode:Int:Input01')
     editor._link_view_id_map = {
         ('1:TestNode:Int:Output01', '2:TestNode:Int:Input01'): 'existing-link'
     }
@@ -275,6 +323,11 @@ def test_insert_node_into_selected_link_requires_selection(editor_and_dpg):
 def test_open_insert_link_popup_on_right_click_with_single_selection(editor_and_dpg):
     editor, dpg = editor_and_dpg
     dpg.get_selected_links.return_value = ['existing-link']
+    dpg.get_item_configuration.return_value = {'attr_1': 101, 'attr_2': 102}
+    dpg.get_item_alias.side_effect = {
+        101: '1:TestNode:Int:Output01',
+        102: '2:TestNode:Int:Input01',
+    }.get
     dpg.get_mouse_pos.return_value = [128.3, 255.9]
 
     editor._cntrl_open_insert_link_popup(None, None)
@@ -288,6 +341,11 @@ def test_open_insert_link_popup_on_hovered_link(editor_and_dpg):
     editor._link_view_id_map = {
         ('1:TestNode:Int:Output01', '2:TestNode:Int:Input01'): 'link-1'
     }
+    dpg.get_item_configuration.return_value = {'attr_1': 101, 'attr_2': 102}
+    dpg.get_item_alias.side_effect = {
+        101: '1:TestNode:Int:Output01',
+        102: '2:TestNode:Int:Input01',
+    }.get
     dpg.get_selected_links.return_value = []
     dpg.is_item_hovered.side_effect = lambda item: item == 'link-1'
     dpg.get_mouse_pos.return_value = [10, 20]
@@ -310,7 +368,7 @@ def test_insert_node_into_selected_link_uses_pending_hovered_link(editor_and_dpg
     }
     dpg.add_node_link.side_effect = ['new-link-1', 'new-link-2']
     editor._pending_insert_link_dpg_id = 'existing-link'
-    editor._node_link_list = [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
+    editor._mdl_add_link('1:TestNode:Int:Output01', '2:TestNode:Int:Input01')
     editor._link_view_id_map = {
         ('1:TestNode:Int:Output01', '2:TestNode:Int:Input01'): 'existing-link'
     }
@@ -424,7 +482,7 @@ def test_delete_node(editor_and_dpg):
     editor, dpg = editor_and_dpg
     editor._cntrl_add_node(None, None, 'TestNode')
     editor._cntrl_add_node(None, None, 'TestNode')
-    editor._node_link_list = [['1:TestNode:Output01', '2:TestNode:Input01']]
+    editor._mdl_add_link('1:TestNode:Int:Output01', '2:TestNode:Int:Input01')
     dpg.get_selected_nodes.return_value = ['1:TestNode']
     editor._cntrl_delete_selected(None, None)
     assert '1:TestNode' not in editor._node_list
@@ -450,3 +508,28 @@ def test_set_get_terminate_flag(editor_and_dpg):
     assert editor.get_terminate_flag() is True
     editor.set_terminate_flag(False)
     assert editor.get_terminate_flag() is False
+
+
+def test_delete_linked_node_after_import_keeps_registries_consistent(editor_and_dpg):
+    editor, dpg = editor_and_dpg
+    dpg.does_item_exist.return_value = True
+
+    setting_dict = {
+        'node_list': ['1:TestNode', '2:TestNode'],
+        'link_list': [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']],
+        '1:TestNode': {'setting': {'ver': '1.0', 'pos': [0, 0]}, 'name': 'TestNode'},
+        '2:TestNode': {'setting': {'ver': '1.0', 'pos': [100, 0]}, 'name': 'TestNode'},
+    }
+    editor._cntrl_import_setting_dict(setting_dict)
+
+    assert editor._node_link_list == [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
+    assert editor._mdl_get_link_by_destination('2:TestNode:Int:Input01') == [
+        '1:TestNode:Int:Output01', '2:TestNode:Int:Input01'
+    ]
+
+    dpg.get_selected_nodes.return_value = ['1:TestNode']
+    editor._cntrl_delete_selected(None, None)
+
+    assert '1:TestNode' not in editor._node_list
+    assert editor._node_link_list == []
+    assert editor._mdl_get_link_by_destination('2:TestNode:Int:Input01') is None


### PR DESCRIPTION
### Motivation

- Improve robustness of node/port/link management by tracking typed metadata rather than relying on string splits.  
- Centralize and cache node and port references for safer operations during link/node insertion, deletion, and UI callbacks.  
- Preserve backwards compatibility when importing serialized graphs that may violate runtime single-input constraints.

### Description

- Add frozen dataclasses `NodeRef` and `PortRef` and registries `_node_registry`, `_port_registry`, `_link_registry`, and `_link_by_dest_port` to cache typed metadata and accelerate lookups.  
- Implement `_cntrl_parse_port_tag` to parse a port alias into a `PortRef` (and register it) and use it throughout link/node operations instead of naive `split(':')` parsing.  
- Update link lifecycle logic (`_mdl_add_link`, `_mdl_delete_link`, `_mdl_get_link_by_destination`, `_mdl_delete_node`, `_vw_delete_links_for_node`, `_cntrl_link`, `_cntrl_insert_node_into_selected_link`, `_cntrl_add_node_from_output_port`, `_cntrl_find_linked_result_node`, `_cntrl_reconnect_through_node`) to consult typed metadata and maintain the new registries.  
- Make import logic (`_cntrl_import_setting_dict`) register new `NodeRef`s and preserve serialized links when `_mdl_add_link` refuses them (for backward compatibility), while still creating visual links in the editor.  
- Update and extend unit tests in `tests/unit/test_node_editor_core.py` to cover parsing, registry updates, import behaviors, and to adapt mocks to the typed API changes.

### Testing

- Ran the unit test module with `pytest tests/unit/test_node_editor_core.py` which was extended to include `test_parse_port_tag_returns_typed_metadata`, `test_delete_link_updates_typed_registries`, and `test_delete_linked_node_after_import_keeps_registries_consistent`.  
- Existing link/node behavior tests were updated to use the new parsing/registry semantics and UI mocks, and the full test file passed under the updated mocks.  
- All automated tests in the modified unit file completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12795281a48323a33ad46944463a86)