### PR TITLE
Add canonical typed link storage (`_link_refs`) and normalize legacy compact link pairs

### DIFF
--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -28,9 +28,8 @@ Implemented so far:
 - `node.port_model` defines the first reusable passive `NodeRef` / `PortRef`
   records for node-side declarations.
 - `DpgNodeBase` also has typed port declaration APIs (`input_port`,
-  `output_port`, `parameter_port`) that create passive `PortRef` metadata while
-  preserving the compact DPG tag format, plus lookup/value-tag helpers for code
-  paths that can reuse existing declarations instead of rebuilding compact tags.
+  `output_port`, `parameter_port`) that create passive `PortRef` metadata using
+  `PortDirection` enum values while preserving the compact DPG tag format.
 - `DeclarativeImageProcessNodeBase` uses typed `PortRef` declarations for its
   standard image input/output, elapsed-time output, and declared parameter ports;
   cache/result toggles still use value tags because they are toolbar controls,
@@ -41,7 +40,8 @@ Implemented so far:
 - Direct non-declarative node `update()` implementations now iterate typed
   connection info records through `_iter_connection_infos()` instead of the legacy
   `_iter_connections()` adapter. Source value nodes and the still-image node now
-  reuse declared output port value tags in setting/update paths.
+  keep their declared output `PortRef` handles and read value tags from those
+  handles in setting/update paths.
 - `DpgNodeABC` is back to the abstract lifecycle contract, shared metadata, shared
   type constants, and the optional editor hook.
 - The editor imports the shared `node.port_model` records, registers node-owned
@@ -313,5 +313,6 @@ plus a readable compact boundary string.
   string pairs to typed refs.
 - In progress: continue shrinking compact-tag helper usage in node implementations
   where the tag is not part of a DearPyGui UI boundary. The current pass added
-  declared-port lookup/value-tag helpers and migrated `IntValue`, `FloatValue`,
-  and `Image` source-node output value access to them.
+  `PortDirection` and migrated `IntValue`, `FloatValue`, and `Image` source nodes
+  to store output `PortRef` handles instead of re-querying value tags by compact
+  `port_name` / direction strings.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -48,15 +48,18 @@ Implemented so far:
   parsing remains as a compatibility boundary for imported graphs, callback
   aliases, and undo/redo data.
 
-Important limitation of the current implementation:
+Current implementation note:
 
 - The editor now exports and imports typed `link_refs` directly; graph sorting,
   cycle detection, delete-through-node reconnection, the runtime scheduler,
   undo/redo link history, and the node `update()` connection boundary all consume
-  or preserve typed `LinkRef` data when it is available. The declarative image
-  process base and direct non-declarative nodes now read typed connection-info
-  records, while `_iter_connections()` remains only as a legacy compatibility
-  adapter for external callers and tests that explicitly cover that boundary.
+  or preserve typed `LinkRef` data. The editor stores canonical links in
+  `_link_refs`; `_node_link_list` remains only as a legacy compact-pair adapter
+  for compatibility with older tests/integrations and DearPyGui boundary code. The
+  declarative image process base and direct non-declarative nodes read typed
+  connection-info records, while `_iter_connections()` remains only as a legacy
+  compatibility adapter for external callers and tests that explicitly cover that
+  boundary.
 
 ## Next work
 
@@ -298,11 +301,13 @@ plus a readable compact boundary string.
 - Done: replace hovered-port discovery and node-port lookup with registered
   `PortRef` iteration; legacy compact-tag scanning has been removed from these
   normal paths.
-- Done: add typed `LinkRef` registry entries while preserving legacy `_node_link_list`
-  pairs for existing history/runtime code.
+- Done: add canonical typed `LinkRef` storage in `_link_refs` while preserving
+  legacy `_node_link_list` compact pairs as a compatibility adapter.
 - Done: add typed `link_refs` import/export schema and remove normal-path legacy
   `link_list` import/export fallback after fixture conversion.
 - Done: move graph sorting, cycle detection, delete-through-node reconnection, and
   runtime scheduling onto typed `LinkRef` iteration.
-- Next: migrate history payloads and node `update()` connection consumers from
+- Done: migrate history payloads and node `update()` connection consumers from
   string pairs to typed refs.
+- Next: continue shrinking compact-tag helper usage in node implementations where
+  the tag is not part of a DearPyGui UI boundary.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -63,10 +63,64 @@ Current implementation note:
   compatibility adapter for external callers and tests that explicitly cover that
   boundary.
 
+## Chosen near-term architecture: Option A
+
+After discussion, the refactor will **not** switch immediately to one Python
+object per graph node. The current plugin/editor architecture keeps one node
+object per node type and passes `node_id` into lifecycle methods. That shape is
+confusing for per-node state, but rewriting it now would touch node loading, the
+runtime loop, history, import/export, and callbacks all at once.
+
+Instead, use Option A as the near-term plan:
+
+- Keep the existing editor/runtime lifecycle and one-node-object-per-node-type
+  plugin model for now.
+- Stop doing broad mechanical conversions that merely replace one compact string
+  lookup with another compact or semantic string lookup.
+- Add a base-owned, typed per-node port-handle layer so node implementations can
+  keep using `node_id` lifecycle methods while accessing ports through handles
+  created by `DpgNodeBase`, not through node-local dictionaries.
+- Introduce typed `PortSpec` / `PortDataType` declarations before migrating more
+  nodes, so `Input01` / `Output01` and data-type strings are derived at the
+  DearPyGui/import/export boundary instead of being authored throughout node
+  implementations.
+- Keep compact DPG aliases and legacy pair adapters only at explicit boundary
+  functions: DearPyGui item creation/callbacks, import/export, compatibility
+  tests, and old history payload replay.
+
+The intended node authoring style after this foundation is closer to:
+
+```python
+class Node(DpgNodeBase):
+    port_specs = PortSpecs(
+        value=OutputPort(PortDataType.INT),
+    )
+
+    def add_node(...):
+        ports = self.create_ports(node_id)
+        dpg.add_input_int(tag=ports.value.value_tag)
+
+    def get_setting_dict(self, node_id):
+        ports = self.ports(node_id)
+        return {ports.value.value_tag: dpg_get_value(ports.value.value_tag)}
+```
+
+Normal node code should not repeatedly call string-keyed helpers such as
+`port_handle(node_id, "value")`, and it should not define ad hoc maps such as
+`self._output_ports[str(node_id)]`. A string key may appear once in a declaration
+(`value=...` or equivalent), but regular node logic should use generated handle
+attributes (`ports.value`).
+
 ## Next work
 
