### PR TITLE
Introduce typed Port/Link model and DpgNodeBase; migrate nodes and editor to typed ports/links

### DIFF
--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -14,6 +14,58 @@ string tags.
   classes unless a later refactor finds real duplicated behavior.
 - Preserve import/export compatibility while allowing a future typed schema.
 
+## Current status
+
+Implemented so far:
+
+- `DpgNodeBase` has been introduced as the concrete DearPyGui node base.
+- Direct node/base subclasses under `node/` now inherit from `DpgNodeBase`
+  instead of `DpgNodeABC`, while preserving existing behavior and tag strings.
+- Existing concrete helper methods for tag construction, legacy connection/tag
+  parsing, and the standard editor toolbar now live on `DpgNodeBase`.
+- `DpgNodeBase` now has composed node/port/value tag helpers that accept a
+  `node_id` directly, reducing repeated nested tag construction in node code.
+- `node.port_model` defines the first reusable passive `NodeRef` / `PortRef`
+  records for node-side declarations.
+- `DpgNodeBase` also has the first typed port declaration APIs
+  (`input_port`, `output_port`, `parameter_port`) that create passive `PortRef`
+  metadata while preserving the compact DPG tag format.
+- `DeclarativeImageProcessNodeBase` uses typed `PortRef` declarations for its
+  standard image input/output, elapsed-time output, and declared parameter ports;
+  cache/result toggles still use value tags because they are toolbar controls,
+  not graph ports.
+- Direct non-declarative node `add_node()` implementations now declare their DPG
+  input/output graph attributes through `input_port()` / `output_port()` while
+  preserving existing compact tag strings.
+- Direct non-declarative node `update()` implementations now iterate typed
+  connection info records through `_iter_connection_infos()` instead of the legacy
+  `_iter_connections()` adapter.
+- Node implementations now use composed `_node_port_tag()` / `_node_value_tag()`
+  / `_port_value_tag()` helpers for repeated node-owned tag composition instead
+  of nesting `_value_tag(_port_tag(...))` at each call site.
+- `DpgNodeABC` is back to the abstract lifecycle contract, shared metadata, shared
+  type constants, and the optional editor hook.
+- The editor imports the shared `node.port_model` records, registers node-owned
+  declared ports during node creation, and now prefers registered `PortRef` data
+  for right-click hovered-port discovery and node-port lookup. Legacy compact tag
+  parsing remains as a compatibility boundary for imported graphs, callback
+  aliases, and undo/redo data.
+
+Important limitation of the current implementation:
+
+- The editor now exports and imports typed `link_refs` directly; graph sorting,
+  cycle detection, delete-through-node reconnection, the runtime scheduler,
+  undo/redo link history, and the node `update()` connection boundary all consume
+  or preserve typed `LinkRef` data when it is available. The declarative image
+  process base and direct non-declarative nodes now read typed connection-info
+  records, while `_iter_connections()` remains only as a legacy compatibility
+  adapter for external callers and tests that explicitly cover that boundary.
+
+## Next work
+
+1. Continue replacing remaining direct compact `PortRef` tag reads in node logic with
+   typed `PortRef` fields where the value does not have to be passed to DearPyGui.
+
 ## Step 1: Split the abstract interface from concrete node behavior
 
 Create a concrete base node, for example `DpgNodeBase`, and move implementation
@@ -79,25 +131,25 @@ already centralize a large amount of repeated node UI and setting behavior.
 
 After `DpgNodeBase` can register typed ports and
 `DeclarativeImageProcessNodeBase` has moved onto it, fold audit item 2
-(hovered-port discovery) into this refactor. Do not do this as a standalone
-pre-refactor cleanup, because the current `_port_registry` is populated lazily
-from parsed strings rather than authoritatively during node creation.
+(hovered-port discovery) into this refactor. This should happen after
+creation-time registration is available, because pre-refactor `_port_registry`
+data was populated lazily from parsed strings rather than authoritatively during
+node creation.
 
-Replace `_cntrl_get_hovered_output_port_tag()` and
-`_cntrl_get_hovered_input_port_tag()` so they iterate registered `PortRef` data
-instead of synthesizing possible DearPyGui tags from every node, hardcoded data
-types, and fixed port-index ranges.
+Done: `_cntrl_get_hovered_output_port_tag()` and
+`_cntrl_get_hovered_input_port_tag()` now iterate registered `PortRef` data only;
+legacy DearPyGui tag synthesis is no longer used for hovered-port discovery.
+`_cntrl_find_node_port()` also requires registered refs, so newly created nodes are
+connected through the typed registry rather than through fixed index scans.
 
-Recommended incremental shape:
+Implemented incremental shape:
 
-1. keep the public return value as the compact DPG tag at first, so surrounding
-   context-menu code does not need to change in the same patch,
-2. source the returned tag from a registered `PortRef`,
-3. keep legacy parsing only for imported/test graphs that have not gone through
-   creation-time registration,
-4. add or keep behavior tests for add-node-from-hovered-output,
-   add-node-to-hovered-input, insert-node-between-links, and occupied input
-   replacement.
+1. public helpers still return compact DPG tags, so surrounding context-menu code
+   remains compatible,
+2. returned tags are sourced from registered `PortRef` objects,
+3. behavior tests cover registered high-index ports, missing-registration behavior,
+   add-node-from-hovered-output, add-node-to-hovered-input, insert-node-between-links,
+   and occupied input replacement.
 
 This makes hovered-port lookup the first editor-side proof that typed port
 registration is reliable, without forcing the entire graph model to change at
@@ -108,13 +160,16 @@ once.
 Once hovered-port lookup is backed by creation-time port registration, continue
 shifting editor internals from string pairs toward typed objects.
 
-Recommended intermediate model:
+Implemented intermediate model:
 
-- keep `_node_link_list` as exported legacy string pairs until import/export and
-  runtime are migrated,
-- add a canonical typed link collection keyed by destination `PortRef`,
-- make `_mdl_add_link()` accept `PortRef` / `LinkRef` on the normal path,
-- keep string-to-`PortRef` resolution only at boundaries.
+- keep `_node_link_list` as an internal string-pair adapter until history/runtime
+  are migrated,
+- add `LinkRef` as the canonical typed link record stored in `_link_registry` and
+  `_link_by_dest_port_ref`,
+- make `_mdl_add_link()` accept string aliases or `PortRef` endpoints on the normal
+  path and normalize successful links to `LinkRef`,
+- export typed `link_refs` from `LinkRef` data and import `link_refs` without
+  normal-path fallback to legacy `link_list`.
 
 Boundary-only parsing is still acceptable for:
 
@@ -160,6 +215,40 @@ After nodes reliably register ports, migrate graph consumers in this order:
 At the end of this step, parsing a port tag should be a compatibility adapter,
 not part of normal graph mutation.
 
+Current typed graph-consumer checkpoint:
+
+- Graph sorting iterates typed `LinkRef` records and uses `NodeRef` metadata for
+  dependency ordering while preserving legacy connection-list values for node
+  `update()` calls.
+- Cycle detection validates the candidate link once into a `LinkRef` and builds
+  adjacency from typed registered links.
+- Delete-through-node reconnection reads source/destination node IDs and link data
+  types from `LinkRef` endpoints.
+- Runtime scheduling prefers typed sorted connection refs and wraps typed links in
+  a compatibility adapter for node `update()` calls; the adapter exposes typed
+  endpoints while still iterating like the legacy source/destination tag pair.
+- `DeclarativeImageProcessNodeBase` consumes typed adapter fields for its image
+  source lookup and linked-parameter synchronization while keeping legacy pair
+  fallback behavior. `_iter_connections()` now yields tag-compatible strings that
+  retain `PortRef` metadata, so existing non-declarative nodes using shared source,
+  port-name, node-id, and value-tag helpers also avoid reparsing typed endpoints.
+- History replay normalizes stored link entries through a link-pair adapter, so
+  commands can carry `LinkRef` payloads while older string-pair commands continue
+  to replay through the same ID-remapping path. New link-add, link-replace,
+  delete/reconnect, import, and add-node history payloads now preserve `LinkRef`
+  values when the editor has a registered link.
+
+Current typed import/export checkpoint:
+
+- New exports include `link_refs` records with typed source/destination endpoint
+  metadata and no longer write legacy `link_list`.
+- Imports require `link_refs` and remap endpoint node IDs through the same import
+  ID map as nodes.
+- The checked-in exported graph fixtures have been converted externally, normal
+  import no longer falls back to legacy compact-link payloads, and import/export
+  tests now construct typed `link_refs` payloads directly instead of building
+  compact `link_list` inputs and converting them inside the test.
+
 ## Serialization and DearPyGui tag format notes
 
 The official DearPyGui documentation says item IDs can be integers or strings,
@@ -175,7 +264,7 @@ Recommendation:
   longer, harder to read in debugging output, and not necessary once the live
   graph model is typed.
 - Treat compact strings as a boundary encoding only. Internally, use typed
-  `NodeRef`, `PortRef`, and eventually `LinkRef` objects.
+  `NodeRef`, `PortRef`, and `LinkRef` objects.
 
 If a versioned compact format is needed later, prefer a small URI/URN-like or
 version-prefixed delimiter format over JSON-in-a-string, for example:
@@ -202,11 +291,21 @@ plus a readable compact boundary string.
 
 ## Suggested checkpoints
 
-- Add unit tests for concrete base port declaration output and editor port
-  registration.
-- Migrate declarative process nodes and run process-node tests.
-- Migrate direct nodes in one wave and run the full test suite.
-- Replace editor link internals with typed links behind a compatibility export
-  adapter.
-- Add import/export round-trip tests covering both legacy compact strings and any
-  future typed endpoint schema.
+- Done: introduce `DpgNodeBase`, migrate direct node subclasses to inherit from
+  it, and move existing concrete helper methods from `DpgNodeABC` into
+  `DpgNodeBase`.
+- Done: migrate declarative and direct node static graph attributes to typed
+  `PortRef` declarations while preserving existing compact DPG tags.
+- Done: wire node-owned declared ports into the editor registry during node
+  creation, with callback support for dynamic ports created later.
+- Done: replace hovered-port discovery and node-port lookup with registered
+  `PortRef` iteration; legacy compact-tag scanning has been removed from these
+  normal paths.
+- Done: add typed `LinkRef` registry entries while preserving legacy `_node_link_list`
+  pairs for existing history/runtime code.
+- Done: add typed `link_refs` import/export schema and remove normal-path legacy
+  `link_list` import/export fallback after fixture conversion.
+- Done: move graph sorting, cycle detection, delete-through-node reconnection, and
+  runtime scheduling onto typed `LinkRef` iteration.
+- Next: migrate history payloads and node `update()` connection consumers from
+  string pairs to typed refs.

--- a/node/analysis_node/node_BRISQUE.py
+++ b/node/analysis_node/node_BRISQUE.py
@@ -9,7 +9,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -18,7 +18,7 @@ def image_process(image, model_path, range_path):
     return score
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'BRISQUE'
@@ -43,20 +43,18 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE,
-                                               'Input01')
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = self._value_tag(tag_node_input01_name)
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE,
-                                                'Output01')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS,
-                                                'Output02')
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = self._value_tag(tag_node_output02_name)
 
-        tag_node_score_name = self._port_tag(tag_node_name, self.TYPE_TEXT,
-                                            'Score')
-        tag_node_score_value_name = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Score'))
+        tag_node_score_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Score')
+        tag_node_score_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Score')
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -134,13 +132,10 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        output_value01_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
 
-        tag_node_score_value_name = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Score'))
+        tag_node_score_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Score')
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -148,12 +143,16 @@ class Node(DpgNodeABC):
 
         # Check connection info
         connection_info_src = ''
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
             if connection_type == self.TYPE_FLOAT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = round(float(dpg_get_value(source_value_tag)), 3)
                 input_value = max([self._min_val, input_value])
@@ -161,7 +160,7 @@ class Node(DpgNodeABC):
                 dpg_set_value(destination_value_tag, input_value)
             if connection_type == self.TYPE_IMAGE:
                 # Get source node name for image (with ID)
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
 
         # Get image
         frame = node_image_dict.get(connection_info_src, None)

--- a/node/analysis_node/node_fps.py
+++ b/node/analysis_node/node_fps.py
@@ -7,10 +7,10 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'FPS'
@@ -39,13 +39,15 @@ class Node(DpgNodeABC):
 
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input00_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input00')
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input01'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input00_name = self._node_port_tag(node_id, self.TYPE_TIME_MS, 'Input00')
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_TIME_MS, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_output01_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Output01')
+        tag_node_output01_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Output01')
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -111,18 +113,22 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
 
         total_elapsed_time = 0
 
         # Get source node name for image (with ID)
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
             if connection_type == self.TYPE_TIME_MS:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
 
                 # Update value
                 input_value = dpg_get_value(source_value_tag)
@@ -214,14 +220,14 @@ class Node(DpgNodeABC):
             self._slot_id[tag_node_name] += 1
 
             # Generate insertion destination tag name
-            before_tag = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input')
+            before_tag = self._node_port_tag(node_id, self.TYPE_TIME_MS, 'Input')
             before_tag += str(self._slot_id[tag_node_name] - 1).zfill(2)
 
             # Generate added slot tag
-            tag_node_inputXX_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input')
+            tag_node_inputXX_name = self._node_port_tag(node_id, self.TYPE_TIME_MS, 'Input')
             tag_node_inputXX_name += str(self._slot_id[tag_node_name]).zfill(2)
 
-            tag_node_inputXX_value_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input')
+            tag_node_inputXX_value_name = self._node_port_tag(node_id, self.TYPE_TIME_MS, 'Input')
             tag_node_inputXX_value_name += str(
                 self._slot_id[tag_node_name]).zfill(2) + 'Value'
 

--- a/node/analysis_node/node_rgb_histgram.py
+++ b/node/analysis_node/node_rgb_histgram.py
@@ -6,10 +6,10 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'RGB Histgram'
@@ -34,10 +34,9 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE,
-                                               'Input01')
-        tag_node_input01_value_name = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Input01')
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -112,17 +111,16 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_value_name = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
+        tag_node_input01_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Input01')
 
         # Get source node name for image (with ID)
         connection_info_src = ''
-        for source_tag, _, connection_type in self._iter_connections(
+        for connection_info, source_tag, _, connection_type in self._iter_connection_infos(
                 connection_list):
             if connection_type != self.TYPE_IMAGE:
                 continue
 
-            connection_info_src = self._extract_source_node_key(source_tag)
+            connection_info_src = self._connection_source_node_key(connection_info, source_tag)
 
         # Get image
         frame = node_image_dict.get(connection_info_src, None)

--- a/node/base/declarative_node_base.py
+++ b/node/base/declarative_node_base.py
@@ -6,11 +6,11 @@ from abc import abstractmethod
 import dearpygui.dearpygui as dpg
 import numpy as np
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg, dpg_get_value, dpg_set_value
 
 
-class DeclarativeImageProcessNodeBase(DpgNodeABC):
+class DeclarativeImageProcessNodeBase(DpgNodeBase):
     """Common implementation for simple image process nodes."""
 
     _opencv_setting_dict = None
@@ -36,28 +36,27 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
         callback=None,
     ):
         tag_node_name = self._node_name(node_id)
-        input_image_tag = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
-        input_image_value_tag = self._value_tag(input_image_tag)
-        output_image_tag = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        output_image_value_tag = self._value_tag(output_image_tag)
-        elapsed_tag = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        elapsed_value_tag = self._value_tag(elapsed_tag)
-        cache_toggle_tag = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Cache')
-        cache_toggle_value_tag = self._value_tag(cache_toggle_tag)
-        result_image_toggle_tag = self._port_tag(
-            tag_node_name, self.TYPE_TEXT, 'ResultImage'
-        )
-        result_image_toggle_value_tag = self._value_tag(result_image_toggle_tag)
-        result_large_image_toggle_tag = self._port_tag(
-            tag_node_name, self.TYPE_TEXT, 'ResultImageLarge'
-        )
-        result_large_image_toggle_value_tag = self._value_tag(result_large_image_toggle_tag)
 
         self._opencv_setting_dict = opencv_setting_dict
         self._ui_callback = callback
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
         use_pref_counter = self._opencv_setting_dict['use_pref_counter']
+
+        input_image_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        output_image_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        elapsed_port = None
+        if self.show_elapsed_time and use_pref_counter:
+            elapsed_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        cache_toggle_value_tag = self._node_value_tag(
+            node_id, self.TYPE_TEXT, 'Cache'
+        )
+        result_image_toggle_value_tag = self._node_value_tag(
+            node_id, self.TYPE_TEXT, 'ResultImage'
+        )
+        result_large_image_toggle_value_tag = self._node_value_tag(
+            node_id, self.TYPE_TEXT, 'ResultImageLarge'
+        )
 
         black_image = np.zeros((small_window_w, small_window_h, 3))
         black_texture = convert_cv_to_dpg(black_image, small_window_w, small_window_h)
@@ -67,7 +66,7 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
                 small_window_w,
                 small_window_h,
                 black_texture,
-                tag=output_image_value_tag,
+                tag=output_image_port.value_tag,
                 format=dpg.mvFormat_Float_rgb,
             )
 
@@ -89,19 +88,19 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
             )
 
             with dpg.node_attribute(
-                tag=input_image_tag,
+                tag=input_image_port.dpg_tag,
                 attribute_type=dpg.mvNode_Attr_Input,
             ):
                 pass
 
             with dpg.node_attribute(
-                tag=output_image_tag,
+                tag=output_image_port.dpg_tag,
                 attribute_type=dpg.mvNode_Attr_Output,
             ):
                 pass
 
             for parameter in self.parameters:
-                self._add_parameter_ui(tag_node_name, parameter, small_window_w, callback)
+                self._add_parameter_ui(node_id, parameter, small_window_w, callback)
 
             self.build_custom_ui(
                 tag_node_name,
@@ -112,11 +111,11 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
 
             if self.show_elapsed_time and use_pref_counter:
                 with dpg.node_attribute(
-                    tag=elapsed_tag,
+                    tag=elapsed_port.dpg_tag,
                     attribute_type=dpg.mvNode_Attr_Output,
                 ):
                     dpg.add_text(
-                        tag=elapsed_value_tag,
+                        tag=elapsed_port.value_tag,
                         default_value='elapsed time(ms)',
                     )
 
@@ -165,11 +164,11 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
         del node_result_dict
 
         tag_node_name = self._node_name(node_id)
-        output_image_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
+        output_image_value_tag = self._node_value_tag(
+            node_id, self.TYPE_IMAGE, 'Output01'
         )
-        elapsed_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
+        elapsed_value_tag = self._node_value_tag(
+            node_id, self.TYPE_TIME_MS, 'Output02'
         )
 
         small_window_w = self._opencv_setting_dict['process_width']
@@ -179,9 +178,18 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
         connection_info_src = ''
         self._sync_linked_parameters(connection_list)
 
-        for source_tag, _, connection_type in self._iter_connections(connection_list):
+        for (
+            connection_info,
+            source_tag,
+            _,
+            connection_type,
+        ) in self._iter_connection_infos(connection_list):
             if connection_type == self.TYPE_IMAGE:
-                connection_info_src = self._extract_source_node_key(source_tag)
+                source_port = getattr(connection_info, 'source', None)
+                if source_port is not None:
+                    connection_info_src = source_port.node_ref.node_id_name
+                else:
+                    connection_info_src = self._extract_source_node_key(source_tag)
 
         frame = node_image_dict.get(connection_info_src, None)
         parameter_values = self._get_parameter_values(tag_node_name)
@@ -211,12 +219,11 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
             return
 
         start_time = time.perf_counter()
-        tag_node_name = self._node_name(node_id)
-        output_image_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
+        output_image_value_tag = self._node_value_tag(
+            node_id, self.TYPE_IMAGE, 'Output01'
         )
-        elapsed_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
+        elapsed_value_tag = self._node_value_tag(
+            node_id, self.TYPE_TIME_MS, 'Output02'
         )
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -239,8 +246,8 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
         }
 
         for parameter in self.parameters:
