### PR TITLE
Begin typed port registry behavior coverage

### DIFF
--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -132,6 +132,32 @@ class DpgNodeEditor(object):
     def _mdl_get_node_ref(self, node_id_name):
         return self._node_registry.get(node_id_name)
 
+    def _mdl_register_port_ref(self, port_ref):
+        self._port_registry[port_ref.dpg_tag] = port_ref
+        if port_ref.node_ref.node_id_name not in self._node_registry:
+            self._mdl_register_node_ref(port_ref.node_ref)
+
+    def _mdl_iter_registered_ports(
+        self, node_id_name=None, data_type=None, direction=None
+    ):
+        ports = sorted(
+            self._port_registry.values(),
+            key=lambda port: (
+                port.node_ref.node_id_name,
+                port.direction,
+                port.data_type,
+                port.index,
+            ),
+        )
+        for port in ports:
+            if node_id_name is not None and port.node_ref.node_id_name != node_id_name:
+                continue
+            if data_type is not None and port.data_type != data_type:
+                continue
+            if direction is not None and port.direction != direction:
+                continue
+            yield port
+
     def _cntrl_parse_port_tag(self, port_tag):
         if not isinstance(port_tag, str):
             return None
@@ -155,9 +181,7 @@ class DpgNodeEditor(object):
         except ValueError:
             return None
         parsed = PortRef(node_ref, direction, parts[2], index, port_tag)
-        self._port_registry[port_tag] = parsed
-        if node_ref.node_id_name not in self._node_registry:
-            self._mdl_register_node_ref(node_ref)
+        self._mdl_register_port_ref(parsed)
         return parsed
 
     def _mdl_validate_link(self, source_tag, dest_tag):
@@ -1214,7 +1238,16 @@ class DpgNodeEditor(object):
         return None
 
 
-    def _cntrl_get_hovered_output_port_tag(self):
+    def _cntrl_get_hovered_registered_port_tag(self, direction):
+        node_ids = set(self._node_list)
+        for port in self._mdl_iter_registered_ports(direction=direction):
+            if node_ids and port.node_ref.node_id_name not in node_ids:
+                continue
+            if dpg.does_item_exist(port.dpg_tag) and dpg.is_item_hovered(port.dpg_tag):
+                return port.dpg_tag
+        return None
+
+    def _cntrl_get_hovered_legacy_port_tag(self, direction):
         for node_id_name in self._node_list:
             parts = node_id_name.split(':')
             if len(parts) < 2:
@@ -1222,31 +1255,33 @@ class DpgNodeEditor(object):
             node_id = parts[0]
             node_name = parts[1]
             for index in range(100):
-                port_tag = f'{node_id}:{node_name}:Image:Output{index:02d}'
+                port_tag = f'{node_id}:{node_name}:Image:{direction}{index:02d}'
                 if dpg.does_item_exist(port_tag) and dpg.is_item_hovered(port_tag):
+                    self._cntrl_parse_port_tag(port_tag)
                     return port_tag
                 for port_type in ('Int', 'Float', 'Text', 'Time', 'TimeMs', 'TimeMS'):
-                    type_port_tag = f'{node_id}:{node_name}:{port_type}:Output{index:02d}'
-                    if dpg.does_item_exist(type_port_tag) and dpg.is_item_hovered(type_port_tag):
+                    type_port_tag = (
+                        f'{node_id}:{node_name}:{port_type}:{direction}{index:02d}'
+                    )
+                    if (
+                        dpg.does_item_exist(type_port_tag)
+                        and dpg.is_item_hovered(type_port_tag)
+                    ):
+                        self._cntrl_parse_port_tag(type_port_tag)
                         return type_port_tag
         return None
 
+    def _cntrl_get_hovered_output_port_tag(self):
+        port_tag = self._cntrl_get_hovered_registered_port_tag('Output')
+        if port_tag is not None:
+            return port_tag
+        return self._cntrl_get_hovered_legacy_port_tag('Output')
+
     def _cntrl_get_hovered_input_port_tag(self):
-        for node_id_name in self._node_list:
-            parts = node_id_name.split(':')
-            if len(parts) < 2:
-                continue
-            node_id = parts[0]
-            node_name = parts[1]
-            for index in range(100):
-                port_tag = f'{node_id}:{node_name}:Image:Input{index:02d}'
-                if dpg.does_item_exist(port_tag) and dpg.is_item_hovered(port_tag):
-                    return port_tag
-                for port_type in ('Int', 'Float', 'Text', 'Time', 'TimeMs', 'TimeMS'):
-                    type_port_tag = f'{node_id}:{node_name}:{port_type}:Input{index:02d}'
-                    if dpg.does_item_exist(type_port_tag) and dpg.is_item_hovered(type_port_tag):
-                        return type_port_tag
-        return None
+        port_tag = self._cntrl_get_hovered_registered_port_tag('Input')
+        if port_tag is not None:
+            return port_tag
+        return self._cntrl_get_hovered_legacy_port_tag('Input')
 
     def _cntrl_get_insert_node_pos(self, source_tag, dest_tag):
         source_node = ':'.join(source_tag.split(':')[:2])
@@ -1266,18 +1301,29 @@ class DpgNodeEditor(object):
         elif port_prefix == 'Output':
             expected_attr_type = dpg.mvNode_Attr_Output
 