-1. Continue shrinking legacy compact-tag helper usage inside node implementations
-   where the tag is not part of a DearPyGui UI boundary.
+1. Add `PortDataType` and keep compatibility aliases for the existing
+   `TYPE_*` constants.
+2. Add `PortSpec` / `InputPort` / `OutputPort` declarations and a base-owned
+   per-`node_id` port-handle registry on `DpgNodeBase`.
+3. Move compact tag build/parse functions into an explicit serialization
+   boundary module.
+4. Convert one small node (for example `IntValue`) to the new handle style and
+   evaluate ergonomics before continuing the broader node migration.
 
 ## Step 1: Split the abstract interface from concrete node behavior
 
@@ -94,21 +148,25 @@ Move concrete behavior to `DpgNodeBase`:
 - new typed port declaration/registration helpers.
 
 The new base should provide explicit port declaration APIs that create both the
-compact DearPyGui tag and typed metadata in one place. Suggested shape:
+compact DearPyGui tag and typed metadata in one place. The initial helpers accept
+legacy `TYPE_*` data-type values and optional compatibility port names, but the
+Option A target is to declare ports by semantic spec/handle and let the base
+derive legacy names from direction plus numeric index:
 
 ```python
-image_in = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
-image_out = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
-threshold = self.parameter_port(node_id, self.TYPE_INT, 'Input02')
+ports = self.create_ports(node_id)
+image_in = ports.image
+image_out = ports.result
+threshold = ports.threshold
 ```
 
-Each returned object should expose at least:
+Each returned or generated port handle should expose at least:
 
 - `node_ref`,
-- `direction`,
-- `data_type`,
-- `index` / port name,
-- `dpg_tag`,
+- typed `direction`,
+- typed `data_type`,
+- numeric `index`,
+- boundary `dpg_tag`,
 - optional value/control tags for parameter widgets.
 
 The editor should receive these declarations through a registration callback or
@@ -180,27 +238,41 @@ Boundary-only parsing is still acceptable for:
 - undo/redo payloads until history commands are migrated,
 - tests that intentionally exercise malformed serialized data.
 
-## Step 5: Migrate all remaining nodes to the concrete base in one mechanical wave
+## Step 5: Add typed port specs and base-owned per-node handles before more node migration
 
-Do one broad, mechanical pass changing direct `DpgNodeABC` subclasses to inherit
-from `DpgNodeBase` and use the typed port helpers.
+Do **not** continue a broad mechanical pass that only swaps compact string
+helpers for another lookup helper. Before migrating more nodes, add the small
+foundation needed for consistent node authoring inside the current architecture.
 
-There is no need to introduce extra source/capture/model/sink/dynamic-slot base
-families as part of this step. The current nodes already work because they share
-the same tag construction convention, so this migration should be mostly
-risk-controlled and repetitive:
+Near-term target:
 
-1. replace direct `_port_tag(...)` / `_value_tag(...)` construction with concrete
-   base port helper calls,
-2. keep existing UI layout and business logic intact,
-3. register static ports during `add_node()`,
-4. register dynamic ports at the same time they are added to DearPyGui,
-5. preserve existing external tag strings for compatibility during the first
-   pass.
+1. Add `PortDataType` for `Int`, `Float`, `Image`, `TimeMS`, and `Text`, while
+   keeping existing `TYPE_*` constants as compatibility aliases during migration.
+2. Add `PortSpec` declarations for static graph ports. A spec should describe a
+   semantic handle name, direction, data type, optional index override, and UI
+   label/control metadata if needed.
+3. Add base-owned per-`node_id` handle storage on `DpgNodeBase`, so node code can
+   call `ports = self.create_ports(node_id)` in `add_node()` and
+   `ports = self.ports(node_id)` in later lifecycle methods.
+4. Generate attribute-style handles from declarations (`ports.value`,
+   `ports.image`, `ports.elapsed`) rather than requiring repeated string-keyed
+   calls such as `port_handle(node_id, "value")`.
+5. Derive legacy `Input01` / `Output01` names from `PortDirection` plus numeric
+   index. `port_name` should become a compatibility/serialization value, not the
+   node-authored source of truth.
+6. Move compact DPG tag serialization/deserialization into an explicit boundary
+   helper/module. Normal node logic should work with `PortRef` handles; only
+   DearPyGui aliases, import/export, and legacy compatibility paths should build
+   or parse compact strings.
 
-If family-specific abstractions are useful later, add them only after this
-migration exposes real duplication. They are not required to make `PortRef`
-authoritative.
+Only after this foundation exists should remaining nodes be migrated. The first
+validation migration should be a small node such as `IntValue`; if the resulting
+node code is not simpler than the current node-local `_output_ports` map, pause
+and revisit the design before touching more files.
+
+Family-specific abstractions can still be added later if repeated UI/state
+patterns emerge, but they should build on the same typed spec/handle layer rather
+than introducing separate graph identity conventions.
 
 ## Step 6: Move runtime/history/import/export to typed graph data
 
@@ -311,8 +383,8 @@ plus a readable compact boundary string.
   runtime scheduling onto typed `LinkRef` iteration.
 - Done: migrate history payloads and node `update()` connection consumers from
   string pairs to typed refs.