-            parameter_value_tag = self._value_tag(
-                self._port_tag(tag_node_name, parameter['type'], parameter['port'])
+            parameter_value_tag = self._port_value_tag(
+                tag_node_name, parameter['type'], parameter['port']
             )
             setting_dict[parameter_value_tag] = dpg_get_value(parameter_value_tag)
 
@@ -261,8 +268,8 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
         tag_node_name = self._node_name(node_id)
 
         for parameter in self.parameters:
-            parameter_value_tag = self._value_tag(
-                self._port_tag(tag_node_name, parameter['type'], parameter['port'])
+            parameter_value_tag = self._port_value_tag(
+                tag_node_name, parameter['type'], parameter['port']
             )
             if parameter_value_tag not in setting_dict:
                 continue
@@ -272,14 +279,14 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
 
         self.set_custom_setting_dict(tag_node_name, node_id, setting_dict)
 
-        cache_toggle_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Cache')
+        cache_toggle_value_tag = self._node_value_tag(
+            node_id, self.TYPE_TEXT, 'Cache'
         )
-        result_image_toggle_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TEXT, 'ResultImage')
+        result_image_toggle_value_tag = self._node_value_tag(
+            node_id, self.TYPE_TEXT, 'ResultImage'
         )
-        result_large_image_toggle_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TEXT, 'ResultImageLarge')
+        result_large_image_toggle_value_tag = self._node_value_tag(
+            node_id, self.TYPE_TEXT, 'ResultImageLarge'
         )
         cache_enabled = bool(setting_dict.get(self._cache_toggle_setting_key, True))
         result_image_enabled = bool(
@@ -422,13 +429,27 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
         pass
 
     def _sync_linked_parameters(self, connection_list):
-        for source_tag, destination_tag, connection_type in self._iter_connections(connection_list):
-            destination_port = self._extract_port_name(destination_tag)
+        for (
+            connection_info,
+            source_tag,
+            destination_tag,
+            connection_type,
+        ) in self._iter_connection_infos(connection_list):
+            destination_ref = getattr(connection_info, 'destination', None)
+            if destination_ref is not None:
+                destination_port = destination_ref.port_name
+            else:
+                destination_port = self._extract_port_name(destination_tag)
             parameter = self._find_parameter(connection_type, destination_port)
             if parameter is None:
                 continue
 
-            source_value = dpg_get_value(self._value_tag(source_tag))
+            source_ref = getattr(connection_info, 'source', None)
+            if source_ref is not None and source_ref.value_tag:
+                source_value_tag = source_ref.value_tag
+            else:
+                source_value_tag = self._value_tag(source_tag)
+            source_value = dpg_get_value(source_value_tag)
             if source_value is None:
                 continue
 
@@ -439,8 +460,8 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
     def _get_parameter_values(self, tag_node_name):
         values = {}
         for parameter in self.parameters:
-            parameter_value_tag = self._value_tag(
-                self._port_tag(tag_node_name, parameter['type'], parameter['port'])
+            parameter_value_tag = self._port_value_tag(
+                tag_node_name, parameter['type'], parameter['port']
             )
             value = dpg_get_value(parameter_value_tag)
             value = self._cast_parameter_value(parameter, value)
@@ -448,9 +469,23 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
             values[parameter['name']] = value
         return values
 
-    def _add_parameter_ui(self, tag_node_name, parameter, width, callback):
-        port_tag = self._port_tag(tag_node_name, parameter['type'], parameter['port'])
-        value_tag = self._value_tag(port_tag)
+    def _add_parameter_ui(self, node_id, parameter, width, callback):
+        tag_node_name = self._node_name(node_id)
+        attribute_type = parameter.get('attribute_type', dpg.mvNode_Attr_Input)
+        if attribute_type == dpg.mvNode_Attr_Output:
+            port_ref = self.output_port(
+                node_id,
+                parameter['type'],
+                parameter['port'],
+            )
+        else:
+            port_ref = self.parameter_port(
+                node_id,
+                parameter['type'],
+                parameter['port'],
+            )
+        port_tag = port_ref.dpg_tag
+        value_tag = port_ref.value_tag
         callback_payload = {
             'node_id_name': tag_node_name,
             'port_tag': port_tag,
@@ -462,7 +497,7 @@ class DeclarativeImageProcessNodeBase(DpgNodeABC):
 
         with dpg.node_attribute(
             tag=port_tag,
-            attribute_type=parameter.get('attribute_type', dpg.mvNode_Attr_Input),
+            attribute_type=attribute_type,
         ):
             if parameter['widget'] == 'slider_int':
                 dpg.add_slider_int(

--- a/node/deep_learning_node/node_classification.py
+++ b/node/deep_learning_node/node_classification.py
@@ -9,7 +9,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.classification.MobileNetV3.mobilenet_v3 import MobileNetV3
@@ -23,7 +23,7 @@ from node.draw_node.draw_util.draw_util import (
 )
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Classification'
@@ -68,17 +68,20 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
-        tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_input02_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
-        tag_provider_select_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Provider')
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Provider')
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -171,11 +174,11 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
 
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -185,12 +188,16 @@ class Node(DpgNodeABC):
         # Check connection info
         src_node_name = ''
         connection_info_src = ''
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
             if connection_type == self.TYPE_INT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = int(dpg_get_value(source_value_tag))
                 input_value = max([self._min_val, input_value])
@@ -198,7 +205,7 @@ class Node(DpgNodeABC):
                 dpg_set_value(destination_value_tag, input_value)
             if connection_type == self.TYPE_IMAGE:
                 # Get source node name for image (with ID)
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
                 src_node_name = connection_info_src.split(':')[1]
 
         # Get image
@@ -333,7 +340,7 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
 
         # Selected model
         model_name = dpg_get_value(input_value02_tag)
@@ -349,7 +356,7 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
 
         model_name = setting_dict[input_value02_tag]
 

--- a/node/deep_learning_node/node_face_detection.py
+++ b/node/deep_learning_node/node_face_detection.py
@@ -9,7 +9,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.face_detection.YuNet.yunet import YuNet
@@ -25,7 +25,7 @@ from node.deep_learning_node.face_detection.mediapipe_facemesh.mediapipe_facemes
 from node.draw_node.draw_util.draw_util import draw_face_detection_info
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Face Detection'
@@ -69,19 +69,23 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
-        tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_name = self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03')
-        tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_input02_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_FLOAT, 'Input03')
+        tag_node_input03_name = tag_node_input03_name_port.dpg_tag
+        tag_node_input03_value_name = tag_node_input03_name_port.value_tag
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
-        tag_provider_select_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Provider')
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Provider')
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -188,12 +192,12 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input03')
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
 
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -202,12 +206,16 @@ class Node(DpgNodeABC):
 
         # Check connection info
         connection_info_src = ''
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
             if connection_type == self.TYPE_FLOAT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = round(float(dpg_get_value(source_value_tag)), 3)
                 input_value = max([self._min_val, input_value])
@@ -215,7 +223,7 @@ class Node(DpgNodeABC):
                 dpg_set_value(destination_value_tag, input_value)
             if connection_type == self.TYPE_IMAGE:
                 # Get source node name for image (with ID)
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
 
         # Get image
         frame = node_image_dict.get(connection_info_src, None)
@@ -291,8 +299,8 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input03')
 
         # Selected model
         model_name = dpg_get_value(input_value02_tag)
@@ -311,8 +319,8 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input03')
 
         model_name = setting_dict[input_value02_tag]
         score_th = setting_dict[input_value03_tag]

--- a/node/deep_learning_node/node_low_light_image_enhancement.py
+++ b/node/deep_learning_node/node_low_light_image_enhancement.py
@@ -8,7 +8,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.low_light_image_enhancement.TBEFN.tbefn import TBEFN
@@ -16,7 +16,7 @@ from node.deep_learning_node.low_light_image_enhancement.SCI.sci import SCI
 from node.deep_learning_node.low_light_image_enhancement.AGLLNet.agllnet import AGLLNet
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Low-Light Image Enhancement'
@@ -64,17 +64,20 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
-        tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_input02_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
-        tag_provider_select_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Provider')
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Provider')
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -167,11 +170,11 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
 
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -180,12 +183,16 @@ class Node(DpgNodeABC):
 
         # Check connection info
         connection_info_src = ''
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
             if connection_type == self.TYPE_INT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = int(dpg_get_value(source_value_tag))
                 input_value = max([self._min_val, input_value])
@@ -193,7 +200,7 @@ class Node(DpgNodeABC):
                 dpg_set_value(destination_value_tag, input_value)
             if connection_type == self.TYPE_IMAGE:
                 # Get source node name for image (with ID)
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
 
         # Get image
         frame = node_image_dict.get(connection_info_src, None)
@@ -254,7 +261,7 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
 
         # Selected model
         model_name = dpg_get_value(input_value02_tag)
@@ -270,7 +277,7 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
 
         model_name = setting_dict[input_value02_tag]
 

--- a/node/deep_learning_node/node_monocular_depth_estimation.py
+++ b/node/deep_learning_node/node_monocular_depth_estimation.py
@@ -9,14 +9,14 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.monocular_depth_estimation.FSRE_Depth.fsre_depth import FSRE_Depth
 from node.deep_learning_node.monocular_depth_estimation.HR_Depth.hr_depth import HR_Depth
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Monocular Depth Estimation'
@@ -62,17 +62,20 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
-        tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_input02_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
-        tag_provider_select_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Provider')
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Provider')
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -165,11 +168,11 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
 
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -178,12 +181,16 @@ class Node(DpgNodeABC):
 
         # Check connection info
         connection_info_src = ''
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
             if connection_type == self.TYPE_INT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = int(dpg_get_value(source_value_tag))
                 input_value = max([self._min_val, input_value])
@@ -191,7 +198,7 @@ class Node(DpgNodeABC):
                 dpg_set_value(destination_value_tag, input_value)
             if connection_type == self.TYPE_IMAGE:
                 # Get source node name for image (with ID)
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
 
         # Get image
         frame = node_image_dict.get(connection_info_src, None)
@@ -255,7 +262,7 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
 
         # Selected model
         model_name = dpg_get_value(input_value02_tag)
@@ -271,7 +278,7 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
 
         model_name = setting_dict[input_value02_tag]
 

--- a/node/deep_learning_node/node_object_detection.py
+++ b/node/deep_learning_node/node_object_detection.py
@@ -9,7 +9,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.object_detection.YOLOX.yolox import YOLOX
@@ -22,7 +22,7 @@ from node.deep_learning_node.object_detection.coco_class_names_only_person impor
 from node.draw_node.draw_util.draw_util import draw_object_detection_info
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Object Detection'
@@ -82,19 +82,23 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
-        tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_name = self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03')
-        tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_input02_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_FLOAT, 'Input03')
+        tag_node_input03_name = tag_node_input03_name_port.dpg_tag
+        tag_node_input03_value_name = tag_node_input03_name_port.value_tag
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
-        tag_provider_select_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Provider')
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Provider')
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -201,12 +205,12 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input03')
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
 
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -215,12 +219,16 @@ class Node(DpgNodeABC):
 
         # Check connection info
         connection_info_src = ''
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
             if connection_type == self.TYPE_FLOAT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = round(float(dpg_get_value(source_value_tag)), 3)
                 input_value = max([self._min_val, input_value])
@@ -228,7 +236,7 @@ class Node(DpgNodeABC):
                 dpg_set_value(destination_value_tag, input_value)
             if connection_type == self.TYPE_IMAGE:
                 # Get source node name for image (with ID)
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
 
         # Get image
         frame = node_image_dict.get(connection_info_src, None)
@@ -316,8 +324,8 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input03')
 
         # Selected model
         model_name = dpg_get_value(input_value02_tag)
@@ -336,8 +344,8 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input03')
 
         model_name = setting_dict[input_value02_tag]
         score_th = setting_dict[input_value03_tag]

--- a/node/deep_learning_node/node_pose_estimation.py
+++ b/node/deep_learning_node/node_pose_estimation.py
@@ -9,7 +9,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.pose_estimation.movenet.movenet import (
@@ -30,7 +30,7 @@ from node.deep_learning_node.pose_estimation.mediapipe_pose.mediapipe_pose impor
 from node.draw_node.draw_util.draw_util import draw_pose_estimation_info
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Pose Estimation'
@@ -82,19 +82,23 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
-        tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_name = self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03')
-        tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_input02_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_FLOAT, 'Input03')
+        tag_node_input03_name = tag_node_input03_name_port.dpg_tag
+        tag_node_input03_value_name = tag_node_input03_name_port.value_tag
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
-        tag_provider_select_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Provider')
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Provider')
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -201,12 +205,12 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input03')
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
 
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -215,12 +219,16 @@ class Node(DpgNodeABC):
 
         # Check connection info
         connection_info_src = ''
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
             if connection_type == self.TYPE_FLOAT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = round(float(dpg_get_value(source_value_tag)), 3)
                 input_value = max([self._min_val, input_value])
@@ -228,7 +236,7 @@ class Node(DpgNodeABC):
                 dpg_set_value(destination_value_tag, input_value)
             if connection_type == self.TYPE_IMAGE:
                 # Get source node name for image (with ID)
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
 
         # Get image
         frame = node_image_dict.get(connection_info_src, None)
@@ -304,8 +312,8 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input03')
 
         # Selected model
         model_name = dpg_get_value(input_value02_tag)
@@ -324,8 +332,8 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input03')
 
         model_name = setting_dict[input_value02_tag]
         score_th = setting_dict[input_value03_tag]

--- a/node/deep_learning_node/node_qrcode_detection.py.disable
+++ b/node/deep_learning_node/node_qrcode_detection.py.disable
@@ -10,13 +10,13 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 from node.draw_node.draw_util.draw_util import draw_qrcode_detection_info
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'QR Code Detection'
@@ -55,15 +55,18 @@ class Node(DpgNodeABC):
         callback=None,
     ):
         # タグ名
-        tag_node_name = str(node_id) + ':' + self.node_tag
-        tag_node_input01_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Input01'
-        tag_node_input01_value_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Input01Value'
-        tag_node_input02_name = tag_node_name + ':' + self.TYPE_TEXT + ':Input02'
-        tag_node_input02_value_name = tag_node_name + ':' + self.TYPE_TEXT + ':Input02Value'
-        tag_node_output01_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01'
-        tag_node_output01_value_name = tag_node_name + ':' + self.TYPE_IMAGE + ':Output01Value'
-        tag_node_output02_name = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02'
-        tag_node_output02_value_name = tag_node_name + ':' + self.TYPE_TIME_MS + ':Output02Value'
+        tag_node_name = self._node_name(node_id)
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_input02_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
         # OpenCV向け設定
         self._opencv_setting_dict = opencv_setting_dict

--- a/node/deep_learning_node/node_semantic_segmentation.py
+++ b/node/deep_learning_node/node_semantic_segmentation.py
@@ -8,7 +8,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.semantic_segmentation.deeplab_v3.deeplab_v3 import DeepLabV3
@@ -22,7 +22,7 @@ from node.deep_learning_node.semantic_segmentation.mediapipe_selfie_segmentation
 from node.draw_node.draw_util.draw_util import draw_semantic_segmentation_info
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Semantic Segmentation'
@@ -72,19 +72,23 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
-        tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_name = self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03')
-        tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_input02_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_FLOAT, 'Input03')
+        tag_node_input03_name = tag_node_input03_name_port.dpg_tag
+        tag_node_input03_value_name = tag_node_input03_name_port.value_tag
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
-        tag_provider_select_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Provider')
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Provider')
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -191,12 +195,12 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input03')
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
 
-        tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
+        tag_provider_select_value_name = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Provider')
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -205,12 +209,16 @@ class Node(DpgNodeABC):
 
         # Check connection info
         connection_info_src = ''
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
             if connection_type == self.TYPE_FLOAT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = round(float(dpg_get_value(source_value_tag)), 3)
                 input_value = max([self._min_val, input_value])
@@ -218,7 +226,7 @@ class Node(DpgNodeABC):
                 dpg_set_value(destination_value_tag, input_value)
             if connection_type == self.TYPE_IMAGE:
                 # Get source node name for image (with ID)
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
 
         # Get image
         frame = node_image_dict.get(connection_info_src, None)
@@ -295,8 +303,8 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input03')
 
         # Selected model
         model_name = dpg_get_value(input_value02_tag)
@@ -315,8 +323,8 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input03')
 
         model_name = setting_dict[input_value02_tag]
         score_th = setting_dict[input_value03_tag]

--- a/node/draw_node/node_draw_information.py
+++ b/node/draw_node/node_draw_information.py
@@ -5,12 +5,12 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 from node.draw_node.draw_util.draw_util import draw_info
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Draw Information'
@@ -31,11 +31,11 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE,
-                                               'Input01')
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = self._value_tag(tag_node_input01_name)
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE,
-                                                'Output01')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
 
         # OpenCV settings
@@ -97,8 +97,7 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        output_value01_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -106,14 +105,14 @@ class Node(DpgNodeABC):
         # Check connection info
         node_name = ''
         connection_info_src = ''
-        for source_tag, _, connection_type in self._iter_connections(
+        for connection_info, source_tag, _, connection_type in self._iter_connection_infos(
                 connection_list):
             if connection_type != self.TYPE_IMAGE:
                 continue
 
             # Get source node name for image (with ID)
-            connection_info_src = self._extract_source_node_key(source_tag)
-            node_name = self._extract_source_node_key(source_tag).split(':')[1]
+            connection_info_src = self._connection_source_node_key(connection_info, source_tag)
+            node_name = self._connection_source_node_key(connection_info, source_tag).split(':')[1]
 
         # Get image
         frame = node_image_dict.get(connection_info_src, None)

--- a/node/draw_node/node_image_alpha_blend.py
+++ b/node/draw_node/node_image_alpha_blend.py
@@ -8,7 +8,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 from node.draw_node.draw_util.draw_util import draw_info
 
@@ -60,7 +60,7 @@ def create_image_dict(
     return frame_dict
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Image Alpha Blend'
@@ -92,20 +92,27 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
-        tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input02')
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input02'))
-        tag_node_input03_name = self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03')
-        tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        tag_node_input04_name = self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input04')
-        tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input04'))
-        tag_node_input05_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Input05')
-        tag_node_input05_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input05'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_input02_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input02')
+        tag_node_input02_name = tag_node_input02_name_port.dpg_tag
+        tag_node_input02_value_name = tag_node_input02_name_port.value_tag
+        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_FLOAT, 'Input03')
+        tag_node_input03_name = tag_node_input03_name_port.dpg_tag
+        tag_node_input03_value_name = tag_node_input03_name_port.value_tag
+        tag_node_input04_name_port = self.input_port(node_id, self.TYPE_FLOAT, 'Input04')
+        tag_node_input04_name = tag_node_input04_name_port.dpg_tag
+        tag_node_input04_value_name = tag_node_input04_name_port.value_tag
+        tag_node_input05_name_port = self.input_port(node_id, self.TYPE_INT, 'Input05')
+        tag_node_input05_name = tag_node_input05_name_port.dpg_tag
+        tag_node_input05_value_name = tag_node_input05_name_port.value_tag
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -227,11 +234,11 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        input_value04_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input04'))
-        input_value05_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input05'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input03')
+        input_value04_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Input04')
+        input_value05_tag = self._node_value_tag(node_id, self.TYPE_INT, 'Input05')
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -245,19 +252,27 @@ class Node(DpgNodeABC):
         node_name_dict = {}
         connection_info_src = ''
         connection_info_src_dict = {}
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
 
             # Get slot number from tag name
-            slot_number = re.sub(r'\D', '', destination_tag.split(':')[-1])
+            destination_port_name = self._connection_port_name(
+                connection_info,
+                destination_tag,
+            )
+            slot_number = re.sub(r'\D', '', destination_port_name)
             if slot_number == '':
                 continue
             slot_number = int(slot_number) - 1
-            connection_tag = self._extract_port_name(destination_tag)
+            connection_tag = destination_port_name
             if connection_type == self.TYPE_FLOAT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = round(float(dpg_get_value(source_value_tag)), 3)
                 if connection_tag == 'Input03':
@@ -269,8 +284,8 @@ class Node(DpgNodeABC):
                 dpg_set_value(destination_value_tag, input_value)
             if connection_type == self.TYPE_INT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = int(dpg_get_value(source_value_tag))
                 if connection_tag == 'Input05':
@@ -279,7 +294,7 @@ class Node(DpgNodeABC):
                 dpg_set_value(destination_value_tag, input_value)
             if connection_type == self.TYPE_IMAGE:
                 # Get source node name for image (with ID)
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
                 node_name = connection_info_src.split(':')[1]
                 node_name_dict[slot_number] = node_name
                 connection_info_src_dict[slot_number] = connection_info_src
@@ -331,7 +346,7 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_INT, 'Input03')
 
         kernel_size = dpg_get_value(input_value03_tag)
 
@@ -346,7 +361,7 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input02'))
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_INT, 'Input02')
 
         kernel_size = int(setting_dict[input_value03_tag])
 

--- a/node/draw_node/node_image_concat.py
+++ b/node/draw_node/node_image_concat.py
@@ -9,7 +9,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 from node.draw_node.draw_util.draw_util import draw_info
 
@@ -120,7 +120,7 @@ def create_image_dict(
     return frame_dict
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Image Concat'
@@ -146,11 +146,13 @@ class Node(DpgNodeABC):
 
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input00_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input00')
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
+        tag_node_input00_name = self._node_port_tag(node_id, self.TYPE_IMAGE, 'Input00')
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -225,7 +227,7 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
         resize_width = self._opencv_setting_dict['result_width']
@@ -235,17 +237,25 @@ class Node(DpgNodeABC):
         # Get source node name for image (with ID)
         connection_info_src = ''
         connection_info_src_dict = {}
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
             # Get slot number from tag name
-            slot_number = re.sub(r'\D', '', destination_tag.split(':')[-1])
+            destination_port_name = self._connection_port_name(
+                connection_info,
+                destination_tag,
+            )
+            slot_number = re.sub(r'\D', '', destination_port_name)
             if slot_number == '':
                 continue
             slot_number = int(slot_number) - 1
 
             if connection_type == self.TYPE_IMAGE:
                 # Get source node name for image (with ID)
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
                 node_name = connection_info_src.split(':')[1]
 
                 connection_info_src_dict[slot_number] = connection_info_src
@@ -316,17 +326,23 @@ class Node(DpgNodeABC):
         if self._max_slot_number > self._slot_id[tag_node_name]:
             self._slot_id[tag_node_name] += 1
 
+            node_id = self._extract_node_id(tag_node_name)
+            before_port_name = 'Input' + str(
+                self._slot_id[tag_node_name] - 1
+            ).zfill(2)
+            port_name = 'Input' + str(self._slot_id[tag_node_name]).zfill(2)
+
             # Generate insertion destination tag name
-            before_tag = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input')
-            before_tag += str(self._slot_id[tag_node_name] - 1).zfill(2)
+            before_tag = self._port_tag(
+                tag_node_name,
+                self.TYPE_IMAGE,
+                before_port_name,
+            )
 
             # Generate added slot tag
-            tag_node_inputXX_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input')
-            tag_node_inputXX_name += str(self._slot_id[tag_node_name]).zfill(2)
-
-            tag_node_inputXX_value_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input')
-            tag_node_inputXX_value_name += str(
-                self._slot_id[tag_node_name]).zfill(2) + 'Value'
+            input_port = self.input_port(node_id, self.TYPE_IMAGE, port_name)
+            tag_node_inputXX_name = input_port.dpg_tag
+            tag_node_inputXX_value_name = input_port.value_tag
 
             # Add slot
             with dpg.node_attribute(

--- a/node/draw_node/node_puttext.py
+++ b/node/draw_node/node_puttext.py
@@ -6,7 +6,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 from node.draw_node.draw_util.draw_util import draw_info
 
@@ -49,7 +49,7 @@ def image_process(
     return image
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'PutText'
@@ -70,16 +70,20 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
-        tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input03')
-        tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input03'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_input02_name_port = self.input_port(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input02_name = tag_node_input02_name_port.dpg_tag
+        tag_node_input02_value_name = tag_node_input02_name_port.value_tag
+        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_TIME_MS, 'Input03')
+        tag_node_input03_name = tag_node_input03_name_port.dpg_tag
+        tag_node_input03_value_name = tag_node_input03_name_port.value_tag
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
 
-        tag_color_edit_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'ColorEdit'))
+        tag_color_edit_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'ColorEdit')
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -163,11 +167,11 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input03'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        input_value03_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Input03')
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
 
-        tag_color_edit_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'ColorEdit'))
+        tag_color_edit_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'ColorEdit')
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -177,19 +181,23 @@ class Node(DpgNodeABC):
         node_name = ''
         connection_info_src = ''
         connect_elapsed_time_flag = False
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
             if connection_type == self.TYPE_TEXT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = dpg_get_value(source_value_tag)
                 dpg_set_value(destination_value_tag, input_value)
             if connection_type == self.TYPE_TIME_MS:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = dpg_get_value(source_value_tag)
                 dpg_set_value(destination_value_tag, input_value)
@@ -197,7 +205,7 @@ class Node(DpgNodeABC):
                 connect_elapsed_time_flag = True
             if connection_type == self.TYPE_IMAGE:
                 # Get source node name for image (with ID)
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
                 node_name = connection_info_src.split(':')[1]
 
         # Get image