+        def port_exists_with_expected_type(port_tag):
+            if not dpg.does_item_exist(port_tag):
+                return False
+            if expected_attr_type is None:
+                return True
+            config = dpg.get_item_configuration(port_tag)
+            return config.get('attribute_type') == expected_attr_type
+
+        for port in self._mdl_iter_registered_ports(
+            node_id_name=node_id_name,
+            data_type=port_type,
+            direction=port_prefix,
+        ):
+            if port_exists_with_expected_type(port.dpg_tag):
+                return port.dpg_tag
+
         for index in range(100):
             port_tag = (
                 f'{node_id_name}:{port_type}:{port_prefix}{index:02d}'
             )
-            if not dpg.does_item_exist(port_tag):
-                continue
-
-            if expected_attr_type is not None:
-                config = dpg.get_item_configuration(port_tag)
-                if config.get('attribute_type') != expected_attr_type:
-                    continue
-            return port_tag
+            if port_exists_with_expected_type(port_tag):
+                self._cntrl_parse_port_tag(port_tag)
+                return port_tag
         return None
 
 

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -11,6 +11,8 @@ from node_editor.node_editor import (
     AddNodeCommand,
     CompositeCommand,
     DpgNodeEditor,
+    NodeRef,
+    PortRef,
     RemoveLinkCommand,
     SetParameterCommand,
 )
@@ -136,6 +138,43 @@ def test_parse_port_tag_returns_typed_metadata(editor_and_dpg):
     assert port.data_type == 'Float'
     assert port.index == 3
     assert editor._port_registry['7:TestNode:Float:Input03'] == port
+
+
+def test_registered_hovered_output_port_beyond_legacy_scan_range(editor_and_dpg):
+    editor, dpg = editor_and_dpg
+    port_tag = '1:TestNode:Float:Output123'
+    editor._node_list = ['1:TestNode']
+    port = PortRef(NodeRef('1', 'TestNode'), 'Output', 'Float', 123, port_tag)
+    editor._mdl_register_port_ref(port)
+    dpg.does_item_exist.side_effect = lambda tag: tag == port_tag
+    dpg.is_item_hovered.side_effect = lambda tag: tag == port_tag
+
+    assert editor._cntrl_get_hovered_output_port_tag() == port_tag
+    assert editor._cntrl_get_hovered_input_port_tag() is None
+
+
+def test_registered_find_node_port_uses_typed_registry_before_string_scan(editor_and_dpg):
+    editor, dpg = editor_and_dpg
+    port_tag = '2:TestNode:Int:Input123'
+    port = PortRef(NodeRef('2', 'TestNode'), 'Input', 'Int', 123, port_tag)
+    editor._mdl_register_port_ref(port)
+    dpg.does_item_exist.side_effect = lambda tag: tag == port_tag
+    dpg.get_item_configuration.side_effect = lambda tag: (
+        {'attribute_type': dpg.mvNode_Attr_Input} if tag == port_tag else {}
+    )
+
+    assert editor._cntrl_find_node_port('2:TestNode', 'Int', 'Input') == port_tag
+
+
+def test_registered_hovered_port_falls_back_to_legacy_scan_for_unregistered_graphs(editor_and_dpg):
+    editor, dpg = editor_and_dpg
+    output_tag = '1:TestNode:Int:Output01'
+    editor._node_list = ['1:TestNode']
+    dpg.does_item_exist.side_effect = lambda tag: tag == output_tag
+    dpg.is_item_hovered.side_effect = lambda tag: tag == output_tag
+
+    assert editor._cntrl_get_hovered_output_port_tag() == output_tag
+    assert output_tag in editor._port_registry
 
 
 def test_delete_link_updates_typed_registries(editor_and_dpg):


### PR DESCRIPTION
### Motivation
- Prepare for the typed port model refactor by making the editor able to treat `PortRef` metadata as a first-class registry instead of relying solely on legacy DearPyGui tag string scans.

### Description
- Add ` _mdl_register_port_ref` and `_mdl_iter_registered_ports` helpers to register and iterate `PortRef` entries and ensure corresponding `NodeRef` is registered when ports are added.
- Make `_cntrl_parse_port_tag` register parsed ports via `_mdl_register_port_ref` so legacy-parsed tags flow into the typed registry.
- Prefer registry-backed lookup in hovered-port discovery by adding `_cntrl_get_hovered_registered_port_tag` and fall back to legacy string-scan via `_cntrl_get_hovered_legacy_port_tag`; expose `_cntrl_get_hovered_output_port_tag` and `_cntrl_get_hovered_input_port_tag` that use the registry first.
- Update `_cntrl_find_node_port` to consult the registered `PortRef`s before performing the legacy indexed tag scan, and ensure discovered legacy tags are registered on first sight.
- Add tests to `tests/unit/test_node_editor_core.py` that cover high-index registered ports, registry-backed port lookup, and legacy-fallback registration behavior.

### Testing
- Ran unit tests for the modified file with the cv2 stub: `python -m pytest --use-cv2-stub tests/unit/test_node_editor_core.py -q` and the tests passed.
- Ran the full test suite with the cv2 stub: `python -m pytest --use-cv2-stub -q` and all tests passed (137 passed, 19 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f980898083239a8ee1cbb9121e6a)