-- In progress: continue shrinking compact-tag helper usage in node implementations
-  where the tag is not part of a DearPyGui UI boundary. The current pass added
-  `PortDirection` and migrated `IntValue`, `FloatValue`, and `Image` source nodes
-  to store output `PortRef` handles instead of re-querying value tags by compact
-  `port_name` / direction strings.
+- In progress: adopt Option A before further node migration: keep the current
+  editor/runtime lifecycle, add `PortDataType`, typed `PortSpec` declarations,
+  base-owned per-node port handles, and explicit compact tag serialization
+  boundaries. Then rework one small node to prove the authoring style before
+  touching the remaining compact-tag-heavy node implementations.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -27,9 +27,10 @@ Implemented so far:
   `node_id` directly, reducing repeated nested tag construction in node code.
 - `node.port_model` defines the first reusable passive `NodeRef` / `PortRef`
   records for node-side declarations.
-- `DpgNodeBase` also has the first typed port declaration APIs
-  (`input_port`, `output_port`, `parameter_port`) that create passive `PortRef`
-  metadata while preserving the compact DPG tag format.
+- `DpgNodeBase` also has typed port declaration APIs (`input_port`,
+  `output_port`, `parameter_port`) that create passive `PortRef` metadata while
+  preserving the compact DPG tag format, plus lookup/value-tag helpers for code
+  paths that can reuse existing declarations instead of rebuilding compact tags.
 - `DeclarativeImageProcessNodeBase` uses typed `PortRef` declarations for its
   standard image input/output, elapsed-time output, and declared parameter ports;
   cache/result toggles still use value tags because they are toolbar controls,
@@ -39,7 +40,8 @@ Implemented so far:
   preserving existing compact tag strings.
 - Direct non-declarative node `update()` implementations now iterate typed
   connection info records through `_iter_connection_infos()` instead of the legacy
-  `_iter_connections()` adapter.
+  `_iter_connections()` adapter. Source value nodes and the still-image node now
+  reuse declared output port value tags in setting/update paths.
 - `DpgNodeABC` is back to the abstract lifecycle contract, shared metadata, shared
   type constants, and the optional editor hook.
 - The editor imports the shared `node.port_model` records, registers node-owned
@@ -309,5 +311,7 @@ plus a readable compact boundary string.
   runtime scheduling onto typed `LinkRef` iteration.
 - Done: migrate history payloads and node `update()` connection consumers from
   string pairs to typed refs.
-- Next: continue shrinking compact-tag helper usage in node implementations where
-  the tag is not part of a DearPyGui UI boundary.
+- In progress: continue shrinking compact-tag helper usage in node implementations
+  where the tag is not part of a DearPyGui UI boundary. The current pass added
+  declared-port lookup/value-tag helpers and migrated `IntValue`, `FloatValue`,
+  and `Image` source-node output value access to them.

--- a/node/input_node/node_float_value.py
+++ b/node/input_node/node_float_value.py
@@ -26,9 +26,11 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_FLOAT, 'Output01')
+        tag_node_output01_name_port = self.output_port(
+            node_id, self.TYPE_FLOAT, 'Output01'
+        )
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
-        tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
 
         # Settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -70,8 +72,8 @@ class Node(DpgNodeBase):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        output_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Output01')
+        output_value_tag = self.declared_port_value_tag(
+            node_id, self.TYPE_FLOAT, 'Output01', direction='Output'
         )
 
         output_value = round((dpg_get_value(output_value_tag)), 3)
@@ -86,9 +88,8 @@ class Node(DpgNodeBase):
         return setting_dict
 
     def set_setting_dict(self, node_id, setting_dict):
-        tag_node_name = self._node_name(node_id)
-        output_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Output01')
+        output_value_tag = self.declared_port_value_tag(
+            node_id, self.TYPE_FLOAT, 'Output01', direction='Output'
         )
 
         output_value = float(setting_dict[output_value_tag])

--- a/node/input_node/node_float_value.py
+++ b/node/input_node/node_float_value.py
@@ -14,7 +14,10 @@ class Node(DpgNodeBase):
     node_tag = 'FloatValue'
 
     def __init__(self):
-        pass
+        self._output_ports = {}
+
+    def _output_port(self, node_id):
+        return self._output_ports[str(node_id)]
 
     def add_node(
         self,
@@ -26,9 +29,8 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_output01_name_port = self.output_port(
-            node_id, self.TYPE_FLOAT, 'Output01'
-        )
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_FLOAT)
+        self._output_ports[str(node_id)] = tag_node_output01_name_port
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
 
@@ -72,9 +74,7 @@ class Node(DpgNodeBase):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        output_value_tag = self.declared_port_value_tag(
-            node_id, self.TYPE_FLOAT, 'Output01', direction='Output'
-        )
+        output_value_tag = self._output_port(node_id).value_tag
 
         output_value = round((dpg_get_value(output_value_tag)), 3)
 
@@ -88,9 +88,7 @@ class Node(DpgNodeBase):
         return setting_dict
 
     def set_setting_dict(self, node_id, setting_dict):
-        output_value_tag = self.declared_port_value_tag(
-            node_id, self.TYPE_FLOAT, 'Output01', direction='Output'
-        )
+        output_value_tag = self._output_port(node_id).value_tag
 
         output_value = float(setting_dict[output_value_tag])
 

--- a/node/input_node/node_int_value.py
+++ b/node/input_node/node_int_value.py
@@ -14,7 +14,10 @@ class Node(DpgNodeBase):
     node_tag = 'IntValue'
 
     def __init__(self):
-        pass
+        self._output_ports = {}
+
+    def _output_port(self, node_id):
+        return self._output_ports[str(node_id)]
 
     def add_node(
         self,
@@ -26,9 +29,8 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_output01_name_port = self.output_port(
-            node_id, self.TYPE_INT, 'Output01'
-        )
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_INT)
+        self._output_ports[str(node_id)] = tag_node_output01_name_port
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
 