@@ -237,8 +245,8 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_color_edit_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'ColorEdit'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_color_edit_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'ColorEdit')
 
         text = dpg_get_value(input_value02_tag)
         color = dpg_get_value(tag_color_edit_value_name)
@@ -255,8 +263,8 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_color_edit_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'ColorEdit'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_color_edit_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'ColorEdit')
 
         text = setting_dict[input_value02_tag]
         color = setting_dict[tag_color_edit_value_name]

--- a/node/draw_node/node_result_image.py
+++ b/node/draw_node/node_result_image.py
@@ -5,12 +5,12 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 from node.draw_node.draw_util.draw_util import draw_info
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Result Image'
@@ -47,8 +47,8 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE,
-                                               'Input01')
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_image_name = self._value_tag(tag_node_input01_name)
 
         # OpenCV settings
@@ -112,8 +112,7 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_image_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
+        input_image_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Input01')
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         draw_info_on_result = self._opencv_setting_dict['draw_info_on_result']
@@ -121,13 +120,13 @@ class Node(DpgNodeABC):
         # Get source node name for image (with ID)
         node_name = ''
         connection_info_src = ''
-        for source_tag, _, connection_type in self._iter_connections(
+        for connection_info, source_tag, _, connection_type in self._iter_connection_infos(
                 connection_list):
             if connection_type != self.TYPE_IMAGE:
                 continue
 
-            connection_info_src = self._extract_source_node_key(source_tag)
-            node_name = self._extract_source_node_key(source_tag).split(':')[1]
+            connection_info_src = self._connection_source_node_key(connection_info, source_tag)
+            node_name = self._connection_source_node_key(connection_info, source_tag).split(':')[1]
 
         # Get image
         frame = node_image_dict.get(connection_info_src, None)

--- a/node/draw_node/node_result_large_image.py
+++ b/node/draw_node/node_result_large_image.py
@@ -6,12 +6,12 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 from node.draw_node.draw_util.draw_util import draw_info
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Result Image(Large)'
@@ -53,8 +53,8 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE,
-                                               'Input01')
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_image_name = self._value_tag(tag_node_input01_name)
 
         # OpenCV settings
@@ -114,8 +114,7 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        input_image_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
+        input_image_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Input01')
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         # OpenCV settings
@@ -124,13 +123,13 @@ class Node(DpgNodeABC):
         # Get source node name for image (with ID)
         node_name = ''
         connection_info_src = ''
-        for source_tag, _, connection_type in self._iter_connections(
+        for connection_info, source_tag, _, connection_type in self._iter_connection_infos(
                 connection_list):
             if connection_type != self.TYPE_IMAGE:
                 continue
 
-            connection_info_src = self._extract_source_node_key(source_tag)
-            node_name = self._extract_source_node_key(source_tag).split(':')[1]
+            connection_info_src = self._connection_source_node_key(connection_info, source_tag)
+            node_name = self._connection_source_node_key(connection_info, source_tag).split(':')[1]
 
         # Get image
         frame = node_image_dict.get(connection_info_src, None)

--- a/node/input_node/node_float_value.py
+++ b/node/input_node/node_float_value.py
@@ -4,10 +4,10 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Float Value'
@@ -26,7 +26,8 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Output01')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_FLOAT, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
 
         # Settings
@@ -69,9 +70,7 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        output_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Output01')
-        )
+        output_value_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Output01')
 
         output_value = round((dpg_get_value(output_value_tag)), 3)
 
@@ -86,9 +85,7 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        output_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Output01')
-        )
+        output_value_tag = self._node_value_tag(node_id, self.TYPE_FLOAT, 'Output01')
 
         output_value = float(setting_dict[output_value_tag])
 

--- a/node/input_node/node_int_value.py
+++ b/node/input_node/node_int_value.py
@@ -4,10 +4,10 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Int Value'
@@ -26,7 +26,8 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Output01')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_INT, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
 
         # Settings
@@ -69,9 +70,7 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        output_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_INT, 'Output01')
-        )
+        output_value_tag = self._node_value_tag(node_id, self.TYPE_INT, 'Output01')
 
         output_value = round((dpg_get_value(output_value_tag)), 3)
 
@@ -86,9 +85,7 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        output_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_INT, 'Output01')
-        )
+        output_value_tag = self._node_value_tag(node_id, self.TYPE_INT, 'Output01')
 
         output_value = float(setting_dict[output_value_tag])
 

--- a/node/input_node/node_rtsp_input.py
+++ b/node/input_node/node_rtsp_input.py
@@ -9,7 +9,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -35,7 +35,7 @@ def receive_image_process(rtsp_url, image_queue, request):
             break
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'RTSP'
@@ -76,15 +76,17 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input01'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_image_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input01_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Input01')
+        tag_node_input01_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input01')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_image_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
-        tag_node_button_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Button')
-        tag_node_button_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Button'))
+        tag_node_button_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Button')
+        tag_node_button_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Button')
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -174,9 +176,9 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input01'))
-        output_image_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value01_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input01')
+        output_image_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         small_window_w = self._opencv_setting_dict['input_window_width']
@@ -284,7 +286,7 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input01'))
+        tag_node_input01_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input01')
 
         pos = dpg.get_item_pos(tag_node_name)
         rtsp_url = dpg_get_value(tag_node_input01_value_name)
@@ -298,7 +300,7 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input01'))
+        tag_node_input01_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input01')
 
         rtsp_url = setting_dict[tag_node_input01_value_name]
 
@@ -306,8 +308,8 @@ class Node(DpgNodeABC):
 
     def _button(self, sender, data, user_data):
         tag_node_name = user_data
-        input_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input01'))
-        tag_node_button_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Button'))
+        input_value01_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input01')
+        tag_node_button_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Button')
 
         label = dpg.get_item_label(tag_node_button_value_name)
 

--- a/node/input_node/node_still_image.py
+++ b/node/input_node/node_still_image.py
@@ -8,11 +8,11 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Image'
@@ -51,10 +51,9 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_INT,
-                                               'Input01')
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE,
-                                                'Output01')
+        tag_node_input01_name = self._node_port_tag(node_id, self.TYPE_INT, 'Input01')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_image_name = self._value_tag(tag_node_output01_name)
 
         # OpenCV settings
@@ -137,8 +136,7 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        output_image_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
+        output_image_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         small_window_w = self._opencv_setting_dict['input_window_width']

--- a/node/input_node/node_video_input.py
+++ b/node/input_node/node_video_input.py
@@ -8,11 +8,11 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Video'
@@ -58,19 +58,22 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Input01')
-        tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Input03')
-        tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
-        tag_node_input04_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04')
-        tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
-        tag_node_input05_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05')
-        tag_node_input05_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_image_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input01_name = self._node_port_tag(node_id, self.TYPE_INT, 'Input01')
+        tag_node_input02_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_INT, 'Input03')
+        tag_node_input03_name = tag_node_input03_name_port.dpg_tag
+        tag_node_input03_value_name = tag_node_input03_name_port.value_tag
+        tag_node_input04_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Input04')
+        tag_node_input04_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input04')
+        tag_node_input05_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Input05')
+        tag_node_input05_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input05')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_image_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -210,12 +213,12 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
-        tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
-        tag_node_input05_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05'))
-        output_image_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input03_value_name = self._node_value_tag(node_id, self.TYPE_INT, 'Input03')
+        tag_node_input04_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input04')
+        tag_node_input05_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input05')
+        output_image_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         small_window_w = self._opencv_setting_dict['input_window_width']
@@ -223,12 +226,16 @@ class Node(DpgNodeABC):
         use_pref_counter = self._opencv_setting_dict['use_pref_counter']
 
         # Check connection info
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
             if connection_type == self.TYPE_INT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = int(dpg_get_value(source_value_tag))
                 input_value = max([self._min_val, input_value])
@@ -398,10 +405,10 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
-        tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
-        tag_node_input05_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05'))
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input03_value_name = self._node_value_tag(node_id, self.TYPE_INT, 'Input03')
+        tag_node_input04_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input04')
+        tag_node_input05_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input05')
 
         pos = dpg.get_item_pos(tag_node_name)
 
@@ -424,10 +431,10 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
-        tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
-        tag_node_input05_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05'))
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input03_value_name = self._node_value_tag(node_id, self.TYPE_INT, 'Input03')
+        tag_node_input04_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input04')
+        tag_node_input05_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input05')
 
         movie_path = setting_dict.get('movie_path', None)
         node_id = str(node_id)

--- a/node/input_node/node_video_set_frame_pos_input.py
+++ b/node/input_node/node_video_set_frame_pos_input.py
@@ -9,11 +9,11 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Video(Set Frame Position)'
@@ -57,15 +57,19 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Input01')
-        tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Input02')
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input02'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_image_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
-        tag_node_output03_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Output03')
-        tag_node_output03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Output03'))
+        tag_node_input01_name = self._node_port_tag(node_id, self.TYPE_INT, 'Input01')
+        tag_node_input02_name_port = self.input_port(node_id, self.TYPE_INT, 'Input02')
+        tag_node_input02_name = tag_node_input02_name_port.dpg_tag
+        tag_node_input02_value_name = tag_node_input02_name_port.value_tag
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_image_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
+        tag_node_output03_name_port = self.output_port(node_id, self.TYPE_INT, 'Output03')
+        tag_node_output03_name = tag_node_output03_name_port.dpg_tag
+        tag_node_output03_value_name = tag_node_output03_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -182,10 +186,10 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input02'))
-        output_image_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
-        output_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Output03'))
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_INT, 'Input02')
+        output_image_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
+        output_value03_tag = self._node_value_tag(node_id, self.TYPE_INT, 'Output03')
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         small_window_w = self._opencv_setting_dict['input_window_width']
@@ -196,11 +200,11 @@ class Node(DpgNodeABC):
 
         # Check connection info
         seek_input_value = None
-        for source_tag, _, connection_type in self._iter_connections(
+        for connection_info, source_tag, _, connection_type in self._iter_connection_infos(
                 connection_list):
             if connection_type == self.TYPE_INT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
                 # Get value
                 seek_input_value = int(dpg_get_value(source_value_tag))
                 seek_input_value = max([self._min_val, seek_input_value])
@@ -330,7 +334,7 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input02'))
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_INT, 'Input02')
 
         pos = dpg.get_item_pos(tag_node_name)
 
@@ -345,7 +349,7 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input02'))
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_INT, 'Input02')
 
         seek_value = setting_dict[tag_node_input02_value_name]
 

--- a/node/input_node/node_webcam_input.py
+++ b/node/input_node/node_webcam_input.py
@@ -7,11 +7,11 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'WebCam'
@@ -44,12 +44,14 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input01'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_image_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input01_name = self._node_port_tag(node_id, self.TYPE_INT, 'Input01')
+        tag_node_input01_value_name = self._node_value_tag(node_id, self.TYPE_INT, 'Input01')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_image_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -131,9 +133,9 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input01'))
-        output_image_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value01_tag = self._node_value_tag(node_id, self.TYPE_INT, 'Input01')
+        output_image_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         device_no_list = self._opencv_setting_dict['device_no_list']

--- a/node/node_abc.py
+++ b/node/node_abc.py
@@ -1,5 +1,15 @@
 from abc import ABCMeta, abstractmethod
+
 import dearpygui.dearpygui as dpg
+
+from node.port_model import NodeRef, PortRef
+
+
+class _PortTagString(str):
+    def __new__(cls, value, port_ref=None):
+        tag = str.__new__(cls, value)
+        tag.port_ref = port_ref
+        return tag
 
 
 class DpgNodeABC(metaclass=ABCMeta):
@@ -13,49 +23,6 @@ class DpgNodeABC(metaclass=ABCMeta):
     TYPE_IMAGE = 'Image'
     TYPE_TIME_MS = 'TimeMS'
     TYPE_TEXT = 'Text'