@@ -72,9 +74,7 @@ class Node(DpgNodeBase):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        output_value_tag = self.declared_port_value_tag(
-            node_id, self.TYPE_INT, 'Output01', direction='Output'
-        )
+        output_value_tag = self._output_port(node_id).value_tag
 
         output_value = round((dpg_get_value(output_value_tag)), 3)
 
@@ -88,9 +88,7 @@ class Node(DpgNodeBase):
         return setting_dict
 
     def set_setting_dict(self, node_id, setting_dict):
-        output_value_tag = self.declared_port_value_tag(
-            node_id, self.TYPE_INT, 'Output01', direction='Output'
-        )
+        output_value_tag = self._output_port(node_id).value_tag
 
         output_value = float(setting_dict[output_value_tag])
 

--- a/node/input_node/node_int_value.py
+++ b/node/input_node/node_int_value.py
@@ -26,9 +26,11 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_INT, 'Output01')
+        tag_node_output01_name_port = self.output_port(
+            node_id, self.TYPE_INT, 'Output01'
+        )
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
-        tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
 
         # Settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -70,8 +72,8 @@ class Node(DpgNodeBase):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        output_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_INT, 'Output01')
+        output_value_tag = self.declared_port_value_tag(
+            node_id, self.TYPE_INT, 'Output01', direction='Output'
         )
 
         output_value = round((dpg_get_value(output_value_tag)), 3)
@@ -86,9 +88,8 @@ class Node(DpgNodeBase):
         return setting_dict
 
     def set_setting_dict(self, node_id, setting_dict):
-        tag_node_name = self._node_name(node_id)
-        output_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_INT, 'Output01')
+        output_value_tag = self.declared_port_value_tag(
+            node_id, self.TYPE_INT, 'Output01', direction='Output'
         )
 
         output_value = float(setting_dict[output_value_tag])

--- a/node/input_node/node_still_image.py
+++ b/node/input_node/node_still_image.py
@@ -52,9 +52,11 @@ class Node(DpgNodeBase):
         # Tag names
         tag_node_name = self._node_name(node_id)
         tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Input01')
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = self.output_port(
+            node_id, self.TYPE_IMAGE, 'Output01'
+        )
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
-        tag_node_output01_image_name = self._value_tag(tag_node_output01_name)
+        tag_node_output01_image_name = tag_node_output01_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -135,9 +137,9 @@ class Node(DpgNodeBase):
         node_image_dict,
         node_result_dict,
     ):
-        tag_node_name = self._node_name(node_id)
-        output_image_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
+        output_image_tag = self.declared_port_value_tag(
+            node_id, self.TYPE_IMAGE, 'Output01', direction='Output'
+        )
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         small_window_w = self._opencv_setting_dict['input_window_width']

--- a/node/input_node/node_still_image.py
+++ b/node/input_node/node_still_image.py
@@ -28,6 +28,10 @@ class Node(DpgNodeBase):
         self._display_size_dict = {}
         self._current_texture_tag_dict = {}
         self._texture_tags_dict = {}
+        self._output_ports = {}
+
+    def _output_port(self, node_id):
+        return self._output_ports[str(node_id)]
 
     def _compute_display_size(self, frame, width):
         image_h, image_w = frame.shape[:2]
@@ -51,10 +55,11 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Input01')
-        tag_node_output01_name_port = self.output_port(
-            node_id, self.TYPE_IMAGE, 'Output01'
+        tag_node_input01_name = self._port_tag(
+            tag_node_name, self.TYPE_INT, 'Input01'
         )
+        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE)
+        self._output_ports[str(node_id)] = tag_node_output01_name_port
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_image_name = tag_node_output01_name_port.value_tag
 
@@ -137,9 +142,7 @@ class Node(DpgNodeBase):
         node_image_dict,
         node_result_dict,
     ):
-        output_image_tag = self.declared_port_value_tag(
-            node_id, self.TYPE_IMAGE, 'Output01', direction='Output'
-        )
+        output_image_tag = self._output_port(node_id).value_tag
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         small_window_w = self._opencv_setting_dict['input_window_width']

--- a/node/node_abc.py
+++ b/node/node_abc.py
@@ -2,7 +2,7 @@ from abc import ABCMeta, abstractmethod
 
 import dearpygui.dearpygui as dpg
 
-from node.port_model import NodeRef, PortRef
+from node.port_model import NodeRef, PortDirection, PortRef
 
 
 class _PortTagString(str):
@@ -113,51 +113,21 @@ class DpgNodeBase(DpgNodeABC):
         node_ports = self._declared_port_refs.get(self._node_name(node_id), {})
         return list(node_ports.values())
 
-    def get_declared_port_ref(
-        self,
-        node_id,
-        data_type=None,
-        port_name=None,
-        direction=None,
-    ):
-        for port_ref in self.get_declared_port_refs(node_id):
-            if data_type is not None and port_ref.data_type != data_type:
-                continue
-            if port_name is not None and port_ref.port_name != port_name:
-                continue
-            if direction is not None and port_ref.direction != direction:
-                continue
-            return port_ref
-        return None
-
-    def declared_port_value_tag(
-        self,
-        node_id,
-        data_type,
-        port_name,
-        direction=None,
-    ):
-        port_ref = self.get_declared_port_ref(
-            node_id,
-            data_type=data_type,
-            port_name=port_name,
-            direction=direction,
-        )
-        if port_ref is not None and port_ref.value_tag:
-            return port_ref.value_tag
-        return self._node_value_tag(node_id, data_type, port_name)
-
     def input_port(self, node_id, data_type, port_name=None):
-        return self._declare_port(node_id, data_type, 'Input', port_name)
+        return self._declare_port(
+            node_id, data_type, PortDirection.INPUT, port_name
+        )
 
     def output_port(self, node_id, data_type, port_name=None):
-        return self._declare_port(node_id, data_type, 'Output', port_name)
+        return self._declare_port(
+            node_id, data_type, PortDirection.OUTPUT, port_name
+        )
 
     def parameter_port(self, node_id, data_type, port_name=None, control_tag=None):
         return self._declare_port(
             node_id,
             data_type,
-            'Input',
+            PortDirection.INPUT,
             port_name,
             control_tag=control_tag,
             default_control_tag=True,
@@ -193,11 +163,12 @@ class DpgNodeBase(DpgNodeABC):
         return port_ref
 
     def _resolve_port_name(self, node_ref, direction, port_name):
-        counter_key = (node_ref.node_id_name, direction)
+        direction_value = self._port_direction_value(direction)
+        counter_key = (node_ref.node_id_name, direction_value)
         if port_name is None:
             index = self._port_index_counters.get(counter_key, 0) + 1
             self._port_index_counters[counter_key] = index
-            return f'{direction}{index:02d}', index
+            return f'{direction_value}{index:02d}', index
 
         index = self._port_index(port_name, direction)
         self._port_index_counters[counter_key] = max(
@@ -206,17 +177,28 @@ class DpgNodeBase(DpgNodeABC):
         )
         return port_name, index
 
+    def _port_direction_value(self, direction):
+        if isinstance(direction, PortDirection):
+            return direction.value
+        return direction
+
     def _port_index(self, port_name, direction):
-        if not isinstance(port_name, str) or not port_name.startswith(direction):
+        direction_value = self._port_direction_value(direction)
+        if (
+            not isinstance(port_name, str)
+            or not port_name.startswith(direction_value)
+        ):
             raise ValueError(
-                f'{direction} port names must start with {direction}: {port_name}'
+                f'{direction_value} port names must start with '
+                f'{direction_value}: {port_name}'
             )
-        index_text = port_name[len(direction):]
+        index_text = port_name[len(direction_value):]
         try:
             return int(index_text)
         except ValueError as exc:
             raise ValueError(
-                f'{direction} port names must end with a numeric index: {port_name}'
+                f'{direction_value} port names must end with a numeric '
+                f'index: {port_name}'
             ) from exc
 
     def _remember_port_ref(self, port_ref):

--- a/node/node_abc.py
+++ b/node/node_abc.py
@@ -113,6 +113,40 @@ class DpgNodeBase(DpgNodeABC):
         node_ports = self._declared_port_refs.get(self._node_name(node_id), {})
         return list(node_ports.values())
 
+    def get_declared_port_ref(
+        self,
+        node_id,
+        data_type=None,
+        port_name=None,
+        direction=None,
+    ):
+        for port_ref in self.get_declared_port_refs(node_id):
+            if data_type is not None and port_ref.data_type != data_type:
+                continue
+            if port_name is not None and port_ref.port_name != port_name:
+                continue
+            if direction is not None and port_ref.direction != direction:
+                continue
+            return port_ref
+        return None
+
+    def declared_port_value_tag(
+        self,
+        node_id,
+        data_type,
+        port_name,
+        direction=None,
+    ):
+        port_ref = self.get_declared_port_ref(
+            node_id,
+            data_type=data_type,
+            port_name=port_name,
+            direction=direction,
+        )
+        if port_ref is not None and port_ref.value_tag:
+            return port_ref.value_tag
+        return self._node_value_tag(node_id, data_type, port_name)
+
     def input_port(self, node_id, data_type, port_name=None):
         return self._declare_port(node_id, data_type, 'Input', port_name)
 

--- a/node/port_model.py
+++ b/node/port_model.py
@@ -1,4 +1,10 @@
 from dataclasses import dataclass
+from enum import Enum
+
+
+class PortDirection(str, Enum):
+    INPUT = 'Input'
+    OUTPUT = 'Output'
 
 
 @dataclass(frozen=True)
@@ -14,7 +20,7 @@ class NodeRef:
 @dataclass(frozen=True)
 class PortRef:
     node_ref: NodeRef
-    direction: str
+    direction: PortDirection
     data_type: str
     index: int
     port_name: str

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -12,7 +12,7 @@ from importlib import import_module
 from pathlib import Path
 import dearpygui.dearpygui as dpg
 
-from node.port_model import LinkRef, NodeRef, PortRef
+from node.port_model import LinkRef, NodeRef, PortDirection, PortRef
 from node_editor.history import (
     AddNodeCommand,
     DeleteNodesCommand,
@@ -136,6 +136,8 @@ class DpgNodeEditor(object):
         node_id_name=None,
         data_type=None,
     ):
+        if isinstance(direction, PortDirection):
+            direction = direction.value
         for port_ref in list(self._port_registry.values()):
             if direction is not None and port_ref.direction != direction:
                 continue
@@ -159,11 +161,11 @@ class DpgNodeEditor(object):
         node_ref = NodeRef(parts[0], parts[1])
         port_name = parts[3]
         if port_name.startswith('Input'):
-            direction = 'Input'
-            index_text = port_name[len('Input'):]
+            direction = PortDirection.INPUT
+            index_text = port_name[len(PortDirection.INPUT.value):]
         elif port_name.startswith('Output'):
-            direction = 'Output'
-            index_text = port_name[len('Output'):]
+            direction = PortDirection.OUTPUT
+            index_text = port_name[len(PortDirection.OUTPUT.value):]
         else:
             return None
         try:
@@ -192,7 +194,10 @@ class DpgNodeEditor(object):
         dest_port = self._mdl_resolve_port_ref(destination)
         if source_port is None or dest_port is None:
             return None
-        if source_port.direction != 'Output' or dest_port.direction != 'Input':
+        if (
+            source_port.direction != PortDirection.OUTPUT
+            or dest_port.direction != PortDirection.INPUT
+        ):
             return None
         if source_port.data_type != dest_port.data_type:
             return None
@@ -235,12 +240,15 @@ class DpgNodeEditor(object):
         return None
 
     def _mdl_serialize_port_ref(self, port_ref):
+        direction = port_ref.direction
+        if isinstance(direction, PortDirection):
+            direction = direction.value
         return {
             'node': {
                 'id': port_ref.node_ref.node_id,
                 'tag': port_ref.node_ref.node_tag,
             },
-            'direction': port_ref.direction,
+            'direction': direction,
             'data_type': port_ref.data_type,
             'index': port_ref.index,
             'port_name': port_ref.port_name,
@@ -1377,10 +1385,10 @@ class DpgNodeEditor(object):
         return None
 
     def _cntrl_get_hovered_output_port_tag(self):
-        return self._cntrl_get_hovered_registered_port_tag('Output')
+        return self._cntrl_get_hovered_registered_port_tag(PortDirection.OUTPUT)
 
     def _cntrl_get_hovered_input_port_tag(self):
-        return self._cntrl_get_hovered_registered_port_tag('Input')
+        return self._cntrl_get_hovered_registered_port_tag(PortDirection.INPUT)
 
     def _cntrl_get_insert_node_pos(self, source_tag, dest_tag):
         source_node = ':'.join(source_tag.split(':')[:2])
@@ -1403,9 +1411,9 @@ class DpgNodeEditor(object):
 
     def _cntrl_find_node_port(self, node_id_name, port_type, port_prefix):
         expected_attr_type = None
-        if port_prefix == 'Input':
+        if port_prefix == PortDirection.INPUT.value:
             expected_attr_type = dpg.mvNode_Attr_Input
-        elif port_prefix == 'Output':
+        elif port_prefix == PortDirection.OUTPUT.value:
             expected_attr_type = dpg.mvNode_Attr_Output
 
         for port_ref in self._mdl_iter_registered_ports(

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -46,6 +46,7 @@ class DpgNodeEditor(object):
     _node_instance_list = {}
     _node_list = []
     _node_link_list = []
+    _link_refs = []
     _link_view_id_map = {}
 
     _last_pos = None
@@ -77,6 +78,7 @@ class DpgNodeEditor(object):
         self._node_instance_list = {}
         self._node_list = []
         self._node_link_list = []
+        self._link_refs = []
         self._link_view_id_map = {}
         self._node_connection_dict = OrderedDict([])
         self._node_connection_ref_dict = OrderedDict([])
@@ -196,6 +198,12 @@ class DpgNodeEditor(object):
             return None
         return LinkRef(source_port, dest_port)
 
+    def _mdl_link_key(self, link):
+        if hasattr(link, 'legacy_pair'):
+            return tuple(link.legacy_pair)
+        source_tag, dest_tag = link
+        return source_tag, dest_tag
+
     def _mdl_add_link(self, source, destination):
         link_ref = self._mdl_validate_link(source, destination)
         if link_ref is None:
@@ -204,6 +212,7 @@ class DpgNodeEditor(object):
         dest_tag = link_ref.destination_tag
         if dest_tag in self._link_by_dest_port_ref:
             return False
+        self._link_refs.append(link_ref)
         self._node_link_list.append(link_ref.legacy_pair)
         self._link_registry[(source_tag, dest_tag)] = link_ref
         self._link_by_dest_port[dest_tag] = source_tag
@@ -245,11 +254,28 @@ class DpgNodeEditor(object):
         }
 
     def _mdl_iter_link_refs(self):
+        yielded = set()
+        for link_ref in list(self._link_refs):
+            key = (link_ref.source_tag, link_ref.destination_tag)
+            yielded.add(key)
+            yield link_ref
+
+        # Compatibility boundary: some tests and old integrations still seed
+        # ``_node_link_list`` directly. Normalize those compact pairs once, but
+        # keep typed ``_link_refs`` as the normal graph model.
         for source_tag, dest_tag in list(self._node_link_list):
-            link_ref = self._link_registry.get((source_tag, dest_tag))
+            key = (source_tag, dest_tag)
+            if key in yielded:
+                continue
+            link_ref = self._link_registry.get(key)
             if link_ref is None:
                 link_ref = self._mdl_validate_link(source_tag, dest_tag)
             if link_ref is not None:
+                self._link_refs.append(link_ref)
+                self._link_registry[key] = link_ref
+                self._link_by_dest_port[dest_tag] = source_tag
+                self._link_by_dest_port_ref[dest_tag] = link_ref
+                yielded.add(key)
                 yield link_ref
 
     def _mdl_get_link_refs_for_export(self):
@@ -281,34 +307,29 @@ class DpgNodeEditor(object):
         node_instance.close(node_id)
         self._node_list.remove(node_id_name)
 
-        copy_node_link_list = copy.deepcopy(self._node_link_list)
-        for link_info in copy_node_link_list:
-            source_port = self._port_registry.get(link_info[0])
-            dest_port = self._port_registry.get(link_info[1])
-            source_node = source_port.node_ref.node_id_name if source_port else ''
-            destination_node = dest_port.node_ref.node_id_name if dest_port else ''
-            if not source_node and isinstance(link_info[0], str):
-                source_parts = link_info[0].split(':')
-                if len(source_parts) >= 2:
-                    source_node = f'{source_parts[0]}:{source_parts[1]}'
-            if not destination_node and isinstance(link_info[1], str):
-                dest_parts = link_info[1].split(':')
-                if len(dest_parts) >= 2:
-                    destination_node = f'{dest_parts[0]}:{dest_parts[1]}'
+        for link_ref in list(self._mdl_iter_link_refs()):
+            source_node = link_ref.source.node_ref.node_id_name
+            destination_node = link_ref.destination.node_ref.node_id_name
             if source_node == node_id_name or destination_node == node_id_name:
-                self._link_registry.pop((link_info[0], link_info[1]), None)
-                self._link_by_dest_port.pop(link_info[1], None)
-                self._link_by_dest_port_ref.pop(link_info[1], None)
-                self._node_link_list.remove(link_info)
+                self._mdl_delete_link(link_ref)
         self._node_registry.pop(node_id_name, None)
         self._mdl_sort_node_graph()
 
     def _mdl_delete_link(self, link):
-        source_tag, dest_tag = link
+        source_tag, dest_tag = self._mdl_link_key(link)
         self._link_registry.pop((source_tag, dest_tag), None)
         self._link_by_dest_port.pop(dest_tag, None)
         self._link_by_dest_port_ref.pop(dest_tag, None)
-        self._node_link_list.remove(link)
+        self._link_refs = [
+            link_ref for link_ref in self._link_refs
+            if (
+                link_ref.source_tag,
+                link_ref.destination_tag,
+            ) != (source_tag, dest_tag)
+        ]
+        legacy_pair = [source_tag, dest_tag]
+        if legacy_pair in self._node_link_list:
+            self._node_link_list.remove(legacy_pair)
         self._mdl_sort_node_graph()
 
     def _mdl_sort_node_graph(self):
@@ -1244,11 +1265,11 @@ class DpgNodeEditor(object):
         )
         if source_output_tag is None:
             return None
-        for source_tag, dest_tag in self._node_link_list:
-            if source_tag != source_output_tag:
+        for link_ref in self._mdl_iter_link_refs():
+            if link_ref.source_tag != source_output_tag:
                 continue
-            dest_port = self._port_registry.get(dest_tag)
-            if dest_port and dest_port.node_ref.node_tag == result_node_tag:
+            dest_port = link_ref.destination
+            if dest_port.node_ref.node_tag == result_node_tag:
                 return dest_port.node_ref.node_id_name
         return None
 
@@ -1959,11 +1980,12 @@ class DpgNodeEditor(object):
     def _cntrl_remove_link_by_tags(self, source_tag, dest_tag, record_history=False):
         source_tag = self._cntrl_resolve_history_port_tag(source_tag)
         dest_tag = self._cntrl_resolve_history_port_tag(dest_tag)
+        link_ref = self._link_registry.get((source_tag, dest_tag))
         link = [source_tag, dest_tag]
-        if link not in self._node_link_list:
+        if link_ref is None and link not in self._node_link_list:
             return False
         history_link = self._cntrl_history_link_payload(source_tag, dest_tag)
-        self._mdl_delete_link(link)
+        self._mdl_delete_link(link_ref if link_ref is not None else link)
         self._vw_delete_link(source_tag, dest_tag)
         if record_history:
             self._cntrl_push_undo_command(RemoveLinkCommand(history_link))
@@ -2222,11 +2244,11 @@ class DpgNodeEditor(object):
                     'setting': copy.deepcopy(node.get_setting_dict(node_id)),
                 }
             )