-
-    def _node_name(self, node_id):
-        return f'{node_id}:{self.node_tag}'
-
-    def _port_tag(self, node_name, value_type, port_name):
-        return f'{node_name}:{value_type}:{port_name}'
-
-    def _value_tag(self, port_tag):
-        return f'{port_tag}Value'
-
-    def _extract_source_node_key(self, source_tag):
-        source_tokens = source_tag.split(':')
-        if len(source_tokens) < 2:
-            return ''
-        return ':'.join(source_tokens[:2])
-
-    def _extract_port_name(self, tag):
-        tag_tokens = tag.split(':')
-        if len(tag_tokens) < 4:
-            return ''
-        return tag_tokens[3]
-
-    def _extract_node_id(self, tag):
-        tag_tokens = tag.split(':')
-        if len(tag_tokens) < 2:
-            return ''
-        return tag_tokens[0]
-
-    def _iter_connections(self, connection_list):
-        for connection_info in connection_list:
-            if not isinstance(connection_info, (list, tuple)) or len(connection_info) < 2:
-                continue
-
-            source_tag, destination_tag = connection_info[0], connection_info[1]
-            if not isinstance(source_tag, str) or not isinstance(destination_tag, str):
-                continue
-
-            source_tokens = source_tag.split(':')
-            if len(source_tokens) < 4:
-                continue
-
-            connection_type = source_tokens[2]
-            yield source_tag, destination_tag, connection_type
 
     @abstractmethod
     def add_node(
@@ -99,6 +66,234 @@ class DpgNodeABC(metaclass=ABCMeta):
         """
         del value_tag, value
         return False
+
+
+class DpgNodeBase(DpgNodeABC):
+    """Concrete base for DearPyGui nodes.
+
+    This base owns shared DearPyGui tag, connection parsing, and editor toolbar
+    helpers. `DpgNodeABC` remains the abstract plugin contract.
+    """
+
+    def _node_name(self, node_id):
+        return f'{node_id}:{self.node_tag}'
+
+    def _port_tag(self, node_name, value_type, port_name):
+        return f'{node_name}:{value_type}:{port_name}'
+
+    def _value_tag(self, port_tag):
+        port_ref = getattr(port_tag, 'port_ref', None)
+        if port_ref is not None and port_ref.value_tag:
+            return port_ref.value_tag
+        return f'{port_tag}Value'
+
+    def _node_port_tag(self, node_id, value_type, port_name):
+        return self._port_tag(self._node_name(node_id), value_type, port_name)
+
+    def _port_value_tag(self, node_name, value_type, port_name):
+        return self._value_tag(self._port_tag(node_name, value_type, port_name))
+
+    def _node_value_tag(self, node_id, value_type, port_name):
+        return self._value_tag(self._node_port_tag(node_id, value_type, port_name))
+
+    def node_ref(self, node_id):
+        return NodeRef(str(node_id), self.node_tag)
+
+    def set_port_registration_callback(self, callback):
+        self._port_registration_callback = callback
+
+    def get_declared_port_refs(self, node_id=None):
+        self._ensure_port_declaration_state()
+        if node_id is None:
+            return [
+                port_ref
+                for node_ports in self._declared_port_refs.values()
+                for port_ref in node_ports.values()
+            ]
+        node_ports = self._declared_port_refs.get(self._node_name(node_id), {})
+        return list(node_ports.values())
+
+    def input_port(self, node_id, data_type, port_name=None):
+        return self._declare_port(node_id, data_type, 'Input', port_name)
+
+    def output_port(self, node_id, data_type, port_name=None):
+        return self._declare_port(node_id, data_type, 'Output', port_name)
+
+    def parameter_port(self, node_id, data_type, port_name=None, control_tag=None):
+        return self._declare_port(
+            node_id,
+            data_type,
+            'Input',
+            port_name,
+            control_tag=control_tag,
+            default_control_tag=True,
+        )
+
+    def _declare_port(
+        self,
+        node_id,
+        data_type,
+        direction,
+        port_name=None,
+        control_tag=None,
+        default_control_tag=False,
+    ):
+        self._ensure_port_declaration_state()
+        node_ref = self.node_ref(node_id)
+        port_name, index = self._resolve_port_name(node_ref, direction, port_name)
+        dpg_tag = self._port_tag(node_ref.node_id_name, data_type, port_name)
+        value_tag = self._value_tag(dpg_tag)
+        if control_tag is None and default_control_tag:
+            control_tag = value_tag
+        port_ref = PortRef(
+            node_ref=node_ref,
+            direction=direction,
+            data_type=data_type,
+            index=index,
+            port_name=port_name,
+            dpg_tag=dpg_tag,
+            value_tag=value_tag,
+            control_tag=control_tag,
+        )
+        self._remember_port_ref(port_ref)
+        return port_ref
+
+    def _resolve_port_name(self, node_ref, direction, port_name):
+        counter_key = (node_ref.node_id_name, direction)
+        if port_name is None:
+            index = self._port_index_counters.get(counter_key, 0) + 1
+            self._port_index_counters[counter_key] = index
+            return f'{direction}{index:02d}', index
+
+        index = self._port_index(port_name, direction)
+        self._port_index_counters[counter_key] = max(
+            self._port_index_counters.get(counter_key, 0),
+            index,
+        )
+        return port_name, index
+
+    def _port_index(self, port_name, direction):
+        if not isinstance(port_name, str) or not port_name.startswith(direction):
+            raise ValueError(
+                f'{direction} port names must start with {direction}: {port_name}'
+            )
+        index_text = port_name[len(direction):]
+        try:
+            return int(index_text)
+        except ValueError as exc:
+            raise ValueError(
+                f'{direction} port names must end with a numeric index: {port_name}'
+            ) from exc
+
+    def _remember_port_ref(self, port_ref):
+        node_ports = self._declared_port_refs.setdefault(
+            port_ref.node_ref.node_id_name,
+            {},
+        )
+        node_ports[port_ref.dpg_tag] = port_ref
+        callback = getattr(self, '_port_registration_callback', None)
+        if callback is not None:
+            callback(port_ref)
+
+    def _ensure_port_declaration_state(self):
+        if not hasattr(self, '_declared_port_refs'):
+            self._declared_port_refs = {}
+        if not hasattr(self, '_port_index_counters'):
+            self._port_index_counters = {}
+        if not hasattr(self, '_port_registration_callback'):
+            self._port_registration_callback = None
+
+    def _extract_source_node_key(self, source_tag):
+        port_ref = getattr(source_tag, 'port_ref', None)
+        if port_ref is not None:
+            return port_ref.node_ref.node_id_name
+        source_tokens = source_tag.split(':')
+        if len(source_tokens) < 2:
+            return ''
+        return ':'.join(source_tokens[:2])
+
+    def _extract_port_name(self, tag):
+        port_ref = getattr(tag, 'port_ref', None)
+        if port_ref is not None:
+            return port_ref.port_name
+        tag_tokens = tag.split(':')
+        if len(tag_tokens) < 4:
+            return ''
+        return tag_tokens[3]
+
+    def _extract_node_id(self, tag):
+        port_ref = getattr(tag, 'port_ref', None)
+        if port_ref is not None:
+            return port_ref.node_ref.node_id
+        tag_tokens = tag.split(':')
+        if len(tag_tokens) < 2:
+            return ''
+        return tag_tokens[0]
+
+    def _connection_source_node_key(self, connection_info, source_tag):
+        source_port = getattr(connection_info, 'source', None)
+        if source_port is not None:
+            return source_port.node_ref.node_id_name
+        return self._extract_source_node_key(source_tag)
+
+    def _connection_port_name(self, connection_info, destination_tag):
+        destination_port = getattr(connection_info, 'destination', None)
+        if destination_port is not None:
+            return destination_port.port_name
+        return self._extract_port_name(destination_tag)
+
+    def _connection_value_tag(self, connection_info, endpoint, fallback_tag):
+        port_ref = getattr(connection_info, endpoint, None)
+        if port_ref is not None and port_ref.value_tag:
+            return port_ref.value_tag
+        return self._value_tag(fallback_tag)
+
+    def _iter_connection_infos(self, connection_list):
+        for connection_info in connection_list:
+            source_port = getattr(connection_info, 'source', None)
+            destination_port = getattr(connection_info, 'destination', None)
+            if hasattr(connection_info, 'legacy_pair'):
+                source_tag, destination_tag = connection_info.legacy_pair
+            elif (
+                isinstance(connection_info, (list, tuple))
+                and len(connection_info) >= 2
+            ):
+                source_tag, destination_tag = connection_info[0], connection_info[1]
+            else:
+                continue
+
+            if not isinstance(source_tag, str) or not isinstance(destination_tag, str):
+                continue
+
+            if source_port is not None:
+                connection_type = source_port.data_type
+            else:
+                source_tokens = source_tag.split(':')
+                if len(source_tokens) < 4:
+                    continue
+                connection_type = source_tokens[2]
+            yield (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+            )
+
+    def _iter_connections(self, connection_list):
+        for (
+            connection_info,
+            source_tag,
+            destination_tag,
+            connection_type,
+        ) in self._iter_connection_infos(connection_list):
+            yield (
+                _PortTagString(source_tag, getattr(connection_info, 'source', None)),
+                _PortTagString(
+                    destination_tag,
+                    getattr(connection_info, 'destination', None),
+                ),
+                connection_type,
+            )
 
     def _editor_toolbar_attr_tag(self, node_id):
         return f'{self._node_name(node_id)}:ToolbarAttr'

--- a/node/other_node/node_on_off_switch.py
+++ b/node/other_node/node_on_off_switch.py
@@ -8,7 +8,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -16,7 +16,7 @@ def image_process(image):
     return image
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'ON/OFF Switch'
@@ -40,17 +40,15 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE,
-                                               'Input01')
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = self._value_tag(tag_node_input01_name)
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE,
-                                                'Output01')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
 
-        tag_switch_select_name = self._port_tag(tag_node_name, self.TYPE_TEXT,
-                                             'Switch')
-        tag_switch_select_value_name = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Switch'))
+        tag_switch_select_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Switch')
+        tag_switch_select_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Switch')
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -119,23 +117,21 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        output_value01_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
 
-        tag_switch_select_value_name = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Switch'))
+        tag_switch_select_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Switch')
 
         small_window_w = int(self._opencv_setting_dict['process_width'] / 2)
         small_window_h = int(self._opencv_setting_dict['process_height'] / 2)
 
         # Get source node name for image (with ID)
         connection_info_src = ''
-        for source_tag, _, connection_type in self._iter_connections(
+        for connection_info, source_tag, _, connection_type in self._iter_connection_infos(
                 connection_list):
             if connection_type != self.TYPE_IMAGE:
                 continue
 
-            connection_info_src = self._extract_source_node_key(source_tag)
+            connection_info_src = self._connection_source_node_key(connection_info, source_tag)
 
         # Get ON/OFF selection state
         switch_status = dpg_get_value(tag_switch_select_value_name)

--- a/node/other_node/node_video_writer.py
+++ b/node/other_node/node_video_writer.py
@@ -10,11 +10,11 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Video Writer'
@@ -41,11 +41,12 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
 
-        tag_node_button_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Button')
-        tag_node_button_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Button'))
+        tag_node_button_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Button')
+        tag_node_button_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Button')
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -106,17 +107,17 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
-        tag_node_button_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Button'))
+        input_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_button_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Button')
 
         # Get source node name for image (with ID)
         connection_info_src = ''
-        for source_tag, _, connection_type in self._iter_connections(
+        for connection_info, source_tag, _, connection_type in self._iter_connection_infos(
                 connection_list):
             if connection_type != self.TYPE_IMAGE:
                 continue
 
-            connection_info_src = self._extract_source_node_key(source_tag)
+            connection_info_src = self._connection_source_node_key(connection_info, source_tag)
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -197,7 +198,7 @@ class Node(DpgNodeABC):
 
     def _recording_button(self, sender, data, user_data):
         tag_node_name = user_data
-        tag_node_button_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Button'))
+        tag_node_button_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Button')
 
         label = dpg.get_item_label(tag_node_button_value_name)
 

--- a/node/port_model.py
+++ b/node/port_model.py
@@ -1,0 +1,86 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class NodeRef:
+    node_id: str
+    node_tag: str
+
+    @property
+    def node_id_name(self):
+        return f'{self.node_id}:{self.node_tag}'
+
+
+@dataclass(frozen=True)
+class PortRef:
+    node_ref: NodeRef
+    direction: str
+    data_type: str
+    index: int
+    port_name: str
+    dpg_tag: str
+    value_tag: str = None
+    control_tag: str = None
+
+
+@dataclass(frozen=True)
+class LinkRef:
+    source: PortRef
+    destination: PortRef
+
+    @property
+    def source_tag(self):
+        return self.source.dpg_tag
+
+    @property
+    def destination_tag(self):
+        return self.destination.dpg_tag
+
+    @property
+    def legacy_pair(self):
+        return [self.source_tag, self.destination_tag]
+
+    def __iter__(self):
+        yield self.source
+        yield self.destination
+
+    def __len__(self):
+        return 2
+
+    def __getitem__(self, index):
+        return (self.source, self.destination)[index]
+
+
+@dataclass(frozen=True)
+class LinkConnectionAdapter:
+    link_ref: LinkRef
+
+    @property
+    def source(self):
+        return self.link_ref.source
+
+    @property
+    def destination(self):
+        return self.link_ref.destination
+
+    @property
+    def source_tag(self):
+        return self.link_ref.source_tag
+
+    @property
+    def destination_tag(self):
+        return self.link_ref.destination_tag
+
+    @property
+    def legacy_pair(self):
+        return self.link_ref.legacy_pair
+
+    def __iter__(self):
+        yield self.source_tag
+        yield self.destination_tag
+
+    def __len__(self):
+        return 2
+
+    def __getitem__(self, index):
+        return (self.source_tag, self.destination_tag)[index]

--- a/node/preview_release_node/node_code_exec.py
+++ b/node/preview_release_node/node_code_exec.py
@@ -9,7 +9,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -57,7 +57,7 @@ def image_process(input_image, input_value, code):
     return output_image
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Exec Python Code'
@@ -78,16 +78,15 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE,
-                                               'Input01')
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = self._value_tag(tag_node_input01_name)
-        tag_node_input02_value_name = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE,
-                                                'Output01')
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS,
-                                                'Output02')
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = self._value_tag(tag_node_output02_name)
 
         # OpenCV settings
@@ -168,12 +167,9 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        output_value01_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
 
         small_window_w = int(self._opencv_setting_dict['process_width'] * 2.5)
         small_window_h = int(self._opencv_setting_dict['process_height'] * 2.5)
@@ -182,12 +178,12 @@ class Node(DpgNodeABC):
         # Get source node name for image (with ID)
         src_node_result = None
         connection_info_src = ''
-        for source_tag, _, connection_type in self._iter_connections(
+        for connection_info, source_tag, _, connection_type in self._iter_connection_infos(
                 connection_list):
             if connection_type == self.TYPE_INT:
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
             if connection_type == self.TYPE_IMAGE:
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
                 src_node_result = node_result_dict.get(connection_info_src,
                                                        None)
 
@@ -228,8 +224,7 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
 
         pos = dpg.get_item_pos(tag_node_name)
         code = dpg_get_value(tag_node_input02_value_name)
@@ -243,8 +238,7 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
 
         code = setting_dict[tag_node_input02_value_name]
 

--- a/node/preview_release_node/node_mot.py
+++ b/node/preview_release_node/node_mot.py
@@ -8,7 +8,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 from node.preview_release_node.mot.motpy.motpy import Motpy
@@ -18,7 +18,7 @@ from node.preview_release_node.mot.motpy.motpy import Motpy
 from node.draw_node.draw_util.draw_util import draw_multi_object_tracking_info
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'MOT(Preview Release Version)'
@@ -50,14 +50,17 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
-        tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name = tag_node_input01_name_port.dpg_tag
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_input02_name = self._node_port_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input02_value_name = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -137,9 +140,9 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -148,12 +151,16 @@ class Node(DpgNodeABC):
         # Check connection info
         src_node_name = ''
         connection_info_src = ''
-        for source_tag, destination_tag, connection_type in self._iter_connections(
-                connection_list):
+        for (
+                connection_info,
+                source_tag,
+                destination_tag,
+                connection_type,
+        ) in self._iter_connection_infos(connection_list):
             if connection_type == self.TYPE_INT:
                 # Get connection tag
-                source_value_tag = self._value_tag(source_tag)
-                destination_value_tag = self._value_tag(destination_tag)
+                source_value_tag = self._connection_value_tag(connection_info, 'source', source_tag)
+                destination_value_tag = self._connection_value_tag(connection_info, 'destination', destination_tag)
                 # Update value
                 input_value = int(dpg_get_value(source_value_tag))
                 input_value = max([self._min_val, input_value])
@@ -161,7 +168,7 @@ class Node(DpgNodeABC):
                 dpg_set_value(destination_value_tag, input_value)
             if connection_type == self.TYPE_IMAGE:
                 # Get source node name for image (with ID)
-                connection_info_src = self._extract_source_node_key(source_tag)
+                connection_info_src = self._connection_source_node_key(connection_info, source_tag)
                 src_node_name = connection_info_src.split(':')[1]
 
         # Get image
@@ -293,7 +300,7 @@ class Node(DpgNodeABC):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
 
         # Selected model
         model_name = dpg_get_value(input_value02_tag)
@@ -309,7 +316,7 @@ class Node(DpgNodeABC):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
+        input_value02_tag = self._node_value_tag(node_id, self.TYPE_TEXT, 'Input02')
 
         model_name = setting_dict[input_value02_tag]
 

--- a/node/preview_release_node/node_screen_capture.py
+++ b/node/preview_release_node/node_screen_capture.py
@@ -11,7 +11,7 @@ import dearpygui.dearpygui as dpg
 
 from node_editor.util import dpg_get_value, dpg_set_value
 
-from node.node_abc import DpgNodeABC
+from node.node_abc import DpgNodeBase
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -30,7 +30,7 @@ def screen_capture_process(image_queue, request):
             break
 
 
-class Node(DpgNodeABC):
+class Node(DpgNodeBase):
     _ver = '0.0.1'
 
     node_label = 'Screen Capture'
@@ -58,10 +58,12 @@ class Node(DpgNodeABC):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        tag_node_output02_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02')
-        tag_node_output02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name = tag_node_output01_name_port.dpg_tag
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name = tag_node_output02_name_port.dpg_tag
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -123,8 +125,8 @@ class Node(DpgNodeABC):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        output_value01_tag = self._node_value_tag(node_id, self.TYPE_IMAGE, 'Output01')
+        output_value02_tag = self._node_value_tag(node_id, self.TYPE_TIME_MS, 'Output02')
 
         small_window_w = self._opencv_setting_dict['input_window_width']
         small_window_h = self._opencv_setting_dict['input_window_height']

--- a/node/process_node/node_canny.py
+++ b/node/process_node/node_canny.py
@@ -51,11 +51,11 @@ class Node(DeclarativeImageProcessNodeBase):
         if min_val > max_val:
             min_val, max_val = max_val - 1, min_val + 1
             dpg_set_value(
-                self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input02')),
+                self._port_value_tag(tag_node_name, self.TYPE_INT, 'Input02'),
                 min_val,
             )
             dpg_set_value(
-                self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03')),
+                self._port_value_tag(tag_node_name, self.TYPE_INT, 'Input03'),
                 max_val,
             )
 

--- a/node/process_node/node_crop.py
+++ b/node/process_node/node_crop.py
@@ -83,22 +83,22 @@ class Node(DeclarativeImageProcessNodeBase):
         if min_x > max_x:
             min_x, max_x = max_x - 0.01, min_x + 0.01
             dpg_set_value(
-                self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input02')),
+                self._port_value_tag(tag_node_name, self.TYPE_FLOAT, 'Input02'),
                 min_x,
             )
             dpg_set_value(
-                self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03')),
+                self._port_value_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'),
                 max_x,
             )
 
         if min_y > max_y:
             min_y, max_y = max_y - 0.01, min_y + 0.01
             dpg_set_value(
-                self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input04')),
+                self._port_value_tag(tag_node_name, self.TYPE_FLOAT, 'Input04'),
                 min_y,
             )
             dpg_set_value(
-                self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input05')),
+                self._port_value_tag(tag_node_name, self.TYPE_FLOAT, 'Input05'),
                 max_y,
             )
 

--- a/node/process_node/node_gaussian_blur.py
+++ b/node/process_node/node_gaussian_blur.py
@@ -56,12 +56,8 @@ class Node(DeclarativeImageProcessNodeBase):
     ]
 
     def on_node_added(self, tag_node_name):
-        sigma_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03')
-        )
-        auto_sigma_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_INT, 'Input04')
-        )
+        sigma_tag = self._port_value_tag(tag_node_name, self.TYPE_FLOAT, 'Input03')
+        auto_sigma_tag = self._port_value_tag(tag_node_name, self.TYPE_INT, 'Input04')
 
         def _toggle_sigma(_sender, app_data, user_data):
             dpg.configure_item(user_data, enabled=not app_data)
@@ -84,12 +80,8 @@ class Node(DeclarativeImageProcessNodeBase):
         dpg.configure_item(sigma_tag, enabled=not auto_sigma)
 
     def on_settings_applied(self, tag_node_name):
-        sigma_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03')
-        )
-        auto_sigma_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_INT, 'Input04')
-        )
+        sigma_tag = self._port_value_tag(tag_node_name, self.TYPE_FLOAT, 'Input03')
+        auto_sigma_tag = self._port_value_tag(tag_node_name, self.TYPE_INT, 'Input04')
         auto_sigma = bool(dpg.get_value(auto_sigma_tag))
         dpg.configure_item(sigma_tag, enabled=not auto_sigma)
 

--- a/node/process_node/node_hue_saturation_adjustment.py
+++ b/node/process_node/node_hue_saturation_adjustment.py
@@ -172,7 +172,7 @@ class Node(DeclarativeImageProcessNodeBase):
     def build_custom_ui(self, tag_node_name, node_id, width, callback):
         del callback
         with dpg.node_attribute(
-            tag=self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input99'),
+            tag=self._node_port_tag(node_id, self.TYPE_TEXT, 'Input99'),
             attribute_type=dpg.mvNode_Attr_Static,
         ):
             dpg.add_button(
@@ -190,8 +190,10 @@ class Node(DeclarativeImageProcessNodeBase):
                 dpg.add_key_press_handler(dpg.mvKey_Right, callback=self._nudge_slider, user_data=1)
 
         for parameter in self.parameters:
-            slider_tag = self._value_tag(
-                self._port_tag(tag_node_name, parameter['type'], parameter['port'])
+            slider_tag = self._node_value_tag(
+                node_id,
+                parameter['type'],
+                parameter['port'],
             )
             dpg.configure_item(slider_tag, callback=self._slider_touched_callback, user_data=node_id)
 
@@ -245,11 +247,12 @@ class Node(DeclarativeImageProcessNodeBase):
 
     def _reset_all_callback(self, sender, app_data, user_data):
         del sender, app_data
-        tag_node_name = self._node_name(user_data)
         batch_changes = []
         for parameter in self.parameters:
-            parameter_value_tag = self._value_tag(
-                self._port_tag(tag_node_name, parameter['type'], parameter['port'])
+            parameter_value_tag = self._node_value_tag(
+                user_data,
+                parameter['type'],
+                parameter['port'],
             )
             before_value = dpg.get_value(parameter_value_tag)
             after_value = parameter['default']

--- a/node/process_node/node_resize.py
+++ b/node/process_node/node_resize.py
@@ -73,18 +73,18 @@ class Node(DeclarativeImageProcessNodeBase):
         height = max(1, min(4096, height))
 
         dpg_set_value(
-            self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input02')),
+            self._port_value_tag(tag_node_name, self.TYPE_INT, 'Input02'),
             width,
         )
         dpg_set_value(
-            self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03')),
+            self._port_value_tag(tag_node_name, self.TYPE_INT, 'Input03'),
             height,
         )
 
         if interpolation_text not in self._interpolation:
             interpolation_text = 'INTER_LINEAR'
             dpg_set_value(
-                self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04')),
+                self._port_value_tag(tag_node_name, self.TYPE_TEXT, 'Input04'),
                 interpolation_text,
             )
 

--- a/node_editor/graph_runtime.py
+++ b/node_editor/graph_runtime.py
@@ -4,6 +4,8 @@ import copy
 import hashlib
 import pickle
 
+from node.port_model import LinkConnectionAdapter
+
 
 class GraphRuntime:
     """Owns graph update state (images/results/cache) and executes update ticks."""
@@ -158,6 +160,31 @@ def _strip_cache_meta(result):
     }
 
 
+def _connection_info_to_update_connection(connection_info):
+    if isinstance(connection_info, LinkConnectionAdapter):
+        return connection_info
+    if (
+        hasattr(connection_info, 'source')
+        and hasattr(connection_info, 'destination')
+        and hasattr(connection_info, 'legacy_pair')
+    ):
+        return LinkConnectionAdapter(connection_info)
+    return connection_info
+
+
+def _connection_info_node_names(connection_info):
+    if (
+        hasattr(connection_info, 'source')
+        and hasattr(connection_info, 'destination')
+    ):
+        return (
+            connection_info.source.node_ref.node_id_name,
+            connection_info.destination.node_ref.node_id_name,
+        )
+
+    source_tag, dest_tag = connection_info
+    return ':'.join(source_tag.split(':')[:2]), ':'.join(dest_tag.split(':')[:2])
+
 def update_node_info(
     node_editor,
     node_image_dict,
@@ -187,9 +214,9 @@ def update_node_info(
         if len(connection_info) != 2:
             return False
 
-        source_tag, dest_tag = connection_info
-        source_node_id_name = ':'.join(source_tag.split(':')[:2])
-        dest_node_id_name = ':'.join(dest_tag.split(':')[:2])
+        source_node_id_name, dest_node_id_name = _connection_info_node_names(
+            connection_info
+        )
         if source_node_id_name not in valid_nodes:
             return False
         if dest_node_id_name not in valid_nodes:
@@ -214,7 +241,10 @@ def update_node_info(
     for deleted_node_id_name in deleted_result_node_id_name_list:
         del node_result_dict[deleted_node_id_name]
 
-    sorted_node_connection_dict = node_editor.get_sorted_node_connection()
+    if hasattr(node_editor, 'get_sorted_node_connection_refs'):
+        sorted_node_connection_dict = node_editor.get_sorted_node_connection_refs()
+    else:
+        sorted_node_connection_dict = node_editor.get_sorted_node_connection()
 
     for node_id_name in node_list:
         if node_id_name not in node_image_dict:
@@ -229,10 +259,14 @@ def update_node_info(
             except Exception:
                 pass
 
-        connection_list = sorted_node_connection_dict.get(node_id_name, [])
-        connection_list = [
-            connection_info for connection_info in connection_list
+        connection_refs = sorted_node_connection_dict.get(node_id_name, [])
+        connection_refs = [
+            connection_info for connection_info in connection_refs
             if _is_valid_connection(connection_info, active_node_set)
+        ]
+        connection_list = [
+            _connection_info_to_update_connection(connection_info)
+            for connection_info in connection_refs
         ]
 
         node_instance = node_editor.get_node_instance(node_name)

--- a/node_editor/history.py
+++ b/node_editor/history.py
@@ -1,6 +1,17 @@
 from dataclasses import dataclass
 
 
+def _iter_history_link_pairs(editor, links):
+    for link in links:
+        yield editor._cntrl_history_link_pair(link)
+
+
+def _history_link_pair(editor, source_tag, dest_tag=None):
+    if dest_tag is None:
+        return editor._cntrl_history_link_pair(source_tag)
+    return editor._cntrl_history_link_pair((source_tag, dest_tag))
+
+
 @dataclass(frozen=True)
 class AddNodeCommand:
     node_id: int
@@ -15,7 +26,9 @@ class AddNodeCommand:
             f'{self.node_id}:{self.node_tag}'
         )
         editor._cntrl_delete_node_by_tag(node_id_name)
-        for source_tag, dest_tag in self.replaced_links:
+        for source_tag, dest_tag in _iter_history_link_pairs(
+            editor, self.replaced_links
+        ):
             editor._cntrl_add_link_by_tags(source_tag, dest_tag)
 
     def redo(self, editor):
@@ -25,9 +38,13 @@ class AddNodeCommand:
             self.pos,
             self.setting,
         )
-        for source_tag, dest_tag in self.replaced_links:
+        for source_tag, dest_tag in _iter_history_link_pairs(
+            editor, self.replaced_links
+        ):
             editor._cntrl_remove_link_by_tags(source_tag, dest_tag)
-        for source_tag, dest_tag in self.created_links:
+        for source_tag, dest_tag in _iter_history_link_pairs(
+            editor, self.created_links
+        ):
             editor._cntrl_add_link_by_tags(source_tag, dest_tag)
         return recreated_node_id_name
 
@@ -47,21 +64,32 @@ class DeleteNodesCommand:
                 node_info['pos'],
                 node_info['setting'],
             )
-        for source_tag, dest_tag in self.healed_links:
+        for source_tag, dest_tag in _iter_history_link_pairs(
+            editor, self.healed_links
+        ):
             editor._cntrl_remove_link_by_tags(source_tag, dest_tag)
-        for source_tag, dest_tag in self.removed_links + self.removed_selected_links:
+        for source_tag, dest_tag in _iter_history_link_pairs(
+            editor, self.removed_links + self.removed_selected_links
+        ):
             editor._cntrl_add_link_by_tags(source_tag, dest_tag)
 
     def redo(self, editor):
-        for source_tag, dest_tag in self.removed_selected_links:
+        for source_tag, dest_tag in _iter_history_link_pairs(
+            editor, self.removed_selected_links
+        ):
             editor._cntrl_remove_link_by_tags(source_tag, dest_tag)
-        for source_tag, dest_tag in self.removed_links:
+        for source_tag, dest_tag in _iter_history_link_pairs(
+            editor, self.removed_links
+        ):
             editor._cntrl_remove_link_by_tags(source_tag, dest_tag)
         for node_info in self.nodes:
-            editor._cntrl_delete_node_by_tag(editor._cntrl_resolve_history_node_id_name(
+            node_id_name = editor._cntrl_resolve_history_node_id_name(
                 f"{node_info['node_id']}:{node_info['node_tag']}"
-            ))
-        for source_tag, dest_tag in self.healed_links:
+            )
+            editor._cntrl_delete_node_by_tag(node_id_name)
+        for source_tag, dest_tag in _iter_history_link_pairs(
+            editor, self.healed_links
+        ):
             editor._cntrl_add_link_by_tags(source_tag, dest_tag)
 
 
@@ -85,7 +113,9 @@ class ImportGraphCommand:
                 node_info['pos'],
                 node_info['setting'],
             )
-        for source_tag, dest_tag in self.links:
+        for source_tag, dest_tag in _iter_history_link_pairs(
+            editor, self.links
+        ):
             editor._cntrl_add_or_replace_link_by_tags(source_tag, dest_tag)
 
 
@@ -108,41 +138,65 @@ class MoveNodeCommand:
 
 @dataclass(frozen=True)
 class AddLinkCommand:
-    source_tag: str
-    dest_tag: str
+    source_tag: object
+    dest_tag: object = None
 
     def undo(self, editor):
-        editor._cntrl_remove_link_by_tags(self.source_tag, self.dest_tag)
+        source_tag, dest_tag = _history_link_pair(
+            editor, self.source_tag, self.dest_tag
+        )
+        editor._cntrl_remove_link_by_tags(source_tag, dest_tag)
 
     def redo(self, editor):
-        editor._cntrl_add_link_by_tags(self.source_tag, self.dest_tag)
+        source_tag, dest_tag = _history_link_pair(
+            editor, self.source_tag, self.dest_tag
+        )
+        editor._cntrl_add_link_by_tags(source_tag, dest_tag)
 
 
 @dataclass(frozen=True)
 class RemoveLinkCommand:
-    source_tag: str
-    dest_tag: str
+    source_tag: object
+    dest_tag: object = None
 
     def undo(self, editor):
-        editor._cntrl_add_link_by_tags(self.source_tag, self.dest_tag)
+        source_tag, dest_tag = _history_link_pair(
+            editor, self.source_tag, self.dest_tag
+        )
+        editor._cntrl_add_link_by_tags(source_tag, dest_tag)
 
     def redo(self, editor):
-        editor._cntrl_remove_link_by_tags(self.source_tag, self.dest_tag)
+        source_tag, dest_tag = _history_link_pair(
+            editor, self.source_tag, self.dest_tag
+        )
+        editor._cntrl_remove_link_by_tags(source_tag, dest_tag)
 
 
 @dataclass(frozen=True)
 class ReplaceLinkCommand:
-    old_source_tag: str
-    new_source_tag: str
-    dest_tag: str
+    old_source_tag: object
+    new_source_tag: object
+    dest_tag: object = None
 
     def undo(self, editor):
-        editor._cntrl_remove_link_by_tags(self.new_source_tag, self.dest_tag)
-        editor._cntrl_add_link_by_tags(self.old_source_tag, self.dest_tag)
+        new_source_tag, dest_tag = _history_link_pair(
+            editor, self.new_source_tag, self.dest_tag
+        )
+        old_source_tag, _ = _history_link_pair(
+            editor, self.old_source_tag, self.dest_tag
+        )
+        editor._cntrl_remove_link_by_tags(new_source_tag, dest_tag)
+        editor._cntrl_add_link_by_tags(old_source_tag, dest_tag)
 
     def redo(self, editor):
-        editor._cntrl_remove_link_by_tags(self.old_source_tag, self.dest_tag)
-        editor._cntrl_add_link_by_tags(self.new_source_tag, self.dest_tag)
+        old_source_tag, dest_tag = _history_link_pair(
+            editor, self.old_source_tag, self.dest_tag
+        )
+        new_source_tag, _ = _history_link_pair(
+            editor, self.new_source_tag, self.dest_tag
+        )
+        editor._cntrl_remove_link_by_tags(old_source_tag, dest_tag)
+        editor._cntrl_add_link_by_tags(new_source_tag, dest_tag)
 
 
 @dataclass(frozen=True)

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -10,30 +10,9 @@ from glob import glob
 from collections import OrderedDict
 from importlib import import_module
 from pathlib import Path
-from dataclasses import dataclass
-
 import dearpygui.dearpygui as dpg
 
-
-@dataclass(frozen=True)
-class NodeRef:
-    node_id: str
-    node_tag: str
-
-    @property
-    def node_id_name(self):
-        return f'{self.node_id}:{self.node_tag}'
-
-
-@dataclass(frozen=True)
-class PortRef:
-    node_ref: NodeRef
-    direction: str
-    data_type: str
-    index: int
-    dpg_tag: str
-
-
+from node.port_model import LinkRef, NodeRef, PortRef
 from node_editor.history import (
     AddNodeCommand,
     DeleteNodesCommand,
@@ -100,6 +79,7 @@ class DpgNodeEditor(object):
         self._node_link_list = []
         self._link_view_id_map = {}
         self._node_connection_dict = OrderedDict([])
+        self._node_connection_ref_dict = OrderedDict([])
         self._pending_insert_link_dpg_id = None
         self._pending_add_from_output_tag = None
         self._pending_add_to_input_tag = None
@@ -108,6 +88,7 @@ class DpgNodeEditor(object):
         self._port_registry = {}
         self._link_registry = {}
         self._link_by_dest_port = {}
+        self._link_by_dest_port_ref = {}
         self._use_debug_print = use_debug_print
         self._terminate_flag = False
         self._opencv_setting_dict = opencv_setting_dict
@@ -132,6 +113,39 @@ class DpgNodeEditor(object):
     def _mdl_get_node_ref(self, node_id_name):
         return self._node_registry.get(node_id_name)
 
+    def _mdl_register_port_ref(self, port_ref):
+        self._port_registry[port_ref.dpg_tag] = port_ref
+        if port_ref.node_ref.node_id_name not in self._node_registry:
+            self._mdl_register_node_ref(port_ref.node_ref)
+
+    def _mdl_register_node_declared_ports(self, node, node_id):
+        get_declared_port_refs = getattr(node, 'get_declared_port_refs', None)
+        if not callable(get_declared_port_refs):
+            return
+        declared_ports = get_declared_port_refs(node_id)
+        if not isinstance(declared_ports, (list, tuple)):
+            return
+        for port_ref in declared_ports:
+            self._mdl_register_port_ref(port_ref)
+
+    def _mdl_iter_registered_ports(
+        self,
+        direction=None,
+        node_id_name=None,
+        data_type=None,
+    ):
+        for port_ref in list(self._port_registry.values()):
+            if direction is not None and port_ref.direction != direction:
+                continue
+            if (
+                node_id_name is not None
+                and port_ref.node_ref.node_id_name != node_id_name
+            ):
+                continue
+            if data_type is not None and port_ref.data_type != data_type:
+                continue
+            yield port_ref
+
     def _cntrl_parse_port_tag(self, port_tag):
         if not isinstance(port_tag, str):
             return None
@@ -154,44 +168,100 @@ class DpgNodeEditor(object):
             index = int(index_text)
         except ValueError:
             return None
-        parsed = PortRef(node_ref, direction, parts[2], index, port_tag)
-        self._port_registry[port_tag] = parsed
-        if node_ref.node_id_name not in self._node_registry:
-            self._mdl_register_node_ref(node_ref)
+        parsed = PortRef(
+            node_ref=node_ref,
+            direction=direction,
+            data_type=parts[2],
+            index=index,
+            port_name=port_name,
+            dpg_tag=port_tag,
+            value_tag=f'{port_tag}Value',
+        )
+        self._mdl_register_port_ref(parsed)
         return parsed
 
-    def _mdl_validate_link(self, source_tag, dest_tag):
-        source_port = self._cntrl_parse_port_tag(source_tag)
-        dest_port = self._cntrl_parse_port_tag(dest_tag)
+    def _mdl_resolve_port_ref(self, port):
+        if isinstance(port, PortRef):
+            return port
+        return self._cntrl_parse_port_tag(port)
+
+    def _mdl_validate_link(self, source, destination):
+        source_port = self._mdl_resolve_port_ref(source)
+        dest_port = self._mdl_resolve_port_ref(destination)
         if source_port is None or dest_port is None:
             return None
         if source_port.direction != 'Output' or dest_port.direction != 'Input':
             return None
         if source_port.data_type != dest_port.data_type:
             return None
-        return source_port, dest_port
+        return LinkRef(source_port, dest_port)
 
-    def _mdl_add_link(self, source_tag, dest_tag):
-        validated_ports = self._mdl_validate_link(source_tag, dest_tag)
-        if validated_ports is None:
+    def _mdl_add_link(self, source, destination):
+        link_ref = self._mdl_validate_link(source, destination)
+        if link_ref is None:
             return False
-        if dest_tag in self._link_by_dest_port:
+        source_tag = link_ref.source_tag
+        dest_tag = link_ref.destination_tag
+        if dest_tag in self._link_by_dest_port_ref:
             return False
-        self._node_link_list.append([source_tag, dest_tag])
-        self._link_registry[(source_tag, dest_tag)] = validated_ports
+        self._node_link_list.append(link_ref.legacy_pair)
+        self._link_registry[(source_tag, dest_tag)] = link_ref
         self._link_by_dest_port[dest_tag] = source_tag
+        self._link_by_dest_port_ref[dest_tag] = link_ref
         return True
 
+    def _mdl_get_link_ref_by_destination(self, destination):
+        dest_port = self._mdl_resolve_port_ref(destination)
+        if dest_port is None:
+            return None
+        return self._link_by_dest_port_ref.get(dest_port.dpg_tag)
+
     def _mdl_get_link_by_destination(self, dest_tag):
+        link_ref = self._mdl_get_link_ref_by_destination(dest_tag)
+        if link_ref is not None:
+            return link_ref.legacy_pair
         source_tag = self._link_by_dest_port.get(dest_tag)
         if source_tag is not None:
             return [source_tag, dest_tag]
         return None
 
+    def _mdl_serialize_port_ref(self, port_ref):
+        return {
+            'node': {
+                'id': port_ref.node_ref.node_id,
+                'tag': port_ref.node_ref.node_tag,
+            },
+            'direction': port_ref.direction,
+            'data_type': port_ref.data_type,
+            'index': port_ref.index,
+            'port_name': port_ref.port_name,
+            'dpg_tag': port_ref.dpg_tag,
+        }
+
+    def _mdl_serialize_link_ref(self, link_ref):
+        return {
+            'source': self._mdl_serialize_port_ref(link_ref.source),
+            'destination': self._mdl_serialize_port_ref(link_ref.destination),
+        }
+
+    def _mdl_iter_link_refs(self):
+        for source_tag, dest_tag in list(self._node_link_list):
+            link_ref = self._link_registry.get((source_tag, dest_tag))
+            if link_ref is None:
+                link_ref = self._mdl_validate_link(source_tag, dest_tag)
+            if link_ref is not None:
+                yield link_ref
+
+    def _mdl_get_link_refs_for_export(self):
+        return list(self._mdl_iter_link_refs())
+
     def _mdl_get_export_settings(self):
         setting_dict = {}
         setting_dict['node_list'] = self._node_list
-        setting_dict['link_list'] = self._node_link_list
+        setting_dict['link_refs'] = [
+            self._mdl_serialize_link_ref(link_ref)
+            for link_ref in self._mdl_get_link_refs_for_export()
+        ]
         for node_id_name in self._node_list:
             node_id, node_name = node_id_name.split(':')
             node = self._node_instance_list[node_name]
@@ -228,6 +298,7 @@ class DpgNodeEditor(object):
             if source_node == node_id_name or destination_node == node_id_name:
                 self._link_registry.pop((link_info[0], link_info[1]), None)
                 self._link_by_dest_port.pop(link_info[1], None)
+                self._link_by_dest_port_ref.pop(link_info[1], None)
                 self._node_link_list.remove(link_info)
         self._node_registry.pop(node_id_name, None)
         self._mdl_sort_node_graph()
@@ -236,35 +307,38 @@ class DpgNodeEditor(object):
         source_tag, dest_tag = link
         self._link_registry.pop((source_tag, dest_tag), None)
         self._link_by_dest_port.pop(dest_tag, None)
+        self._link_by_dest_port_ref.pop(dest_tag, None)
         self._node_link_list.remove(link)
         self._mdl_sort_node_graph()
 
     def _mdl_sort_node_graph(self):
         node_list = self._node_list
-        node_link_list = self._node_link_list
 
         node_id_dict = OrderedDict({})
         node_connection_dict = OrderedDict({})
+        node_connection_ref_dict = OrderedDict({})
 
         # Organize node IDs and node links as dictionaries
-        for source, destination in node_link_list:
-            source_id = int(source.split(':')[0])
-            destination_id = int(destination.split(':')[0])
+        for link_ref in self._mdl_iter_link_refs():
+            source_id = int(link_ref.source.node_ref.node_id)
+            destination_id = int(link_ref.destination.node_ref.node_id)
 
             if destination_id not in node_id_dict:
                 node_id_dict[destination_id] = [source_id]
             else:
                 node_id_dict[destination_id].append(source_id)
 
-            split_destination = destination.split(':')
-            node_name = split_destination[0] + ':' + split_destination[1]
+            node_name = link_ref.destination.node_ref.node_id_name
             if node_name not in node_connection_dict:
-                node_connection_dict[node_name] = [[source, destination]]
+                node_connection_dict[node_name] = [link_ref.legacy_pair]
+                node_connection_ref_dict[node_name] = [link_ref]
             else:
-                node_connection_dict[node_name].append([source, destination])
+                node_connection_dict[node_name].append(link_ref.legacy_pair)
+                node_connection_ref_dict[node_name].append(link_ref)
 
         node_id_list = list(node_id_dict.items())
         node_connection_list = list(node_connection_dict.items())
+        node_connection_ref_list = list(node_connection_ref_dict.items())
 
         # Reorder processing from input to output
         index = 0
@@ -287,6 +361,10 @@ class DpgNodeEditor(object):
                             check_index], node_connection_list[
                                 index] = node_connection_list[
                                     index], node_connection_list[check_index]
+                        node_connection_ref_list[
+                            check_index], node_connection_ref_list[
+                                index] = node_connection_ref_list[
+                                    index], node_connection_ref_list[check_index]
 
                         swap_flag = True
                         break
@@ -315,8 +393,10 @@ class DpgNodeEditor(object):
 
         for unfinded_value in unfinded_id_dict.values():
             node_connection_list.insert(0, (unfinded_value, []))
+            node_connection_ref_list.insert(0, (unfinded_value, []))
 
         self._node_connection_dict = OrderedDict(node_connection_list)
+        self._node_connection_ref_dict = OrderedDict(node_connection_ref_list)
 
     # -------------------------------------------------------------------------
     # View functions
@@ -611,6 +691,8 @@ class DpgNodeEditor(object):
 
     def _vw_add_node(self, node_tag, new_id, pos):
         node = self._node_instance_list[node_tag]
+        if hasattr(node, 'set_port_registration_callback'):
+            node.set_port_registration_callback(self._mdl_register_port_ref)
         node.add_node(
             self._node_editor_tag,
             new_id,
@@ -618,6 +700,7 @@ class DpgNodeEditor(object):
             opencv_setting_dict=self._opencv_setting_dict,
             callback=self._cntrl_node_callback,
         )
+        self._mdl_register_node_declared_ports(node, new_id)
 
     def _vw_add_link(self, source, destination):
         source_id = source
@@ -774,6 +857,7 @@ class DpgNodeEditor(object):
         self._node_list.append(new_node_id_name)
         self._cntrl_update_node_position_cache(new_node_id_name)
         node_setting = self.get_node_instance(user_data).get_setting_dict(str(new_id))
+        self._cntrl_prime_parameter_last_values_from_setting(node_setting)
         self._cntrl_push_undo_command(
             AddNodeCommand(
                 new_id,
@@ -794,6 +878,19 @@ class DpgNodeEditor(object):
             print(f'\tself._node_list : {", ".join(self._node_list)}')
             print()
 
+    def _cntrl_remap_node_setting_for_id(self, node_tag, node_id, setting):
+        if not isinstance(setting, dict):
+            return setting
+        remapped_setting = {}
+        for key, value in setting.items():
+            if isinstance(key, str):
+                key_parts = key.split(':')
+                if len(key_parts) >= 2 and key_parts[1] == node_tag:
+                    key_parts[0] = str(node_id)
+                    key = ':'.join(key_parts)
+            remapped_setting[key] = value
+        return remapped_setting
+
     def _cntrl_add_node_with_id(self, node_tag, node_id, pos, setting):
         self._node_id = max(self._node_id, int(node_id))
         node_id_name = f'{node_id}:{node_tag}'
@@ -804,10 +901,14 @@ class DpgNodeEditor(object):
         self._node_list.append(node_id_name)
         self._cntrl_update_node_position_cache(node_id_name)
         node = self.get_node_instance(node_tag)
+        remapped_setting = self._cntrl_remap_node_setting_for_id(
+            node_tag, node_id, copy.deepcopy(setting)
+        )
         try:
-            node.set_setting_dict(str(node_id), copy.deepcopy(setting))
+            node.set_setting_dict(str(node_id), remapped_setting)
         except Exception:
             pass
+        self._cntrl_prime_parameter_last_values_from_setting(remapped_setting)
         return node_id_name
 
     def _cntrl_add_node_from_history(self, node_tag, requested_node_id, pos, setting):
@@ -843,6 +944,37 @@ class DpgNodeEditor(object):
         parts[0] = resolved_id
         parts[1] = resolved_tag
         return ':'.join(parts)
+
+    def _cntrl_history_link_pair(self, link):
+        source_tag = None
+        dest_tag = None
+        if hasattr(link, 'legacy_pair'):
+            source_tag, dest_tag = link.legacy_pair
+        elif isinstance(link, dict):
+            source_tag = link.get('source_tag')
+            dest_tag = link.get('destination_tag')
+            if source_tag is None:
+                source_payload = link.get('source')
+                if isinstance(source_payload, dict):
+                    source_tag = source_payload.get('dpg_tag')
+            if dest_tag is None:
+                destination_payload = link.get('destination')
+                if isinstance(destination_payload, dict):
+                    dest_tag = destination_payload.get('dpg_tag')
+        else:
+            source_tag, dest_tag = link
+        return [
+            self._cntrl_resolve_history_port_tag(source_tag),
+            self._cntrl_resolve_history_port_tag(dest_tag),
+        ]
+
+    def _cntrl_history_link_payload(self, source_tag, dest_tag):
+        source_tag = self._cntrl_resolve_history_port_tag(source_tag)
+        dest_tag = self._cntrl_resolve_history_port_tag(dest_tag)
+        link_ref = self._link_registry.get((source_tag, dest_tag))
+        if link_ref is not None:
+            return link_ref
+        return (source_tag, dest_tag)
 
     def _cntrl_node_callback(self, event_name, data):
         if event_name == 'toggle_result_node':
@@ -1214,39 +1346,20 @@ class DpgNodeEditor(object):
         return None
 
 
-    def _cntrl_get_hovered_output_port_tag(self):
-        for node_id_name in self._node_list:
-            parts = node_id_name.split(':')
-            if len(parts) < 2:
-                continue
-            node_id = parts[0]
-            node_name = parts[1]
-            for index in range(100):
-                port_tag = f'{node_id}:{node_name}:Image:Output{index:02d}'
-                if dpg.does_item_exist(port_tag) and dpg.is_item_hovered(port_tag):
-                    return port_tag
-                for port_type in ('Int', 'Float', 'Text', 'Time', 'TimeMs', 'TimeMS'):
-                    type_port_tag = f'{node_id}:{node_name}:{port_type}:Output{index:02d}'
-                    if dpg.does_item_exist(type_port_tag) and dpg.is_item_hovered(type_port_tag):
-                        return type_port_tag
+    def _cntrl_get_hovered_registered_port_tag(self, direction):
+        for port_ref in self._mdl_iter_registered_ports(direction=direction):
+            if (
+                dpg.does_item_exist(port_ref.dpg_tag)
+                and dpg.is_item_hovered(port_ref.dpg_tag)
+            ):
+                return port_ref.dpg_tag
         return None
 
+    def _cntrl_get_hovered_output_port_tag(self):
+        return self._cntrl_get_hovered_registered_port_tag('Output')
+
     def _cntrl_get_hovered_input_port_tag(self):
-        for node_id_name in self._node_list:
-            parts = node_id_name.split(':')
-            if len(parts) < 2:
-                continue
-            node_id = parts[0]
-            node_name = parts[1]
-            for index in range(100):
-                port_tag = f'{node_id}:{node_name}:Image:Input{index:02d}'
-                if dpg.does_item_exist(port_tag) and dpg.is_item_hovered(port_tag):
-                    return port_tag
-                for port_type in ('Int', 'Float', 'Text', 'Time', 'TimeMs', 'TimeMS'):
-                    type_port_tag = f'{node_id}:{node_name}:{port_type}:Input{index:02d}'
-                    if dpg.does_item_exist(type_port_tag) and dpg.is_item_hovered(type_port_tag):
-                        return type_port_tag
-        return None
+        return self._cntrl_get_hovered_registered_port_tag('Input')
 
     def _cntrl_get_insert_node_pos(self, source_tag, dest_tag):
         source_node = ':'.join(source_tag.split(':')[:2])
@@ -1259,6 +1372,14 @@ class DpgNodeEditor(object):
             int((source_pos[1] + dest_pos[1]) / 2),
         ]
 
+    def _cntrl_port_ref_has_dpg_attribute_type(self, port_ref, expected_attr_type):
+        if expected_attr_type is None:
+            return True
+        if not dpg.does_item_exist(port_ref.dpg_tag):
+            return False
+        config = dpg.get_item_configuration(port_ref.dpg_tag)
+        return config.get('attribute_type') == expected_attr_type
+
     def _cntrl_find_node_port(self, node_id_name, port_type, port_prefix):
         expected_attr_type = None
         if port_prefix == 'Input':
@@ -1266,18 +1387,16 @@ class DpgNodeEditor(object):
         elif port_prefix == 'Output':
             expected_attr_type = dpg.mvNode_Attr_Output
 
-        for index in range(100):
-            port_tag = (
-                f'{node_id_name}:{port_type}:{port_prefix}{index:02d}'
-            )
-            if not dpg.does_item_exist(port_tag):
-                continue
+        for port_ref in self._mdl_iter_registered_ports(
+            direction=port_prefix,
+            node_id_name=node_id_name,
+            data_type=port_type,
+        ):
+            if self._cntrl_port_ref_has_dpg_attribute_type(
+                port_ref, expected_attr_type
+            ):
+                return port_ref.dpg_tag
 
-            if expected_attr_type is not None:
-                config = dpg.get_item_configuration(port_tag)
-                if config.get('attribute_type') != expected_attr_type:
-                    continue
-            return port_tag
         return None
 
 
@@ -1327,7 +1446,9 @@ class DpgNodeEditor(object):
                     user_data,
                     list(new_pos),
                     copy.deepcopy(node_setting),
-                    [(source_tag, input_tag)],
+                    [
+                        self._cntrl_history_link_payload(source_tag, input_tag)
+                    ],
                     [],
                 )
             )
@@ -1369,7 +1490,11 @@ class DpgNodeEditor(object):
 
         replaced_links = []
         existing_link = self._mdl_get_link_by_destination(dest_tag)
+        existing_link_payload = None
         if existing_link is not None:
+            existing_link_payload = self._cntrl_history_link_payload(
+                existing_link[0], existing_link[1]
+            )
             self._cntrl_remove_link_by_tags(
                 existing_link[0], existing_link[1], record_history=False
             )
@@ -1385,13 +1510,15 @@ class DpgNodeEditor(object):
                 self._cntrl_push_undo_command(
                     CompositeCommand(
                         [
-                            RemoveLinkCommand(replaced_links[0][0], replaced_links[0][1]),
+                            RemoveLinkCommand(existing_link_payload),
                             AddNodeCommand(
                                 new_id,
                                 user_data,
                                 list(new_pos),
                                 copy.deepcopy(node_setting),
-                                [(output_tag, dest_tag)],
+                                [
+                                    self._cntrl_history_link_payload(output_tag, dest_tag)
+                                ],
                                 [],
                             ),
                         ]
@@ -1404,7 +1531,9 @@ class DpgNodeEditor(object):
                         user_data,
                         list(new_pos),
                         copy.deepcopy(node_setting),
-                        [(output_tag, dest_tag)],
+                        [
+                            self._cntrl_history_link_payload(output_tag, dest_tag)
+                        ],
                         [],
                     )
                 )
@@ -1474,6 +1603,7 @@ class DpgNodeEditor(object):
             return
 
         original_link = [source_tag, dest_tag]
+        original_link_payload = self._cntrl_history_link_payload(source_tag, dest_tag)
         self._mdl_delete_link(original_link)
         self._link_view_id_map.pop(tuple(original_link), None)
         self._vw_delete_item(selected_link_dpg_id)
@@ -1492,15 +1622,15 @@ class DpgNodeEditor(object):
         self._cntrl_push_undo_command(
             CompositeCommand(
                 [
-                    RemoveLinkCommand(source_tag, dest_tag),
+                    RemoveLinkCommand(original_link_payload),
                     AddNodeCommand(
                         new_id,
                         user_data,
                         list(insert_pos),
                         copy.deepcopy(node_setting),
                         [
-                            (source_tag, input_tag),
-                            (output_tag, dest_tag),
+                            self._cntrl_history_link_payload(source_tag, input_tag),
+                            self._cntrl_history_link_payload(output_tag, dest_tag),
                         ],
                         [],
                     ),
@@ -1558,7 +1688,11 @@ class DpgNodeEditor(object):
             return
 
         existing_link = self._mdl_get_link_by_destination(dest_tag)
+        existing_link_payload = None
         if existing_link is not None:
+            existing_link_payload = self._cntrl_history_link_payload(
+                existing_link[0], existing_link[1]
+            )
             if existing_link[0] == source_tag:
                 self._vw_set_link_feedback(
                     'Link rejected: input is already connected to that source.'
@@ -1575,13 +1709,16 @@ class DpgNodeEditor(object):
             if existing_link is not None:
                 self._cntrl_push_undo_command(
                     ReplaceLinkCommand(
-                        existing_link[0],
-                        source_tag,
-                        dest_tag,
+                        existing_link_payload,
+                        self._cntrl_history_link_payload(source_tag, dest_tag),
                     )
                 )
             else:
-                self._cntrl_push_undo_command(AddLinkCommand(source_tag, dest_tag))
+                self._cntrl_push_undo_command(
+                    AddLinkCommand(
+                        self._cntrl_history_link_payload(source_tag, dest_tag)
+                    )
+                )
             self._vw_set_link_feedback('')
         self._mdl_sort_node_graph()
 
@@ -1645,7 +1782,7 @@ class DpgNodeEditor(object):
         if setting_dict is None:
             return
 
-        if 'node_list' not in setting_dict or 'link_list' not in setting_dict:
+        if 'node_list' not in setting_dict or 'link_refs' not in setting_dict:
             raise KeyError('Invalid node editor setting file format.')
 
         id_map = {}
@@ -1692,22 +1829,18 @@ class DpgNodeEditor(object):
                 }
             )
 
-        for link_info in setting_dict['link_list']:
-            source_parts = link_info[0].split(':')
-            dest_parts = link_info[1].split(':')
-
-            if source_parts[0] in id_map and dest_parts[0] in id_map:
-                source_parts[0] = id_map[source_parts[0]]
-                dest_parts[0] = id_map[dest_parts[0]]
-                new_source = ':'.join(source_parts)
-                new_destination = ':'.join(dest_parts)
-                if self._cntrl_add_or_replace_link_by_tags(new_source, new_destination):
-                    imported_links_payload = [
-                        link
-                        for link in imported_links_payload
-                        if link[1] != new_destination
-                    ]
-                    imported_links_payload.append((new_source, new_destination))
+        for new_source, new_destination in self._cntrl_iter_import_link_tags(
+            setting_dict, id_map
+        ):
+            if self._cntrl_add_or_replace_link_by_tags(new_source, new_destination):
+                imported_links_payload = [
+                    link
+                    for link in imported_links_payload
+                    if self._cntrl_history_link_pair(link)[1] != new_destination
+                ]
+                imported_links_payload.append(
+                    self._cntrl_history_link_payload(new_source, new_destination)
+                )
 
         self._mdl_sort_node_graph()
         self._cntrl_sync_position_cache()
@@ -1715,6 +1848,42 @@ class DpgNodeEditor(object):
             'nodes': imported_nodes_payload,
             'links': imported_links_payload,
         }
+
+    def _cntrl_iter_import_link_tags(self, setting_dict, id_map):
+        for link_ref_payload in setting_dict['link_refs']:
+            link_tags = self._cntrl_import_link_ref_payload_to_tags(
+                link_ref_payload, id_map
+            )
+            if link_tags is not None:
+                yield link_tags
+
+    def _cntrl_import_link_ref_payload_to_tags(self, link_ref_payload, id_map):
+        if not isinstance(link_ref_payload, dict):
+            return None
+        source_tag = self._cntrl_import_port_ref_payload_to_tag(
+            link_ref_payload.get('source'), id_map
+        )
+        destination_tag = self._cntrl_import_port_ref_payload_to_tag(
+            link_ref_payload.get('destination'), id_map
+        )
+        if source_tag is None or destination_tag is None:
+            return None
+        return source_tag, destination_tag
+
+    def _cntrl_import_port_ref_payload_to_tag(self, port_ref_payload, id_map):
+        if not isinstance(port_ref_payload, dict):
+            return None
+        node_payload = port_ref_payload.get('node')
+        if not isinstance(node_payload, dict):
+            return None
+        old_node_id = str(node_payload.get('id'))
+        new_node_id = id_map.get(old_node_id)
+        node_tag = node_payload.get('tag')
+        data_type = port_ref_payload.get('data_type')
+        port_name = port_ref_payload.get('port_name')
+        if not all([new_node_id, node_tag, data_type, port_name]):
+            return None
+        return f'{new_node_id}:{node_tag}:{data_type}:{port_name}'
 
     def _cntrl_sync_position_cache(self):
         self._node_position_cache = {}
@@ -1793,10 +1962,11 @@ class DpgNodeEditor(object):
         link = [source_tag, dest_tag]
         if link not in self._node_link_list:
             return False
+        history_link = self._cntrl_history_link_payload(source_tag, dest_tag)
         self._mdl_delete_link(link)
         self._vw_delete_link(source_tag, dest_tag)
         if record_history:
-            self._cntrl_push_undo_command(RemoveLinkCommand(source_tag, dest_tag))
+            self._cntrl_push_undo_command(RemoveLinkCommand(history_link))
         return True
 
     def _cntrl_capture_move_start_positions(self, sender, data):
@@ -1946,6 +2116,8 @@ class DpgNodeEditor(object):
         self._suspend_parameter_history = True
         try:
             action(self)
+            self._mdl_sort_node_graph()
+            self._cntrl_sync_position_cache()
         finally:
             self._suspend_parameter_history = False
 
@@ -1974,14 +2146,12 @@ class DpgNodeEditor(object):
 
         links_by_dest_node = {}
         outgoing_edges = []
-        for source_tag, dest_tag in self._node_link_list:
-            source_port = self._port_registry.get(source_tag)
-            dest_port = self._port_registry.get(dest_tag)
-            if source_port is None or dest_port is None:
-                continue
-            source_node = source_port.node_ref.node_id_name
-            dest_node = dest_port.node_ref.node_id_name
-            link_type = source_port.data_type
+        for link_ref in self._mdl_iter_link_refs():
+            source_tag = link_ref.source_tag
+            dest_tag = link_ref.destination_tag
+            source_node = link_ref.source.node_ref.node_id_name
+            dest_node = link_ref.destination.node_ref.node_id_name
+            link_type = link_ref.source.data_type
             links_by_dest_node.setdefault(dest_node, []).append(
                 (source_tag, dest_tag, source_node, dest_node, link_type)
             )
@@ -2054,14 +2224,20 @@ class DpgNodeEditor(object):
             )
             for source_tag, dest_tag in list(self._node_link_list):
                 if source_tag.startswith(f'{node_id}:{node_name}:') or dest_tag.startswith(f'{node_id}:{node_name}:'):
-                    removed_links.append((source_tag, dest_tag))
+                    removed_links.append(
+                        self._cntrl_history_link_payload(source_tag, dest_tag)
+                    )
         for node_tag in selected_node_tags:
             self._cntrl_delete_node_by_tag(node_tag)
 
+        reconnect_link_payloads = []
         for source_tag, dest_tag in reconnect_pairs:
             if self._mdl_add_link(source_tag, dest_tag):
                 link_dpg_id = self._vw_add_link(source_tag, dest_tag)
                 self._vw_register_link(source_tag, dest_tag, link_dpg_id)
+                reconnect_link_payloads.append(
+                    self._cntrl_history_link_payload(source_tag, dest_tag)
+                )
 
         for link_dpg_id in selected_link_ids:
             if not dpg.does_item_exist(link_dpg_id):
@@ -2070,15 +2246,16 @@ class DpgNodeEditor(object):
                 link = self._cntrl_get_link_from_dpg_id(link_dpg_id)
             except Exception:
                 continue
+            history_link = self._cntrl_history_link_payload(link[0], link[1])
             if self._cntrl_remove_link_by_tags(link[0], link[1], record_history=False):
-                removed_selected_links.append((link[0], link[1]))
+                removed_selected_links.append(history_link)
 
         if deleted_nodes_payload:
             self._cntrl_push_undo_command(
                 DeleteNodesCommand(
                     deleted_nodes_payload,
                     removed_links,
-                    reconnect_pairs,
+                    reconnect_link_payloads,
                     removed_selected_links,
                 )
             )
@@ -2090,25 +2267,20 @@ class DpgNodeEditor(object):
             print(f'\tself._node_connection_dict : {self._node_connection_dict}')
 
     def _cntrl_would_create_cycle(self, source_tag, dest_tag):
-        source_port = self._cntrl_parse_port_tag(source_tag)
-        dest_port = self._cntrl_parse_port_tag(dest_tag)
-        if source_port is None or dest_port is None:
+        link_ref = self._mdl_validate_link(source_tag, dest_tag)
+        if link_ref is None:
             return False
 
-        source_node = source_port.node_ref.node_id_name
-        dest_node = dest_port.node_ref.node_id_name
+        source_node = link_ref.source.node_ref.node_id_name
+        dest_node = link_ref.destination.node_ref.node_id_name
         if source_node == dest_node:
             return True
 
         adjacency = {}
-        for existing_source_tag, existing_dest_tag in self._node_link_list:
-            existing_source = self._cntrl_parse_port_tag(existing_source_tag)
-            existing_dest = self._cntrl_parse_port_tag(existing_dest_tag)
-            if existing_source is None or existing_dest is None:
-                continue
-            adjacency.setdefault(existing_source.node_ref.node_id_name, set()).add(
-                existing_dest.node_ref.node_id_name
-            )
+        for existing_link_ref in self._mdl_iter_link_refs():
+            adjacency.setdefault(
+                existing_link_ref.source.node_ref.node_id_name, set()
+            ).add(existing_link_ref.destination.node_ref.node_id_name)
         adjacency.setdefault(source_node, set()).add(dest_node)
 
         stack = [dest_node]
@@ -2142,6 +2314,9 @@ class DpgNodeEditor(object):
 
     def get_sorted_node_connection(self):
         return self._node_connection_dict
+
+    def get_sorted_node_connection_refs(self):
+        return self._node_connection_ref_dict
 
     def get_node_instance(self, node_name):
         return self._node_instance_list.get(node_name, None)

--- a/tests/test.json
+++ b/tests/test.json
@@ -5,20 +5,6 @@
         "3:Curves",
         "4:ResultImageLarge"
     ],
-    "link_list": [
-        [
-            "1:Image:Image:Output01",
-            "2:Blur:Image:Input01"
-        ],
-        [
-            "2:Blur:Image:Output01",
-            "3:Curves:Image:Input01"
-        ],
-        [
-            "3:Curves:Image:Output01",
-            "4:ResultImageLarge:Image:Input01"
-        ]
-    ],
     "1:Image": {
         "id": "1",
         "name": "Image",
@@ -97,5 +83,79 @@
                 2
             ]
         }
-    }
+    },
+    "link_refs": [
+        {
+            "source": {
+                "node": {
+                    "id": "1",
+                    "tag": "Image"
+                },
+                "direction": "Output",
+                "data_type": "Image",
+                "index": 1,
+                "port_name": "Output01",
+                "dpg_tag": "1:Image:Image:Output01"
+            },
+            "destination": {
+                "node": {
+                    "id": "2",
+                    "tag": "Blur"
+                },
+                "direction": "Input",
+                "data_type": "Image",
+                "index": 1,
+                "port_name": "Input01",
+                "dpg_tag": "2:Blur:Image:Input01"
+            }
+        },
+        {
+            "source": {
+                "node": {
+                    "id": "2",
+                    "tag": "Blur"
+                },
+                "direction": "Output",
+                "data_type": "Image",
+                "index": 1,
+                "port_name": "Output01",
+                "dpg_tag": "2:Blur:Image:Output01"
+            },
+            "destination": {
+                "node": {
+                    "id": "3",
+                    "tag": "Curves"
+                },
+                "direction": "Input",
+                "data_type": "Image",
+                "index": 1,
+                "port_name": "Input01",
+                "dpg_tag": "3:Curves:Image:Input01"
+            }
+        },
+        {
+            "source": {
+                "node": {
+                    "id": "3",
+                    "tag": "Curves"
+                },
+                "direction": "Output",
+                "data_type": "Image",
+                "index": 1,
+                "port_name": "Output01",
+                "dpg_tag": "3:Curves:Image:Output01"
+            },
+            "destination": {
+                "node": {
+                    "id": "4",
+                    "tag": "ResultImageLarge"
+                },
+                "direction": "Input",
+                "data_type": "Image",
+                "index": 1,
+                "port_name": "Input01",
+                "dpg_tag": "4:ResultImageLarge:Image:Input01"
+            }
+        }
+    ]
 }

--- a/tests/unit/test_declarative_process_nodes.py
+++ b/tests/unit/test_declarative_process_nodes.py
@@ -1,7 +1,9 @@
 import pytest
 import numpy as np
 
+from node.port_model import LinkConnectionAdapter, LinkRef, NodeRef, PortRef
 from node.base import declarative_node_base as base_module
+from node import node_abc as node_abc_module
 import node.process_node.node_blur as blur_module
 import node.process_node.node_brightness as brightness_module
 import node.process_node.node_contrast as contrast_module
@@ -42,6 +44,24 @@ class DpgStub:
         return [10, 20]
 
 
+def _port_ref(node_id, node_tag, direction, data_type, port_name):
+    prefix = 'Input' if direction == 'Input' else 'Output'
+    dpg_tag = f'{node_id}:{node_tag}:{data_type}:{port_name}'
+    return PortRef(
+        node_ref=NodeRef(str(node_id), node_tag),
+        direction=direction,
+        data_type=data_type,
+        index=int(port_name[len(prefix):]),
+        port_name=port_name,
+        dpg_tag=dpg_tag,
+        value_tag=f'{dpg_tag}Value',
+    )
+
+
+def _link_adapter(source, destination):
+    return LinkConnectionAdapter(LinkRef(source, destination))
+
+
 def _prepare_node(node):
     node._opencv_setting_dict = {
         'process_width': 8,
@@ -61,8 +81,16 @@ def test_blur_node_update_with_parameter_link(monkeypatch):
     written = {}
 
     monkeypatch.setattr(base_module, 'dpg_get_value', lambda tag: values.get(tag))
-    monkeypatch.setattr(base_module, 'dpg_set_value', lambda tag, value: written.setdefault(tag, value))
-    monkeypatch.setattr(base_module, 'convert_cv_to_dpg', lambda frame, w, h: ('texture', frame.shape, w, h))
+    monkeypatch.setattr(
+        base_module,
+        'dpg_set_value',
+        lambda tag, value: written.setdefault(tag, value),
+    )
+    monkeypatch.setattr(
+        base_module,
+        'convert_cv_to_dpg',
+        lambda frame, w, h: ('texture', frame.shape, w, h),
+    )
     monkeypatch.setattr(blur_module.cv2, 'blur', lambda f, k: f, raising=False)
 
     frame = np.full((8, 8, 3), 127, dtype=np.uint8)
@@ -79,6 +107,50 @@ def test_blur_node_update_with_parameter_link(monkeypatch):
     assert result is None
     assert out_frame.shape == frame.shape
     assert written['2:Blur:Int:Input02Value'] == 5
+    assert written['2:Blur:Image:Output01Value'][0] == 'texture'
+
+
+def test_blur_node_update_with_typed_connection_adapters(monkeypatch):
+    node = BlurNode()
+    _prepare_node(node)
+
+    image_output = _port_ref(1, 'ImageSource', 'Output', 'Image', 'Output01')
+    image_input = _port_ref(2, 'Blur', 'Input', 'Image', 'Input01')
+    int_output = _port_ref(1, 'IntValue', 'Output', 'Int', 'Output01')
+    int_input = _port_ref(2, 'Blur', 'Input', 'Int', 'Input02')
+    values = {
+        int_output.value_tag: 7,
+        int_input.value_tag: 1,
+    }
+    written = {}
+
+    monkeypatch.setattr(base_module, 'dpg_get_value', lambda tag: values.get(tag))
+    monkeypatch.setattr(
+        base_module,
+        'dpg_set_value',
+        lambda tag, value: written.setdefault(tag, value),
+    )
+    monkeypatch.setattr(
+        base_module,
+        'convert_cv_to_dpg',
+        lambda frame, w, h: ('texture', frame.shape, w, h),
+    )
+    monkeypatch.setattr(blur_module.cv2, 'blur', lambda f, k: f, raising=False)
+
+    frame = np.full((8, 8, 3), 127, dtype=np.uint8)
+    out_frame, result = node.update(
+        2,
+        [
+            _link_adapter(image_output, image_input),
+            _link_adapter(int_output, int_input),
+        ],
+        {image_output.node_ref.node_id_name: frame},
+        {},
+    )
+
+    assert result is None
+    assert out_frame.shape == frame.shape
+    assert written[int_input.value_tag] == 7
     assert written['2:Blur:Image:Output01Value'][0] == 'texture'
 
 
@@ -972,3 +1044,98 @@ def test_warmth_tint_node_update_clamps_linked_values(monkeypatch):
     assert out_frame.shape == frame.shape
     assert writes['301:WarmthTint:Int:Input02Value'] == 100
     assert writes['301:WarmthTint:Int:Input03Value'] == -100
+
+
+class DpgContextRecorder:
+    mvNode_Attr_Input = 'input'
+    mvNode_Attr_Output = 'output'
+    mvNode_Attr_Static = 'static'
+    mvFormat_Float_rgb = 'float-rgb'
+
+    def __init__(self):
+        self.node_attributes = []
+        self.raw_textures = []
+        self.widgets = []
+
+    class _Context:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def texture_registry(self, **kwargs):
+        return self._Context()
+
+    def node(self, **kwargs):
+        return self._Context()
+
+    def node_attribute(self, **kwargs):
+        self.node_attributes.append(kwargs)
+        return self._Context()
+
+    def group(self, **kwargs):
+        return self._Context()
+
+    def add_raw_texture(self, *args, **kwargs):
+        self.raw_textures.append((args, kwargs))
+
+    def add_button(self, **kwargs):
+        self.widgets.append(('button', kwargs))
+
+    def add_checkbox(self, **kwargs):
+        self.widgets.append(('checkbox', kwargs))
+
+    def add_slider_int(self, **kwargs):
+        self.widgets.append(('slider_int', kwargs))
+
+    def add_slider_float(self, **kwargs):
+        self.widgets.append(('slider_float', kwargs))
+
+    def add_input_int(self, **kwargs):
+        self.widgets.append(('input_int', kwargs))
+
+    def add_combo(self, *args, **kwargs):
+        self.widgets.append(('combo', args, kwargs))
+
+    def add_text(self, **kwargs):
+        self.widgets.append(('text', kwargs))
+
+
+def test_declarative_add_node_declares_typed_ports(monkeypatch):
+    node = BlurNode()
+    dpg_recorder = DpgContextRecorder()
+    registered_ports = []
+    node.set_port_registration_callback(registered_ports.append)
+
+    monkeypatch.setattr(base_module, 'dpg', dpg_recorder)
+    monkeypatch.setattr(node_abc_module, 'dpg', dpg_recorder)
+    monkeypatch.setattr(base_module, 'convert_cv_to_dpg', lambda image, w, h: image)
+
+    tag_node_name = node.add_node(
+        'NodeEditor',
+        6,
+        pos=[10, 20],
+        opencv_setting_dict={
+            'process_width': 8,
+            'process_height': 8,
+            'use_pref_counter': True,
+        },
+    )
+
+    declared_tags = [port.dpg_tag for port in node.get_declared_port_refs(6)]
+    assert tag_node_name == '6:Blur'
+    assert declared_tags == [
+        '6:Blur:Image:Input01',
+        '6:Blur:Image:Output01',
+        '6:Blur:TimeMS:Output02',
+        '6:Blur:Int:Input02',
+    ]
+    assert registered_ports == node.get_declared_port_refs(6)
+    assert [attr['tag'] for attr in dpg_recorder.node_attributes] == [
+        '6:Blur:ToolbarAttr',
+        '6:Blur:Image:Input01',
+        '6:Blur:Image:Output01',
+        '6:Blur:Int:Input02',
+        '6:Blur:TimeMS:Output02',
+    ]

--- a/tests/unit/test_graph_runtime.py
+++ b/tests/unit/test_graph_runtime.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from unittest.mock import Mock
 
+from node.port_model import LinkConnectionAdapter, LinkRef, NodeRef, PortRef
 from node_editor.graph_runtime import GraphRuntime
 
 
@@ -18,6 +19,61 @@ class FakeEditor:
 
     def get_node_instance(self, name):
         return self.inst_map[name]
+
+
+class TypedFakeEditor(FakeEditor):
+    def __init__(self, nodes, conn_dict, typed_conn_dict, inst_map):
+        super().__init__(nodes, conn_dict, inst_map)
+        self.typed_conn_dict = typed_conn_dict
+
+    def get_sorted_node_connection_refs(self):
+        return self.typed_conn_dict
+
+
+def _port_ref(node_id, node_tag, direction, data_type, port_name):
+    prefix = 'Input' if direction == 'Input' else 'Output'
+    return PortRef(
+        node_ref=NodeRef(str(node_id), node_tag),
+        direction=direction,
+        data_type=data_type,
+        index=int(port_name[len(prefix):]),
+        port_name=port_name,
+        dpg_tag=f'{node_id}:{node_tag}:{data_type}:{port_name}',
+    )
+
+
+def test_graph_runtime_prefers_typed_connection_refs_and_passes_typed_adapter():
+    source_node = Mock()
+    source_node.update.return_value = ('src-img', {'source': 1})
+
+    process_node = Mock()
+    process_node.update.return_value = ('img1', {'v': 1})
+    process_node.get_setting_dict.return_value = {'alpha': 0.5}
+
+    nodes = ['1:SourceNode', '2:ProcessNode']
+    link_ref = LinkRef(
+        _port_ref(1, 'SourceNode', 'Output', 'Image', 'Output01'),
+        _port_ref(2, 'ProcessNode', 'Input', 'Image', 'Input01'),
+    )
+    editor = TypedFakeEditor(
+        nodes,
+        OrderedDict(),
+        OrderedDict([('1:SourceNode', []), ('2:ProcessNode', [link_ref])]),
+        {'SourceNode': source_node, 'ProcessNode': process_node},
+    )
+
+    runtime = GraphRuntime()
+    runtime.step(editor, mode_async=False)
+
+    process_node.update.assert_called_once()
+    connection_list = process_node.update.call_args.args[1]
+    assert len(connection_list) == 1
+    assert isinstance(connection_list[0], LinkConnectionAdapter)
+    assert connection_list[0].link_ref == link_ref
+    assert list(connection_list[0]) == link_ref.legacy_pair
+    assert connection_list[0].source == link_ref.source
+    assert connection_list[0].destination == link_ref.destination
+    assert runtime.node_image_dict['2:ProcessNode'] == 'img1'
 
 
 def test_graph_runtime_persists_state_between_steps():

--- a/tests/unit/test_node_base_refactor.py
+++ b/tests/unit/test_node_base_refactor.py
@@ -1,0 +1,251 @@
+from node.node_abc import DpgNodeABC, DpgNodeBase
+from node.port_model import LinkConnectionAdapter, LinkRef, NodeRef, PortRef
+from node.input_node.node_int_value import Node as IntValueNode
+from node.process_node.node_blur import Node as BlurNode
+
+
+def test_dpg_node_base_is_concrete_helper_subclass():
+    assert issubclass(DpgNodeBase, DpgNodeABC)
+
+
+def test_abstract_interface_no_longer_owns_concrete_helpers():
+    for helper_name in (
+        '_node_name',
+        '_port_tag',
+        '_value_tag',
+        '_iter_connections',
+        'add_editor_toolbar',
+    ):
+        assert helper_name not in DpgNodeABC.__dict__
+        assert helper_name in DpgNodeBase.__dict__
+
+
+def test_representative_direct_nodes_inherit_concrete_base():
+    assert isinstance(IntValueNode(), DpgNodeBase)
+    assert isinstance(BlurNode(), DpgNodeBase)
+
+
+def test_concrete_base_preserves_existing_tag_helpers():
+    node = IntValueNode()
+    node_name = node._node_name(3)
+    port_tag = node._port_tag(node_name, node.TYPE_INT, 'Output01')
+
+    assert node_name == '3:IntValue'
+    assert port_tag == '3:IntValue:Int:Output01'
+    assert node._value_tag(port_tag) == '3:IntValue:Int:Output01Value'
+
+
+def test_concrete_base_node_tag_helpers_compose_port_and_value_tags():
+    node = IntValueNode()
+
+    assert node._node_port_tag(3, node.TYPE_INT, 'Output01') == (
+        '3:IntValue:Int:Output01'
+    )
+    assert node._port_value_tag('3:IntValue', node.TYPE_INT, 'Output01') == (
+        '3:IntValue:Int:Output01Value'
+    )
+    assert node._node_value_tag(3, node.TYPE_INT, 'Output01') == (
+        '3:IntValue:Int:Output01Value'
+    )
+
+
+def test_concrete_base_preserves_connection_iteration_guards():
+    node = IntValueNode()
+
+    assert list(node._iter_connections([
+        ['1:Src:Int:Output01', '2:IntValue:Int:Input01'],
+        ['malformed-source', '2:IntValue:Int:Input01'],
+        ['1:Src:Int:Output02'],
+        [None, '2:IntValue:Int:Input02'],
+    ])) == [
+        ('1:Src:Int:Output01', '2:IntValue:Int:Input01', 'Int'),
+    ]
+
+
+def test_concrete_base_iter_connections_accepts_typed_link_adapter():
+    node = IntValueNode()
+    link_ref = LinkRef(
+        PortRef(
+            node_ref=NodeRef('1', 'Src'),
+            direction='Output',
+            data_type='Int',
+            index=1,
+            port_name='Output01',
+            dpg_tag='1:Src:Int:Output01',
+        ),
+        PortRef(
+            node_ref=NodeRef('2', 'IntValue'),
+            direction='Input',
+            data_type='Int',
+            index=1,
+            port_name='Input01',
+            dpg_tag='2:IntValue:Int:Input01',
+        ),
+    )
+
+    assert list(node._iter_connections([LinkConnectionAdapter(link_ref)])) == [
+        ('1:Src:Int:Output01', '2:IntValue:Int:Input01', 'Int'),
+    ]
+
+
+def test_concrete_base_iter_connection_infos_exposes_typed_adapter():
+    node = IntValueNode()
+    link_ref = LinkRef(
+        PortRef(
+            node_ref=NodeRef('1', 'Src'),
+            direction='Output',
+            data_type='Int',
+            index=1,
+            port_name='Output01',
+            dpg_tag='1:Src:Int:Output01',
+        ),
+        PortRef(
+            node_ref=NodeRef('2', 'IntValue'),
+            direction='Input',
+            data_type='Int',
+            index=1,
+            port_name='Input01',
+            dpg_tag='2:IntValue:Int:Input01',
+        ),
+    )
+    adapter = LinkConnectionAdapter(link_ref)
+
+    assert list(node._iter_connection_infos([adapter])) == [
+        (adapter, '1:Src:Int:Output01', '2:IntValue:Int:Input01', 'Int'),
+    ]
+
+
+def test_concrete_base_iter_connections_tags_preserve_typed_metadata():
+    node = IntValueNode()
+    source = PortRef(
+        node_ref=NodeRef('1', 'Src'),
+        direction='Output',
+        data_type='Int',
+        index=1,
+        port_name='Output01',
+        dpg_tag='legacy:source:Int:Output99',
+        value_tag='1:Src:Int:Output01Value',
+    )
+    destination = PortRef(
+        node_ref=NodeRef('2', 'IntValue'),
+        direction='Input',
+        data_type='Int',
+        index=1,
+        port_name='Input01',
+        dpg_tag='legacy:dest:Int:Input99',
+        value_tag='2:IntValue:Int:Input01Value',
+    )
+    source_tag, destination_tag, connection_type = next(
+        node._iter_connections([LinkConnectionAdapter(LinkRef(source, destination))])
+    )
+
+    assert connection_type == 'Int'
+    assert str(source_tag) == 'legacy:source:Int:Output99'
+    assert node._extract_source_node_key(source_tag) == '1:Src'
+    assert node._extract_node_id(source_tag) == '1'
+    assert node._extract_port_name(destination_tag) == 'Input01'
+    assert node._value_tag(source_tag) == '1:Src:Int:Output01Value'
+
+
+def test_direct_node_add_node_graph_attributes_use_port_declarations():
+    import re
+    from pathlib import Path
+
+    node_root = Path(__file__).parents[2] / 'node'
+    failures = []
+    for path in sorted(node_root.rglob('*')):
+        if not (path.name.endswith('.py') or path.name.endswith('.py.disable')):
+            continue
+        source = path.read_text(encoding='utf-8')
+        if 'class Node(DpgNodeBase)' not in source:
+            continue
+        add_node_match = re.search(r'(?m)^    def add_node\(', source)
+        if add_node_match is None:
+            continue
+        next_method_match = re.search(
+            r'(?m)^    def \w+\(',
+            source[add_node_match.end():],
+        )
+        if next_method_match is None:
+            add_node_source = source[add_node_match.start():]
+        else:
+            add_node_source = source[
+                add_node_match.start():add_node_match.end() + next_method_match.start()
+            ]
+        declared_tag_variables = {
+            declaration.group(1)
+            for declaration in re.finditer(
+                r'(\w+)_port = self\.(?:input_port|output_port)\(',
+                add_node_source,
+            )
+        }
+        lines = add_node_source.splitlines()
+        index = 0
+        while index < len(lines):
+            if 'with dpg.node_attribute(' not in lines[index]:
+                index += 1
+                continue
+            call_lines = [lines[index]]
+            if '):' not in lines[index]:
+                index += 1
+                while index < len(lines):
+                    call_lines.append(lines[index])
+                    if lines[index].strip() == '):':
+                        break
+                    index += 1
+            call_source = '\n'.join(call_lines)
+            tag_match = re.search(r'tag=(\w+)', call_source)
+            attr_match = re.search(
+                r'attribute_type=dpg\.mvNode_Attr_(Input|Output)',
+                call_source,
+            )
+            if (
+                tag_match is not None
+                and attr_match is not None
+                and tag_match.group(1) not in declared_tag_variables
+            ):
+                failures.append(
+                    f'{path.relative_to(node_root.parent)}: '
+                    f'{attr_match.group(1)} {tag_match.group(1)}'
+                )
+            index += 1
+
+    assert failures == []
+
+
+def test_direct_node_updates_use_typed_connection_info_iteration():
+    from pathlib import Path
+
+    node_root = Path(__file__).parents[2] / 'node'
+    failures = []
+    for path in sorted(node_root.rglob('*')):
+        if path.name == 'node_abc.py':
+            continue
+        if not (path.name.endswith('.py') or path.name.endswith('.py.disable')):
+            continue
+        source = path.read_text(encoding='utf-8')
+        if 'class Node(DpgNodeBase)' not in source:
+            continue
+        if 'self._iter_connections(' in source:
+            failures.append(str(path.relative_to(node_root.parent)))
+
+    assert failures == []
+
+
+def test_node_implementations_use_composed_value_tag_helpers():
+    from pathlib import Path
+
+    node_root = Path(__file__).parents[2] / 'node'
+    failures = []
+    for path in sorted(node_root.rglob('*')):
+        if path.name == 'node_abc.py':
+            continue
+        if not (path.name.endswith('.py') or path.name.endswith('.py.disable')):
+            continue
+        source = path.read_text(encoding='utf-8')
+        if "self._value_tag(\n                self._port_tag(" in source:
+            failures.append(str(path.relative_to(node_root.parent)))
+        if 'self._value_tag(self._port_tag(' in source:
+            failures.append(str(path.relative_to(node_root.parent)))
+
+    assert failures == []

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -7,11 +7,16 @@ from unittest.mock import Mock, patch
 import pytest
 
 # Local application imports
+from node.node_abc import DpgNodeBase
+from node.port_model import LinkRef, NodeRef, PortRef
 from node_editor.node_editor import (
+    AddLinkCommand,
     AddNodeCommand,
     CompositeCommand,
     DpgNodeEditor,
+    ImportGraphCommand,
     RemoveLinkCommand,
+    ReplaceLinkCommand,
     SetParameterCommand,
 )
 
@@ -38,6 +43,51 @@ class DummyNode:
         callback=None,
     ):
         del callback
+        return f"{node_id}:{self.node_tag}"
+
+    def update(self, node_id, connection_list, img_dict, res_dict):
+        return f"img{node_id}", f"res{node_id}"
+
+    def get_setting_dict(self, node_id):
+        return {"ver": self._ver, "pos": [0, 0]}
+
+    def set_setting_dict(self, node_id, setting_dict):
+        pass
+
+    def close(self, node_id):
+        pass
+
+
+class ParameterDefaultDummyNode(DummyNode):
+    def get_setting_dict(self, node_id):
+        return {
+            "ver": self._ver,
+            "pos": [0, 0],
+            f"{node_id}:TestNode:Text:Input04Value": False,
+        }
+
+    def set_setting_dict(self, node_id, setting_dict):
+        self.last_setting = setting_dict
+
+
+class PortDeclaringDummyNode(DpgNodeBase):
+    _ver = '1.0'
+    node_tag = 'TestNode'
+    node_label = 'Test Node'
+
+    def add_node(
+        self,
+        parent,
+        node_id,
+        pos=None,
+        opencv_setting_dict=None,
+        callback=None,
+    ):
+        del parent, pos, opencv_setting_dict, callback
+        self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        self.input_port(node_id, self.TYPE_INT, 'Input01')
+        self.output_port(node_id, self.TYPE_INT, 'Output01')
         return f"{node_id}:{self.node_tag}"
 
     def update(self, node_id, connection_list, img_dict, res_dict):
@@ -120,9 +170,171 @@ def test_link_callback_basic(editor_and_dpg):
     link_ids = [101, 102]
     editor._cntrl_link('NodeEditor', link_ids)
     assert editor._node_link_list == [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
-    assert ('1:TestNode:Int:Output01', '2:TestNode:Int:Input01') in editor._link_registry
+    link_ref = editor._link_registry[(
+        '1:TestNode:Int:Output01',
+        '2:TestNode:Int:Input01',
+    )]
+    assert isinstance(link_ref, LinkRef)
+    assert link_ref.source.dpg_tag == '1:TestNode:Int:Output01'
+    assert link_ref.destination.dpg_tag == '2:TestNode:Int:Input01'
+    assert link_ref.legacy_pair == [
+        '1:TestNode:Int:Output01',
+        '2:TestNode:Int:Input01',
+    ]
     assert editor._link_by_dest_port['2:TestNode:Int:Input01'] == '1:TestNode:Int:Output01'
+    assert editor._mdl_get_link_ref_by_destination(
+        '2:TestNode:Int:Input01'
+    ) == link_ref
+    undo_command = editor._undo_stack[-1]
+    assert isinstance(undo_command, AddLinkCommand)
+    assert undo_command.source_tag == link_ref
+    assert undo_command.dest_tag is None
     dpg.add_node_link.assert_called_once_with(101, 102, parent='NodeEditor')
+
+
+def test_mdl_add_link_accepts_port_refs(editor_and_dpg):
+    editor, _ = editor_and_dpg
+    source_port = PortRef(
+        node_ref=NodeRef('1', 'TestNode'),
+        direction='Output',
+        data_type='Image',
+        index=1,
+        port_name='Output01',
+        dpg_tag='1:TestNode:Image:Output01',
+    )
+    dest_port = PortRef(
+        node_ref=NodeRef('2', 'TestNode'),
+        direction='Input',
+        data_type='Image',
+        index=1,
+        port_name='Input01',
+        dpg_tag='2:TestNode:Image:Input01',
+    )
+
+    assert editor._mdl_add_link(source_port, dest_port) is True
+
+    link_ref = editor._mdl_get_link_ref_by_destination(dest_port)
+    assert link_ref == LinkRef(source_port, dest_port)
+    assert editor._node_link_list == [[
+        '1:TestNode:Image:Output01',
+        '2:TestNode:Image:Input01',
+    ]]
+
+
+def test_history_import_command_accepts_typed_link_refs(editor_and_dpg):
+    editor, dpg = editor_and_dpg
+    dpg.does_item_exist.return_value = True
+    source_port = PortRef(
+        node_ref=NodeRef('1', 'TestNode'),
+        direction='Output',
+        data_type='Image',
+        index=1,
+        port_name='Output01',
+        dpg_tag='1:TestNode:Image:Output01',
+    )
+    dest_port = PortRef(
+        node_ref=NodeRef('2', 'TestNode'),
+        direction='Input',
+        data_type='Image',
+        index=1,
+        port_name='Input01',
+        dpg_tag='2:TestNode:Image:Input01',
+    )
+    link_ref = LinkRef(source_port, dest_port)
+
+    ImportGraphCommand(nodes=[], links=[link_ref]).redo(editor)
+
+    assert editor._node_link_list == [link_ref.legacy_pair]
+    registered_link = editor._mdl_get_link_ref_by_destination(dest_port)
+    assert registered_link.source_tag == link_ref.source_tag
+    assert registered_link.destination_tag == link_ref.destination_tag
+    dpg.add_node_link.assert_called_once_with(
+        source_port.dpg_tag, dest_port.dpg_tag, parent=editor._node_editor_tag
+    )
+
+
+def test_add_node_registers_declared_port_refs(editor_and_dpg):
+    editor, _ = editor_and_dpg
+    editor._node_instance_list['TestNode'] = PortDeclaringDummyNode()
+
+    editor._cntrl_add_node(None, None, 'TestNode')
+
+    input_port = editor._port_registry['1:TestNode:Image:Input01']
+    output_port = editor._port_registry['1:TestNode:Image:Output01']
+    assert input_port.node_ref.node_id_name == '1:TestNode'
+    assert input_port.direction == 'Input'
+    assert input_port.port_name == 'Input01'
+    assert output_port.direction == 'Output'
+    assert output_port.port_name == 'Output01'
+    assert editor._node_registry['1:TestNode'] == input_port.node_ref
+
+
+def test_add_node_keeps_dynamic_port_registration_callback(editor_and_dpg):
+    editor, _ = editor_and_dpg
+    node = PortDeclaringDummyNode()
+    editor._node_instance_list['TestNode'] = node
+
+    editor._cntrl_add_node(None, None, 'TestNode')
+    node.input_port(1, node.TYPE_TEXT, 'Input02')
+
+    assert '1:TestNode:Text:Input02' in editor._port_registry
+
+
+def test_registered_hovered_output_port_beyond_legacy_scan_range(editor_and_dpg):
+    editor, dpg = editor_and_dpg
+    output_port = PortRef(
+        node_ref=NodeRef('1', 'TestNode'),
+        direction='Output',
+        data_type='Int',
+        index=125,
+        port_name='Output125',
+        dpg_tag='1:TestNode:Int:Output125',
+        value_tag='1:TestNode:Int:Output125Value',
+    )
+    editor._mdl_register_port_ref(output_port)
+    dpg.does_item_exist.side_effect = lambda tag: tag == output_port.dpg_tag
+    dpg.is_item_hovered.side_effect = lambda tag: tag == output_port.dpg_tag
+
+    assert editor._cntrl_get_hovered_output_port_tag() == output_port.dpg_tag
+
+
+def test_find_node_port_uses_registered_port_beyond_legacy_scan_range(editor_and_dpg):
+    editor, dpg = editor_and_dpg
+    input_port = PortRef(
+        node_ref=NodeRef('1', 'TestNode'),
+        direction='Input',
+        data_type='Image',
+        index=125,
+        port_name='Input125',
+        dpg_tag='1:TestNode:Image:Input125',
+        value_tag='1:TestNode:Image:Input125Value',
+    )
+    editor._mdl_register_port_ref(input_port)
+    dpg.does_item_exist.side_effect = lambda tag: tag == input_port.dpg_tag
+    dpg.get_item_configuration.side_effect = lambda tag: (
+        {'attribute_type': dpg.mvNode_Attr_Input}
+        if tag == input_port.dpg_tag
+        else {}
+    )
+
+    assert (
+        editor._cntrl_find_node_port('1:TestNode', 'Image', 'Input')
+        == input_port.dpg_tag
+    )
+
+
+def test_find_node_port_requires_registered_port(editor_and_dpg):
+    editor, dpg = editor_and_dpg
+    input_tag = '1:TestNode:Image:Input01'
+    dpg.does_item_exist.side_effect = lambda tag: tag == input_tag
+    dpg.get_item_configuration.side_effect = lambda tag: (
+        {'attribute_type': dpg.mvNode_Attr_Input}
+        if tag == input_tag
+        else {}
+    )
+
+    assert editor._cntrl_find_node_port('1:TestNode', 'Image', 'Input') is None
+    assert input_tag not in editor._port_registry
 
 
 def test_parse_port_tag_returns_typed_metadata(editor_and_dpg):
@@ -135,6 +347,8 @@ def test_parse_port_tag_returns_typed_metadata(editor_and_dpg):
     assert port.direction == 'Input'
     assert port.data_type == 'Float'
     assert port.index == 3
+    assert port.port_name == 'Input03'
+    assert port.value_tag == '7:TestNode:Float:Input03Value'
     assert editor._port_registry['7:TestNode:Float:Input03'] == port
 
 
@@ -191,6 +405,17 @@ def test_link_replaces_existing_dest(editor_and_dpg):
     assert dpg.configure_item.call_args_list[-1].kwargs == {
         'label': 'Node editor'
     }
+    undo_command = editor._undo_stack[-1]
+    assert isinstance(undo_command, ReplaceLinkCommand)
+    assert undo_command.dest_tag is None
+    assert undo_command.old_source_tag.legacy_pair == [
+        '1:TestNode:Int:Output01',
+        '2:TestNode:Int:Input01',
+    ]
+    assert undo_command.new_source_tag.legacy_pair == [
+        '3:TestNode:Int:Output01',
+        '2:TestNode:Int:Input01',
+    ]
 
 
 def test_link_mismatched_type_ignored(editor_and_dpg):
@@ -281,6 +506,7 @@ def test_link_cycle_is_rejected(editor_and_dpg):
 
 def test_insert_node_into_selected_link(editor_and_dpg):
     editor, dpg = editor_and_dpg
+    editor._node_instance_list['TestNode'] = PortDeclaringDummyNode()
     dpg.get_item_alias.side_effect = {
         101: '1:TestNode:Int:Output01',
         102: '2:TestNode:Int:Input01',
@@ -344,6 +570,7 @@ def test_insert_node_into_selected_link(editor_and_dpg):
 
 def test_add_node_to_occupied_input_is_single_composite_undo(editor_and_dpg):
     editor, dpg = editor_and_dpg
+    editor._node_instance_list['TestNode'] = PortDeclaringDummyNode()
     dpg.does_item_exist.side_effect = lambda _tag: True
     dpg.get_item_pos.side_effect = lambda tag: [300, 200] if tag == '2:TestNode' else [0, 0]
     dpg.get_item_configuration.side_effect = lambda tag: (
@@ -374,6 +601,7 @@ def test_add_node_to_occupied_input_is_single_composite_undo(editor_and_dpg):
 
 def test_insert_then_move_undo_redo_sequence(editor_and_dpg):
     editor, dpg = editor_and_dpg
+    editor._node_instance_list['TestNode'] = PortDeclaringDummyNode()
     alias_map = {
         101: '1:TestNode:Int:Output01',
         102: '2:TestNode:Int:Input01',
@@ -598,6 +826,46 @@ def test_parameter_change_coalesces_numeric_edits_and_undo_redo(editor_and_dpg):
     assert value_state[param_tag] == 5
     editor._cntrl_redo(None, None)
     assert value_state[param_tag] == 7
+
+
+def test_raw_widget_callback_uses_primed_add_node_defaults(editor_and_dpg):
+    editor, dpg = editor_and_dpg
+    node = ParameterDefaultDummyNode()
+    editor._node_instance_list['TestNode'] = node
+    dpg.does_item_exist.side_effect = lambda _tag: True
+    param_tag = '1:TestNode:Text:Input04Value'
+    value_state = {param_tag: True}
+    dpg.get_value.side_effect = lambda tag: value_state.get(tag)
+    dpg.set_value.side_effect = lambda tag, value: value_state.__setitem__(tag, value)
+
+    editor._cntrl_add_node(None, None, 'TestNode')
+    editor._undo_stack.clear()
+    editor._redo_stack.clear()
+
+    editor._cntrl_node_callback(param_tag, True)
+
+    assert len(editor._undo_stack) == 1
+    assert editor._undo_stack[-1].before_value is False
+    assert editor._undo_stack[-1].after_value is True
+    editor._cntrl_undo(None, None)
+    assert value_state[param_tag] is False
+
+
+def test_add_node_from_history_remaps_parameter_setting_keys(editor_and_dpg):
+    editor, dpg = editor_and_dpg
+    node = ParameterDefaultDummyNode()
+    editor._node_instance_list['TestNode'] = node
+    dpg.does_item_exist.return_value = True
+    setting = {
+        'ver': '1.0',
+        'pos': [0, 0],
+        '1:TestNode:Text:Input04Value': False,
+    }
+
+    editor._cntrl_add_node_with_id('TestNode', 7, [0, 0], setting)
+
+    assert node.last_setting['7:TestNode:Text:Input04Value'] is False
+    assert editor._parameter_last_values['7:TestNode:Text:Input04Value'] is False
 
 
 def test_raw_widget_callback_records_parameter_history(editor_and_dpg):
@@ -833,6 +1101,14 @@ def test_open_add_node_popup_from_hovered_output_port(editor_and_dpg):
     editor, dpg = editor_and_dpg
     output_tag = '1:TestNode:Int:Output01'
     editor._node_list = ['1:TestNode']
+    editor._mdl_register_port_ref(PortRef(
+        node_ref=NodeRef('1', 'TestNode'),
+        direction='Output',
+        data_type='Int',
+        index=1,
+        port_name='Output01',
+        dpg_tag=output_tag,
+    ))
     editor._vw_populate_append_popup_menu = Mock()
     dpg.does_item_exist.side_effect = lambda tag: tag == output_tag
     dpg.is_item_hovered.side_effect = lambda tag: tag == output_tag
@@ -857,6 +1133,14 @@ def test_open_add_node_popup_from_hovered_input_port(editor_and_dpg):
     editor, dpg = editor_and_dpg
     input_tag = '1:TestNode:Int:Input01'
     editor._node_list = ['1:TestNode']
+    editor._mdl_register_port_ref(PortRef(
+        node_ref=NodeRef('1', 'TestNode'),
+        direction='Input',
+        data_type='Int',
+        index=1,
+        port_name='Input01',
+        dpg_tag=input_tag,
+    ))
     editor._vw_populate_prepend_popup_menu = Mock()
     dpg.does_item_exist.side_effect = lambda tag: tag == input_tag
     dpg.is_item_hovered.side_effect = lambda tag: tag == input_tag
@@ -879,6 +1163,7 @@ def test_open_add_node_popup_from_hovered_input_port(editor_and_dpg):
 
 def test_add_node_from_hovered_output_creates_connected_node(editor_and_dpg):
     editor, dpg = editor_and_dpg
+    editor._node_instance_list['TestNode'] = PortDeclaringDummyNode()
     source_tag = '1:TestNode:Int:Output01'
     input_tag = '2:TestNode:Int:Input01'
     editor._node_id = 1
@@ -911,6 +1196,7 @@ def test_add_node_from_hovered_output_creates_connected_node(editor_and_dpg):
 
 def test_add_node_to_hovered_input_creates_connected_node(editor_and_dpg):
     editor, dpg = editor_and_dpg
+    editor._node_instance_list['TestNode'] = PortDeclaringDummyNode()
     dest_tag = '1:TestNode:Int:Input01'
     output_tag = '2:TestNode:Int:Output01'
     editor._node_id = 1
@@ -1046,10 +1332,10 @@ def test_sort_node_graph(editor_and_dpg):
     editor, _ = editor_and_dpg
     editor._node_list = ['1:TestNode', '2:TestNode', '3:TestNode', '4:TestNode']
     editor._node_link_list = [
-        ['1:TestNode:Output01', '2:TestNode:Input01'],
-        ['1:TestNode:Output01', '3:TestNode:Input01'],
-        ['2:TestNode:Output01', '4:TestNode:Input01'],
-        ['3:TestNode:Output01', '4:TestNode:Input01'],
+        ['1:TestNode:Int:Output01', '2:TestNode:Int:Input01'],
+        ['1:TestNode:Int:Output01', '3:TestNode:Int:Input01'],
+        ['2:TestNode:Int:Output01', '4:TestNode:Int:Input01'],
+        ['3:TestNode:Int:Output01', '4:TestNode:Int:Input01'],
     ]
     editor._mdl_sort_node_graph()
     result = editor.get_sorted_node_connection()

--- a/tests/unit/test_node_editor_import_export.py
+++ b/tests/unit/test_node_editor_import_export.py
@@ -7,6 +7,60 @@ from collections import OrderedDict
 from node_editor.node_editor import DpgNodeEditor
 
 
+def _typed_port_payload(port_tag):
+    parts = str(port_tag).split(':')
+    if len(parts) < 4:
+        return {'dpg_tag': port_tag}
+    node_id, node_tag, data_type, port_name = parts[:4]
+    direction = ''
+    index = 0
+    if port_name.startswith('Input'):
+        direction = 'Input'
+        index_text = port_name[len('Input'):]
+    elif port_name.startswith('Output'):
+        direction = 'Output'
+        index_text = port_name[len('Output'):]
+    else:
+        index_text = ''
+    if index_text.isdigit():
+        index = int(index_text)
+    return {
+        'node': {'id': node_id, 'tag': node_tag},
+        'direction': direction,
+        'data_type': data_type,
+        'index': index,
+        'port_name': port_name,
+        'dpg_tag': port_tag,
+    }
+
+
+def _typed_link_refs(link_pairs):
+    return [
+        {
+            'source': _typed_port_payload(source_tag),
+            'destination': _typed_port_payload(dest_tag),
+        }
+        for source_tag, dest_tag in link_pairs
+    ]
+
+
+def _link_ref_pairs(link_refs):
+    return [
+        [link_ref['source']['dpg_tag'], link_ref['destination']['dpg_tag']]
+        for link_ref in link_refs
+    ]
+
+
+def _history_link_pairs(links):
+    pairs = []
+    for link in links:
+        if hasattr(link, 'legacy_pair'):
+            pairs.append(tuple(link.legacy_pair))
+        else:
+            pairs.append(tuple(link))
+    return pairs
+
+
 class TestDpgNodeEditorImportExport:
     """Test suite for DpgNodeEditor import/export functionality"""
 
@@ -71,9 +125,10 @@ class TestDpgNodeEditorImportExport:
             exported_data = json.load(f)
 
         assert 'node_list' in exported_data
-        assert 'link_list' in exported_data
+        assert 'link_list' not in exported_data
+        assert 'link_refs' in exported_data
         assert exported_data['node_list'] == []
-        assert exported_data['link_list'] == []
+        assert exported_data['link_refs'] == []
 
     def test_export_with_nodes(
         self,
@@ -99,10 +154,27 @@ class TestDpgNodeEditorImportExport:
             exported_data = json.load(f)
 
         assert exported_data['node_list'] == ['1:test_node', '2:test_node']
-        assert exported_data['link_list'] == [[
-            '1:test_node:Image:Output01',
-            '2:test_node:Image:Input01'
-        ]]
+        assert 'link_list' not in exported_data
+        assert exported_data['link_refs'] == [
+            {
+                'source': {
+                    'node': {'id': '1', 'tag': 'test_node'},
+                    'direction': 'Output',
+                    'data_type': 'Image',
+                    'index': 1,
+                    'port_name': 'Output01',
+                    'dpg_tag': '1:test_node:Image:Output01',
+                },
+                'destination': {
+                    'node': {'id': '2', 'tag': 'test_node'},
+                    'direction': 'Input',
+                    'data_type': 'Image',
+                    'index': 1,
+                    'port_name': 'Input01',
+                    'dpg_tag': '2:test_node:Image:Input01',
+                },
+            }
+        ]
 
         assert '1:test_node' in exported_data
         assert '2:test_node' in exported_data
@@ -140,10 +212,10 @@ class TestDpgNodeEditorImportExport:
         """Test successful file import"""
         test_data = {
             'node_list': ['1:test_node', '2:test_node'],
-            'link_list': [[
+            'link_refs': _typed_link_refs([[
                 '1:test_node:Image:Output01',
                 '2:test_node:Image:Input01',
-            ]],
+            ]]),
             '1:test_node': {
                 'id': '1',
                 'name': 'test_node',
@@ -189,6 +261,65 @@ class TestDpgNodeEditorImportExport:
             parent=node_editor._node_editor_tag
         )
 
+    def test_import_prefers_typed_link_refs(
+        self,
+        node_editor,
+        mock_dpg,
+        mock_node_instance,
+        tmp_path,
+    ):
+        test_data = {
+            'node_list': ['1:test_node', '2:test_node'],
+            'link_refs': [
+                {
+                    'source': {
+                        'node': {'id': '1', 'tag': 'test_node'},
+                        'direction': 'Output',
+                        'data_type': 'Image',
+                        'index': 1,
+                        'port_name': 'Output01',
+                        'dpg_tag': '1:test_node:Image:Output01',
+                    },
+                    'destination': {
+                        'node': {'id': '2', 'tag': 'test_node'},
+                        'direction': 'Input',
+                        'data_type': 'Image',
+                        'index': 1,
+                        'port_name': 'Input01',
+                        'dpg_tag': '2:test_node:Image:Input01',
+                    },
+                }
+            ],
+            '1:test_node': {
+                'id': '1',
+                'name': 'test_node',
+                'setting': {'ver': '1.0.0', 'pos': [100, 200]},
+            },
+            '2:test_node': {
+                'id': '2',
+                'name': 'test_node',
+                'setting': {'ver': '1.0.0', 'pos': [300, 400]},
+            },
+        }
+        temp_path = tmp_path / 'typed_import.json'
+        temp_path.write_text(json.dumps(test_data))
+
+        node_editor._cntrl_file_import(
+            'file_import',
+            {'file_name': temp_path.name, 'file_path_name': str(temp_path)},
+        )
+
+        assert node_editor._node_link_list == [[
+            '1:test_node:Image:Output01',
+            '2:test_node:Image:Input01',
+        ]]
+        link_ref = node_editor._mdl_get_link_ref_by_destination(
+            '2:test_node:Image:Input01'
+        )
+        assert link_ref is not None
+        assert link_ref.source.dpg_tag == '1:test_node:Image:Output01'
+        assert link_ref.destination.dpg_tag == '2:test_node:Image:Input01'
+
     def test_import_is_undoable_and_redoable(
         self,
         node_editor,
@@ -197,10 +328,10 @@ class TestDpgNodeEditorImportExport:
     ):
         test_data = {
             'node_list': ['1:test_node', '2:test_node'],
-            'link_list': [[
+            'link_refs': _typed_link_refs([[
                 '1:test_node:Image:Output01',
                 '2:test_node:Image:Input01',
-            ]],
+            ]]),
             '1:test_node': {
                 'id': '1',
                 'name': 'test_node',
@@ -249,10 +380,17 @@ class TestDpgNodeEditorImportExport:
             '1:test_node:Image:Output01',
             '2:test_node:Image:Input01',
         ]]
+        assert node_editor.get_sorted_node_connection() == OrderedDict([
+            ('1:test_node', []),
+            ('2:test_node', [[
+                '1:test_node:Image:Output01',
+                '2:test_node:Image:Input01',
+            ]]),
+        ])
         assert len(node_editor._undo_stack) == 1
 
     @pytest.mark.parametrize(
-        "link_list",
+        "link_pairs",
         [
             [["1:test_node:output", "2:test_node:Image:Input01"]],
             [["1:test_node:Image:Output01", "2:test_node:input"]],
@@ -263,11 +401,11 @@ class TestDpgNodeEditorImportExport:
         node_editor,
         mock_dpg,
         tmp_path,
-        link_list,
+        link_pairs,
     ):
         test_data = {
             'node_list': ['1:test_node', '2:test_node'],
-            'link_list': link_list,
+            'link_refs': _typed_link_refs(link_pairs),
             '1:test_node': {
                 'id': '1',
                 'name': 'test_node',
@@ -313,7 +451,7 @@ class TestDpgNodeEditorImportExport:
         ]
         test_data = {
             'node_list': ['1:test_node', '2:test_node', '3:test_node'],
-            'link_list': [valid_link, replacement_link],
+            'link_refs': _typed_link_refs([valid_link, replacement_link]),
             '1:test_node': {
                 'id': '1',
                 'name': 'test_node',
@@ -357,7 +495,7 @@ class TestDpgNodeEditorImportExport:
             '1:test_node:Image:Output01',
             '3:test_node:Image:Input01',
         ]]
-        assert node_editor._undo_stack[-1].links == [(
+        assert _history_link_pairs(node_editor._undo_stack[-1].links) == [(
             '1:test_node:Image:Output01',
             '3:test_node:Image:Input01',
         )]
@@ -379,10 +517,10 @@ class TestDpgNodeEditorImportExport:
     ):
         test_data = {
             'node_list': ['1:test_node', '2:test_node'],
-            'link_list': [[
+            'link_refs': _typed_link_refs([[
                 '1:test_node:Image:Output99',
                 '2:test_node:Image:Input01',
-            ]],
+            ]]),
             '1:test_node': {
                 'id': '1',
                 'name': 'test_node',
@@ -418,7 +556,7 @@ class TestDpgNodeEditorImportExport:
         mock_dpg.add_node_link.assert_not_called()
 
     @pytest.mark.parametrize(
-        "link_list",
+        "link_pairs",
         [
             [["1:test_node:Image:Input01", "2:test_node:Image:Input01"]],
             [["1:test_node:Int:Output01", "2:test_node:Float:Input01"]],
@@ -429,11 +567,11 @@ class TestDpgNodeEditorImportExport:
         node_editor,
         mock_dpg,
         tmp_path,
-        link_list,
+        link_pairs,
     ):
         test_data = {
             'node_list': ['1:test_node', '2:test_node'],
-            'link_list': link_list,
+            'link_refs': _typed_link_refs(link_pairs),
             '1:test_node': {
                 'id': '1',
                 'name': 'test_node',
@@ -469,10 +607,10 @@ class TestDpgNodeEditorImportExport:
     ):
         test_data = {
             'node_list': ['1:test_node', '2:test_node', '3:test_node'],
-            'link_list': [
+            'link_refs': _typed_link_refs([
                 ['1:test_node:Image:Output01', '3:test_node:Image:Input01'],
                 ['2:test_node:Image:Output01', '3:test_node:Image:Input01'],
-            ],
+            ]),
             '1:test_node': {
                 'id': '1',
                 'name': 'test_node',
@@ -503,7 +641,7 @@ class TestDpgNodeEditorImportExport:
             '2:test_node:Image:Output01',
             '3:test_node:Image:Input01',
         ]]
-        assert node_editor._undo_stack[-1].links == [(
+        assert _history_link_pairs(node_editor._undo_stack[-1].links) == [(
             '2:test_node:Image:Output01',
             '3:test_node:Image:Input01',
         )]
@@ -516,7 +654,7 @@ class TestDpgNodeEditorImportExport:
     ):
         test_data = {
             'node_list': ['1:test_node'],
-            'link_list': [],
+            'link_refs': [],
             '1:test_node': {
                 'id': '1',
                 'name': 'test_node',
@@ -561,7 +699,7 @@ class TestDpgNodeEditorImportExport:
         mock_node_instance._ver = '2.0.0'
         test_data = {
             'node_list': ['1:test_node'],
-            'link_list': [],
+            'link_refs': [],
             '1:test_node': {
                 'id': '1',
                 'name': 'test_node',
@@ -595,7 +733,7 @@ class TestDpgNodeEditorImportExport:
         node_editor._node_id = 1
         test_data = {
             'node_list': ['5:test_node'],
-            'link_list': [],
+            'link_refs': [],
             '5:test_node': {
                 'id': '5',
                 'name': 'test_node',
@@ -622,7 +760,7 @@ class TestDpgNodeEditorImportExport:
         """Test that importing JSON missing mandatory keys raises
            KeyError"""
         # Create JSON missing 'node_list'
-        bad = {'link_list': []}
+        bad = {'link_refs': []}
         path = tmp_path / 'bad.json'
         path.write_text(json.dumps(bad))
         with pytest.raises(KeyError):
@@ -762,7 +900,8 @@ class TestDpgNodeEditorImportExport:
 
         # Assert export structure is correct
         assert set(exported['node_list']) == set(original_nodes)
-        assert (set(tuple(l) for l in exported['link_list'])
+        assert 'link_list' not in exported
+        assert (set(tuple(l) for l in _link_ref_pairs(exported['link_refs']))
                 == set(tuple(l) for l in original_links))
 
         # Act: import into a fresh editor
@@ -804,10 +943,10 @@ class TestDpgNodeEditorImportExport:
         # import JSON with the same IDs (1 & 2), so they must be remapped
         imported = {
             'node_list': ['1:test_node', '2:test_node'],
-            'link_list': [[
+            'link_refs': _typed_link_refs([[
                 '1:test_node:Image:Output01',
                 '2:test_node:Image:Input01',
-            ]],
+            ]]),
             '1:test_node': {
                 'id': '1', 'name': 'test_node',
                 'setting': {'ver': '1.0.0', 'pos': [10, 20]}
@@ -868,10 +1007,10 @@ class TestDpgNodeEditorImportExport:
     ):
         imported = {
             'node_list': ['1:test_node', '2:test_node'],
-            'link_list': [[
+            'link_refs': _typed_link_refs([[
                 '1:test_node:Image:Output01',
                 '2:test_node:Image:Input01',
-            ]],
+            ]]),
             '1:test_node': {
                 'id': '1', 'name': 'test_node',
                 'setting': {'ver': '1.0.0', 'pos': [10, 20]}

--- a/tests/unit/test_node_port_declaration.py
+++ b/tests/unit/test_node_port_declaration.py
@@ -1,0 +1,98 @@
+import pytest
+
+from node.input_node.node_int_value import Node as IntValueNode
+from node.port_model import NodeRef, PortRef
+
+
+def test_explicit_port_declaration_preserves_compact_tag_shape():
+    node = IntValueNode()
+
+    port = node.output_port(7, node.TYPE_INT, 'Output01')
+
+    assert port == PortRef(
+        node_ref=NodeRef('7', 'IntValue'),
+        direction='Output',
+        data_type='Int',
+        index=1,
+        port_name='Output01',
+        dpg_tag='7:IntValue:Int:Output01',
+        value_tag='7:IntValue:Int:Output01Value',
+        control_tag=None,
+    )
+
+
+def test_auto_numbered_ports_increment_by_node_and_direction():
+    node = IntValueNode()
+
+    image_in = node.input_port(3, node.TYPE_IMAGE)
+    int_in = node.parameter_port(3, node.TYPE_INT)
+    image_out = node.output_port(3, node.TYPE_IMAGE)
+    next_node_input = node.input_port(4, node.TYPE_TEXT)
+
+    assert image_in.port_name == 'Input01'
+    assert image_in.dpg_tag == '3:IntValue:Image:Input01'
+    assert image_in.control_tag is None
+    assert int_in.port_name == 'Input02'
+    assert int_in.dpg_tag == '3:IntValue:Int:Input02'
+    assert int_in.control_tag == '3:IntValue:Int:Input02Value'
+    assert image_out.port_name == 'Output01'
+    assert next_node_input.port_name == 'Input01'
+
+
+def test_explicit_port_declaration_advances_auto_numbering():
+    node = IntValueNode()
+
+    explicit_port = node.input_port(2, node.TYPE_INT, 'Input03')
+    auto_port = node.input_port(2, node.TYPE_TEXT)
+
+    assert explicit_port.index == 3
+    assert auto_port.port_name == 'Input04'
+
+
+def test_declared_port_refs_are_stored_by_node():
+    node = IntValueNode()
+
+    first = node.output_port(1, node.TYPE_INT, 'Output01')
+    second = node.output_port(2, node.TYPE_INT, 'Output01')
+
+    assert node.get_declared_port_refs(1) == [first]
+    assert node.get_declared_port_refs(2) == [second]
+    assert node.get_declared_port_refs() == [first, second]
+
+
+def test_port_declaration_invokes_registration_callback():
+    node = IntValueNode()
+    registered_ports = []
+    node.set_port_registration_callback(registered_ports.append)
+
+    declared = node.output_port(4, node.TYPE_TIME_MS, 'Output02')
+
+    assert registered_ports == [declared]
+
+
+def test_parameter_port_accepts_custom_control_tag():
+    node = IntValueNode()
+
+    port = node.parameter_port(
+        5,
+        node.TYPE_TEXT,
+        'Input02',
+        control_tag='5:IntValue:Text:ComboControl',
+    )
+
+    assert port.control_tag == '5:IntValue:Text:ComboControl'
+    assert port.value_tag == '5:IntValue:Text:Input02Value'
+
+
+def test_port_declaration_rejects_mismatched_direction_prefix():
+    node = IntValueNode()
+
+    with pytest.raises(ValueError, match='must start with Output'):
+        node.output_port(1, node.TYPE_IMAGE, 'Input01')
+
+
+def test_port_declaration_rejects_non_numeric_index():
+    node = IntValueNode()
+
+    with pytest.raises(ValueError, match='must end with a numeric index'):
+        node.input_port(1, node.TYPE_IMAGE, 'InputMain')


### PR DESCRIPTION
### Motivation

- Move DearPyGui alias strings from being the primary graph model into a typed model so ports/links/nodes can be reasoned about as structured objects rather than parsed strings.
- Provide a concrete node base for reusable DearPyGui helpers and typed port declaration APIs so node implementations can register ports at creation time.
- Update editor, runtime, import/export, and history to prefer typed `PortRef`/`LinkRef` while preserving a compact DPG tag boundary for compatibility.

### Description

- Add `node/port_model.py` defining frozen dataclasses `NodeRef`, `PortRef`, `LinkRef`, and `LinkConnectionAdapter` to represent typed endpoints and links.
- Introduce `DpgNodeBase` in `node/node_abc.py` that implements concrete DearPyGui tag helpers, typed port declaration (`input_port`, `output_port`, `parameter_port`), registration callback plumbing, and adapters for iterating typed connection infos; keep `DpgNodeABC` as the abstract contract.
- Migrate many concrete node implementations to inherit from `DpgNodeBase` and replace manual tag composition/parsing with the new helpers and typed port/value tags (examples: numerous files under `node/*` updated to use `input_port`, `output_port`, `_node_value_tag`, `_node_port_tag`, and `_iter_connection_infos`).
- Update editor internals (`node_editor.py`) to register node-declared `PortRef`s, store `LinkRef` registry data, prefer registered `PortRef` iteration for hovered-port discovery and node-port lookup, and export/import typed `link_refs` instead of legacy `link_list` while keeping boundary compatibility adapters.
- Update graph runtime and adapters (`node_editor/graph_runtime.py`, etc.) to accept typed adapters (`LinkConnectionAdapter`) and pass typed connection info into node `update()` calls while preserving legacy fallbacks where needed.
- Add and update many unit tests to cover the new typed model, port declaration APIs, editor/link/history behavior, import/export of `link_refs`, and runtime usage of typed adapters.

### Testing

- Ran the project unit test suite via `pytest` (including modified/added tests such as `tests/unit/test_node_base_refactor.py`, `tests/unit/test_node_port_declaration.py`, `tests/unit/test_declarative_process_nodes.py`, `tests/unit/test_graph_runtime.py`, `tests/unit/test_node_editor_core.py`, and `tests/unit/test_node_editor_import_export.py`).
- Verified node-level behavior: declarative nodes declare ports and register `PortRef` entries during `add_node()`, and parameter wiring works through typed connection adapters (tests exercising typed adapters passed).
- Verified editor-level behavior: hovered-port discovery, add-node-from-hovered-port, insert-node-between-links, import/export round-trips with `link_refs`, and history commands correctly carry typed link payloads (tests passed).
- All automated tests in the updated test suite passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f980898083239a8ee1cbb9121e6a)