-            for source_tag, dest_tag in list(self._node_link_list):
-                if source_tag.startswith(f'{node_id}:{node_name}:') or dest_tag.startswith(f'{node_id}:{node_name}:'):
-                    removed_links.append(
-                        self._cntrl_history_link_payload(source_tag, dest_tag)
-                    )
+            for link_ref in list(self._mdl_iter_link_refs()):
+                source_node = link_ref.source.node_ref.node_id_name
+                dest_node = link_ref.destination.node_ref.node_id_name
+                if source_node == node_tag or dest_node == node_tag:
+                    removed_links.append(link_ref)
         for node_tag in selected_node_tags:
             self._cntrl_delete_node_by_tag(node_tag)
 

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -219,6 +219,73 @@ def test_mdl_add_link_accepts_port_refs(editor_and_dpg):
         '1:TestNode:Image:Output01',
         '2:TestNode:Image:Input01',
     ]]
+    assert editor._link_refs == [link_ref]
+    assert list(editor._mdl_iter_link_refs()) == [link_ref]
+
+
+def test_legacy_link_pairs_normalize_to_typed_link_refs(editor_and_dpg):
+    editor, _ = editor_and_dpg
+    editor._node_link_list = [[
+        '1:TestNode:Image:Output01',
+        '2:TestNode:Image:Input01',
+    ]]
+
+    link_refs = list(editor._mdl_iter_link_refs())
+
+    assert len(link_refs) == 1
+    assert link_refs[0].source == PortRef(
+        node_ref=NodeRef('1', 'TestNode'),
+        direction='Output',
+        data_type='Image',
+        index=1,
+        port_name='Output01',
+        dpg_tag='1:TestNode:Image:Output01',
+        value_tag='1:TestNode:Image:Output01Value',
+    )
+    assert link_refs[0].destination == PortRef(
+        node_ref=NodeRef('2', 'TestNode'),
+        direction='Input',
+        data_type='Image',
+        index=1,
+        port_name='Input01',
+        dpg_tag='2:TestNode:Image:Input01',
+        value_tag='2:TestNode:Image:Input01Value',
+    )
+    assert editor._link_refs == link_refs
+    assert editor._link_registry[(
+        '1:TestNode:Image:Output01',
+        '2:TestNode:Image:Input01',
+    )] == link_refs[0]
+
+
+def test_delete_link_accepts_typed_link_refs(editor_and_dpg):
+    editor, _ = editor_and_dpg
+    source_port = PortRef(
+        node_ref=NodeRef('1', 'TestNode'),
+        direction='Output',
+        data_type='Image',
+        index=1,
+        port_name='Output01',
+        dpg_tag='1:TestNode:Image:Output01',
+    )
+    dest_port = PortRef(
+        node_ref=NodeRef('2', 'TestNode'),
+        direction='Input',
+        data_type='Image',
+        index=1,
+        port_name='Input01',
+        dpg_tag='2:TestNode:Image:Input01',
+    )
+    editor._mdl_add_link(source_port, dest_port)
+    link_ref = editor._link_refs[0]
+
+    editor._mdl_delete_link(link_ref)
+
+    assert editor._link_refs == []
+    assert editor._node_link_list == []
+    assert editor._link_registry == {}
+    assert editor._link_by_dest_port == {}
+    assert editor._link_by_dest_port_ref == {}
 
 
 def test_history_import_command_accepts_typed_link_refs(editor_and_dpg):

--- a/tests/unit/test_node_port_declaration.py
+++ b/tests/unit/test_node_port_declaration.py
@@ -1,7 +1,7 @@
 import pytest
 
 from node.input_node.node_int_value import Node as IntValueNode
-from node.port_model import NodeRef, PortRef
+from node.port_model import NodeRef, PortDirection, PortRef
 
 
 def test_explicit_port_declaration_preserves_compact_tag_shape():
@@ -11,7 +11,7 @@ def test_explicit_port_declaration_preserves_compact_tag_shape():
 
     assert port == PortRef(
         node_ref=NodeRef('7', 'IntValue'),
-        direction='Output',
+        direction=PortDirection.OUTPUT,
         data_type='Int',
         index=1,
         port_name='Output01',
@@ -60,37 +60,19 @@ def test_declared_port_refs_are_stored_by_node():
     assert node.get_declared_port_refs() == [first, second]
 
 
-def test_declared_port_ref_lookup_filters_by_metadata():
+def test_declared_ports_use_direction_enum_values():
     node = IntValueNode()
 
-    int_output = node.output_port(10, node.TYPE_INT, 'Output01')
-    node.output_port(10, node.TYPE_FLOAT, 'Output02')
+    output_port = node.output_port(10, node.TYPE_INT)
+    input_port = node.input_port(10, node.TYPE_FLOAT)
 
-    assert node.get_declared_port_ref(
-        10,
-        data_type=node.TYPE_INT,
-        port_name='Output01',
-        direction='Output',
-    ) == int_output
-    assert node.get_declared_port_ref(
-        10,
-        data_type=node.TYPE_TEXT,
-        port_name='Output01',
-        direction='Output',
-    ) is None
-
-
-def test_declared_port_value_tag_prefers_port_ref_with_legacy_fallback():
-    node = IntValueNode()
-
-    declared = node.output_port(11, node.TYPE_INT, 'Output01')
-
-    assert node.declared_port_value_tag(
-        11, node.TYPE_INT, 'Output01', direction='Output'
-    ) == declared.value_tag
-    assert node.declared_port_value_tag(
-        12, node.TYPE_INT, 'Output01', direction='Output'
-    ) == '12:IntValue:Int:Output01Value'
+    assert output_port.direction is PortDirection.OUTPUT
+    assert output_port.direction == 'Output'
+    assert output_port.port_name == 'Output01'
+    assert output_port.value_tag == '10:IntValue:Int:Output01Value'
+    assert input_port.direction is PortDirection.INPUT
+    assert input_port.direction == 'Input'
+    assert input_port.port_name == 'Input01'
 
 
 def test_port_declaration_invokes_registration_callback():

--- a/tests/unit/test_node_port_declaration.py
+++ b/tests/unit/test_node_port_declaration.py
@@ -60,6 +60,39 @@ def test_declared_port_refs_are_stored_by_node():
     assert node.get_declared_port_refs() == [first, second]
 
 
+def test_declared_port_ref_lookup_filters_by_metadata():
+    node = IntValueNode()
+
+    int_output = node.output_port(10, node.TYPE_INT, 'Output01')
+    node.output_port(10, node.TYPE_FLOAT, 'Output02')
+
+    assert node.get_declared_port_ref(
+        10,
+        data_type=node.TYPE_INT,
+        port_name='Output01',
+        direction='Output',
+    ) == int_output
+    assert node.get_declared_port_ref(
+        10,
+        data_type=node.TYPE_TEXT,
+        port_name='Output01',
+        direction='Output',
+    ) is None
+
+
+def test_declared_port_value_tag_prefers_port_ref_with_legacy_fallback():
+    node = IntValueNode()
+
+    declared = node.output_port(11, node.TYPE_INT, 'Output01')
+
+    assert node.declared_port_value_tag(
+        11, node.TYPE_INT, 'Output01', direction='Output'
+    ) == declared.value_tag
+    assert node.declared_port_value_tag(
+        12, node.TYPE_INT, 'Output01', direction='Output'
+    ) == '12:IntValue:Int:Output01Value'
+
+
 def test_port_declaration_invokes_registration_callback():
     node = IntValueNode()
     registered_ports = []


### PR DESCRIPTION
### Motivation
- Make typed `LinkRef` the canonical in-memory graph representation instead of relying on compact DearPyGui string pairs. 
- Preserve backwards compatibility with existing serialized/DPG boundaries that still use the compact `_node_link_list` form.

### Description
- Add a canonical typed link list stored in `DpgNodeEditor._link_refs` and initialize it in `_mdl_init`, while keeping `_node_link_list` as a compatibility adapter (`node_editor/node_editor.py`).
- Populate `_link_refs` from `_mdl_add_link()` and prefer iterating `_link_refs` in `_mdl_iter_link_refs()`, with a compatibility pass that normalizes legacy compact pairs into typed `LinkRef` records when encountered (`node_editor/node_editor.py`).
- Introduce `_mdl_link_key()` to accept either typed `LinkRef` adapters or legacy compact pairs and update `_mdl_delete_link()`, `_mdl_delete_node()`, `_cntrl_find_linked_result_node()`, `_cntrl_remove_link_by_tags()`, and delete-history collection to operate on typed `LinkRef` iteration and keys (`node_editor/node_editor.py`).
- Add unit tests that assert typed link storage, normalization from legacy compact pairs, and typed-link deletion (`tests/unit/test_node_editor_core.py`), and update the refactor plan to document `_link_refs` as canonical storage (`docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md`).

### Testing
- Compiled the edited modules with `python -m compileall node_editor tests/unit/test_node_editor_core.py` which succeeded. 
- Ran the full test suite with `python -m pytest --use-cv2-stub` and all tests passed: `168 passed, 19 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b94dfb12883238631082cb5a7961a)