### PR TITLE
Introduce typed port model, PortSpecs/PortHandles, and migrate editor to typed LinkRef storage

### DIFF
--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -44,8 +44,8 @@ Implemented so far:
   preserving existing compact tag strings.
 - Direct non-declarative node `update()` implementations now iterate typed
   connection info records through `_iter_connection_infos()` instead of the legacy
-  `_iter_connections()` adapter. Source value nodes, the still-image node,
-  `ResultImage`, and `ScreenCapture` now use base-owned `PortSpecs` /
+  `_iter_connections()` adapter. Source value nodes, sink/draw utility nodes,
+  and selected video/control nodes now use base-owned `PortSpecs` /
   `PortHandles` and read value tags from generated handles in setting/update
   paths.
 - `DpgNodeABC` is back to the abstract lifecycle contract, shared metadata, shared
@@ -273,10 +273,12 @@ Near-term target:
    should build or parse compact strings.
 
 Only after this foundation proves ergonomic should remaining nodes be migrated.
-`IntValue`, `FloatValue`, `Image`, `ResultImage`, and `ScreenCapture` are
-the first validation nodes; if this style is not simpler than node-local
-`_output_ports` maps or repeated compact tag reconstruction, pause and revisit
-the design before touching more files.
+`IntValue`, `FloatValue`, `Image`, `ResultImage`, `ResultImageLarge`,
+`ScreenCapture`, `WebCam`, `RTSPInput`, `Video`, `VideoSetFramePos`,
+`DrawInformation`, `ImageAlphaBlend`, and `OnOffSwitch` are the first validation
+nodes; if this style is not simpler than node-local `_output_ports` maps or
+repeated compact tag reconstruction, pause and revisit the design before touching
+more files.
 
 Family-specific abstractions can still be added later if repeated UI/state
 patterns emerge, but they should build on the same typed spec/handle layer rather
@@ -393,7 +395,7 @@ plus a readable compact boundary string.
   string pairs to typed refs.
 - In progress: Option A foundation is underway. `PortDataType`, typed
   `PortSpec` declarations, base-owned per-node port handles, and the
-  `node.port_serialization` boundary module have been introduced; `IntValue`,
-  `FloatValue`, `Image`, `ResultImage`, and `ScreenCapture` now use generated
-  handles. Continue reviewing the authoring style before touching the remaining
-  compact-tag-heavy node implementations.
+  `node.port_serialization` boundary module have been introduced; thirteen
+  direct nodes now use generated handles for graph ports. Continue reviewing the
+  authoring style before touching the remaining compact-tag-heavy node
+  implementations.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -44,10 +44,10 @@ Implemented so far:
   preserving existing compact tag strings.
 - Direct non-declarative node `update()` implementations now iterate typed
   connection info records through `_iter_connection_infos()` instead of the legacy
-  `_iter_connections()` adapter. All direct `DpgNodeBase` node classes now
-  declare their static graph ports with base-owned `PortSpecs` / `PortHandles` and read value tags from generated
-  handles in setting/update paths; only dynamic slot creation still calls the
-  legacy declaration adapters at runtime.
+  `_iter_connections()` adapter. All active direct `DpgNodeBase` node classes now
+  declare their static graph ports with base-owned `PortSpecs` / `PortHandles`
+  and read value tags from generated handles in setting/update paths; only
+  dynamic slot creation still calls declaration adapters at runtime.
 - `DpgNodeABC` is back to the abstract lifecycle contract, shared metadata, shared
   type constants, and the optional editor hook.
 - The editor imports the shared `node.port_model` records, registers node-owned
@@ -117,16 +117,43 @@ Normal node code should not repeatedly call string-keyed helpers such as
 (`value=...` or equivalent), but regular node logic should use generated handle
 attributes (`ports.value`).
 
-## Next work
+## What is left
 
-1. Expand use of `PortDataType`, keeping compatibility aliases for the existing
-   `TYPE_*` constants until all node code can move to enum values.
-2. Continue hardening `PortSpec` / `InputPort` / `OutputPort` declarations and
-   the base-owned per-`node_id` port-handle registry on `DpgNodeBase`.
-3. Continue moving compact tag build/parse functions into the explicit
-   `node.port_serialization` boundary module.
-4. Review the converted `IntValue`, `FloatValue`, and `Image` source nodes for
-   authoring ergonomics before continuing the broader node migration.
+The broad static graph-port migration is done for active `DpgNodeBase` node
+classes: every active direct node now has a class-level `port_specs` declaration
+for static graph ports and uses generated handles for those ports in normal
+lifecycle code. Remaining work is narrower and should be treated as cleanup and
+boundary-hardening rather than another broad node pass:
+
+1. **Dynamic ports:** decide whether dynamic-slot nodes need first-class dynamic
+   `PortSpec` support. `ImageConcat` still calls `input_port()` when users add
+   extra image slots at runtime, and `FPS` still builds some dynamic slot aliases
+   directly. This is acceptable for now because those ports are created after the
+   initial static handle set, but it is the main remaining graph-port ergonomics
+   gap.
+2. **Declarative process base:** `DeclarativeImageProcessNodeBase` still declares
+   its standard image/elapsed ports and parameter ports through the lower-level
+   declaration helpers because its parameters are data-driven. Either keep that
+   as the dynamic/data-driven declaration path or add a `PortSpec` builder for
+   declarative parameter metadata.
+3. **Static/control UI tags:** many non-graph controls still use compact tags
+   (`Input02` model selectors, `Provider`, `Button`, `ColorEdit`, cache/result
+   toggles, etc.). These are DearPyGui UI/control aliases rather than graph
+   endpoint identity. Do not convert them mechanically unless a separate typed
+   control/widget model is introduced.
+4. **Legacy helper containment:** keep pushing compact tag construction/parsing
+   into `node.port_serialization` or narrowly named boundary helpers. The target
+   is not zero compact strings; it is compact strings only at DearPyGui,
+   import/export, history compatibility, tests for malformed data, and dynamic UI
+   boundary points.
+5. **Compatibility aliases:** keep `TYPE_*`, `input_port()`, `output_port()`, and
+   `parameter_port()` as compatibility/dynamic declaration adapters until the
+   dynamic-port story is settled. Static node-authored graph ports should use
+   `PortSpecs` going forward.
+6. **Disabled/legacy nodes:** `*.py.disable` files such as the disabled QR-code
+   node are not part of the active migration. If they are re-enabled, migrate
+   their static graph ports to `PortSpecs` before adding them back to the active
+   node set.
 
 ## Step 1: Split the abstract interface from concrete node behavior
 
@@ -226,22 +253,23 @@ once.
 Once hovered-port lookup is backed by creation-time port registration, continue
 shifting editor internals from string pairs toward typed objects.
 
-Implemented intermediate model:
+Implemented model:
 
-- keep `_node_link_list` as an internal string-pair adapter until history/runtime
-  are migrated,
-- add `LinkRef` as the canonical typed link record stored in `_link_registry` and
-  `_link_by_dest_port_ref`,
-- make `_mdl_add_link()` accept string aliases or `PortRef` endpoints on the normal
-  path and normalize successful links to `LinkRef`,
-- export typed `link_refs` from `LinkRef` data and import `link_refs` without
-  normal-path fallback to legacy `link_list`.
+- `_link_refs` is the canonical in-memory list of typed `LinkRef` records,
+- `_node_link_list` remains only as a legacy compact-pair adapter for older tests,
+  integrations, and DearPyGui boundary code,
+- `_mdl_add_link()` accepts string aliases or `PortRef` endpoints and normalizes
+  successful links to `LinkRef`,
+- graph sorting, cycle detection, delete/reconnect, runtime scheduling, history
+  replay, and node connection adapters consume or preserve typed links,
+- export writes typed `link_refs`, and import expects/remaps `link_refs` rather
+  than performing normal-path legacy `link_list` conversion.
 
 Boundary-only parsing is still acceptable for:
 
 - DearPyGui callback aliases,
-- old import files,
-- undo/redo payloads until history commands are migrated,
+- legacy compatibility adapters and tests,
+- dynamic UI/port creation boundaries,
 - tests that intentionally exercise malformed serialized data.
 
 ## Step 5: Add typed port specs and base-owned per-node handles before more node migration
@@ -264,19 +292,20 @@ Near-term target:
 4. Done initially: generate attribute-style handles from declarations
    (`ports.value`, `ports.image`, `ports.elapsed`) rather than requiring repeated
    string-keyed calls such as `port_handle(node_id, "value")`.
-5. In progress: derive legacy `Input01` / `Output01` names from `PortDirection`
-   plus numeric index. `port_name` should become a compatibility/serialization
-   value, not the node-authored source of truth.
-6. In progress: move compact DPG tag serialization/deserialization into an
-   explicit boundary helper/module. Normal node logic should work with `PortRef`
-   handles; only DearPyGui aliases, import/export, and legacy compatibility paths
-   should build or parse compact strings.
+5. Done for static graph ports: derive legacy `Input01` / `Output01` names from
+   `PortDirection` plus numeric index. `port_name` is now primarily a
+   compatibility/serialization value for static `PortSpecs`; dynamic/data-driven
+   declaration paths may still pass explicit legacy names.
+6. In progress: compact DPG tag serialization/deserialization lives partly in the
+   explicit `node.port_serialization` boundary module, but many static/control UI
+   aliases still call base tag helpers. Normal graph-port logic should work with
+   `PortRef` handles; only DearPyGui aliases, import/export, legacy compatibility
+   paths, tests, and dynamic UI boundaries should build or parse compact strings.
 
-Only after this foundation proves ergonomic should remaining nodes be migrated.
-All direct `DpgNodeBase` node classes now serve as the validation set for this
-style. Dynamic-slot nodes may still declare additional ports at runtime through
-the compatibility declaration adapters, but static graph ports should be authored
-through `PortSpecs` going forward.
+All active direct `DpgNodeBase` node classes now serve as the validation set for
+this style. Dynamic-slot nodes may still declare additional ports at runtime
+through the compatibility declaration adapters, but static graph ports should be
+authored through `PortSpecs` going forward.
 
 Family-specific abstractions can still be added later if repeated UI/state
 patterns emerge, but they should build on the same typed spec/handle layer rather
@@ -391,9 +420,11 @@ plus a readable compact boundary string.
   runtime scheduling onto typed `LinkRef` iteration.
 - Done: migrate history payloads and node `update()` connection consumers from
   string pairs to typed refs.
-- In progress: Option A foundation is underway. `PortDataType`, typed
+- Done: Option A static graph-port foundation is in place. `PortDataType`, typed
   `PortSpec` declarations, base-owned per-node port handles, and the
-  `node.port_serialization` boundary module have been introduced; all direct
-  `DpgNodeBase` node classes now use generated handles for static graph ports.
-  Continue reviewing dynamic-slot behavior and remaining compact static/control
-  tags before removing the legacy declaration adapters.
+  `node.port_serialization` boundary module have been introduced; all active
+  direct `DpgNodeBase` node classes now use generated handles for static graph
+  ports.
+- Remaining: review dynamic-slot behavior, the declarative parameter-port path,
+  and remaining compact static/control tags before removing or narrowing the
+  legacy declaration adapters.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -30,12 +30,13 @@ Implemented so far:
   `node_id` directly, reducing repeated nested tag construction in node code.
 - `node.port_model` defines the first reusable passive `NodeRef` / `PortRef`
   records for node-side declarations.
-- `DpgNodeBase` also has typed port declaration APIs (`input_port`,
-  `output_port`, `parameter_port`) that create passive `PortRef` metadata using
-  `PortDirection` and `PortDataType` enum values while preserving the compact DPG
-  tag format.
-- `node.port_model` now includes `PortSpec`, `InputPort` / `OutputPort`,
-  `PortSpecs`, and `PortHandles` for the Option A typed handle layer.
+- `DpgNodeBase` creates typed `PortRef` metadata through `PortSpecs` /
+  `create_ports()` and dynamic/data-driven `create_port()` calls using
+  `PortDirection` and `PortDataType` enum values while preserving compact DPG
+  aliases at the boundary.
+- `node.port_model` now includes `PortSpec`, `InputPort` / `OutputPort` /
+  `ParameterPort`, `PortSpecs`, and `PortHandles` for the Option A typed handle
+  layer.
 - `DpgNodeBase.create_port()` can now create one data-driven or dynamic
   `PortSpec` at runtime and store it either as a named handle or in a per-node
   handle collection, reusing the same declaration/registration path as static
@@ -48,15 +49,15 @@ Implemented so far:
   ports through `create_port()` handles. Parameter handles are stored under a
   `ports(node_id).parameters` collection, while cache/result toggles still use
   value tags because they are toolbar controls, not graph ports.
-- Direct non-declarative node `add_node()` implementations now declare their DPG
-  input/output graph attributes through `input_port()` / `output_port()` while
-  preserving existing compact tag strings.
+- Direct non-declarative node `add_node()` implementations now declare graph
+  attributes through class-level `PortSpecs` and `create_ports()` handles while
+  preserving existing compact DearPyGui aliases at the UI boundary.
 - Direct non-declarative node `update()` implementations now iterate typed
   connection info records through `_iter_connection_infos()` instead of the legacy
   `_iter_connections()` adapter. All active direct `DpgNodeBase` node classes now
   declare their static graph ports with base-owned `PortSpecs` / `PortHandles`
-  and read value tags from generated handles in setting/update paths; only
-  dynamic slot creation still calls declaration adapters at runtime.
+  and read value tags from generated handles in setting/update paths; dynamic
+  slot creation and data-driven declarative parameters use `create_port()`.
 - `DpgNodeABC` is back to the abstract lifecycle contract, shared metadata, shared
   type constants, and the optional editor hook.
 - The editor imports the shared `node.port_model` records, registers node-owned
@@ -144,11 +145,11 @@ node-by-node graph-port migration:
    Continue moving those call sites from generic `_port_tag()` / `_value_tag()`
    calls to `_control_tag()` / `_control_value_tag()` so control aliases are
    explicit. Do not convert them to `PortSpec` unless they become graph ports.
-2. **Keep legacy graph declaration adapters, but stop expanding their use.**
-   `input_port()`, `output_port()`, and `parameter_port()` can remain as
-   compatibility/declaration adapters for old tests, disabled nodes, or unusual
-   boundary paths. New static graph ports should use `PortSpecs`; new dynamic or
-   data-driven graph ports should use `create_port()`.
+2. **Keep graph declaration adapter APIs removed.** Active nodes no longer use
+   `input_port()`, `output_port()`, or `parameter_port()`, so those public
+   adapters have been removed from `DpgNodeBase`. New static graph ports should
+   use `PortSpecs`; new dynamic or data-driven graph ports should use
+   `create_port()`. Disabled nodes must migrate before being re-enabled.
 3. **Optionally improve declarative parameter metadata.** Declarative process
    graph identity now flows through `ParameterPort`/`create_port()`, but the
    parameter definitions are still dictionaries (`type`, `port`, `widget`,
@@ -451,5 +452,8 @@ plus a readable compact boundary string.
 - In progress: migrate non-graph static/control aliases to `_control_tag()` /
   `_control_value_tag()` helpers; declarative process toolbar controls and the
   `VideoWriter`/`OnOffSwitch` control widgets are now on that explicit boundary.
+- Done: remove the public graph declaration adapters (`input_port()`,
+  `output_port()`, `parameter_port()`) after active nodes and tests moved to
+  `PortSpecs`/`create_port()`.
 - Remaining: finish reviewing compact static/control tags and compatibility
-  helper usage before removing or narrowing the legacy declaration adapters.
+  helper usage.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -44,9 +44,10 @@ Implemented so far:
   preserving existing compact tag strings.
 - Direct non-declarative node `update()` implementations now iterate typed
   connection info records through `_iter_connection_infos()` instead of the legacy
-  `_iter_connections()` adapter. Source value nodes and the still-image node now
-  use base-owned `PortSpecs` / `PortHandles` and read value tags from generated
-  handles in setting/update paths.
+  `_iter_connections()` adapter. Source value nodes, the still-image node,
+  `ResultImage`, and `ScreenCapture` now use base-owned `PortSpecs` /
+  `PortHandles` and read value tags from generated handles in setting/update
+  paths.
 - `DpgNodeABC` is back to the abstract lifecycle contract, shared metadata, shared
   type constants, and the optional editor hook.
 - The editor imports the shared `node.port_model` records, registers node-owned
@@ -272,9 +273,10 @@ Near-term target:
    should build or parse compact strings.
 
 Only after this foundation proves ergonomic should remaining nodes be migrated.
-`IntValue`, `FloatValue`, and `Image` are the first validation nodes; if this
-style is not simpler than node-local `_output_ports` maps, pause and revisit the
-design before touching more files.
+`IntValue`, `FloatValue`, `Image`, `ResultImage`, and `ScreenCapture` are
+the first validation nodes; if this style is not simpler than node-local
+`_output_ports` maps or repeated compact tag reconstruction, pause and revisit
+the design before touching more files.
 
 Family-specific abstractions can still be added later if repeated UI/state
 patterns emerge, but they should build on the same typed spec/handle layer rather
@@ -392,6 +394,6 @@ plus a readable compact boundary string.
 - In progress: Option A foundation is underway. `PortDataType`, typed
   `PortSpec` declarations, base-owned per-node port handles, and the
   `node.port_serialization` boundary module have been introduced; `IntValue`,
-  `FloatValue`, and `Image` now use generated handles. Continue reviewing the
-  authoring style before touching the remaining compact-tag-heavy node
-  implementations.
+  `FloatValue`, `Image`, `ResultImage`, and `ScreenCapture` now use generated
+  handles. Continue reviewing the authoring style before touching the remaining
+  compact-tag-heavy node implementations.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -27,9 +27,14 @@ Implemented so far:
   `node_id` directly, reducing repeated nested tag construction in node code.
 - `node.port_model` defines the first reusable passive `NodeRef` / `PortRef`
   records for node-side declarations.
-- `DpgNodeBase` also has the first typed port declaration APIs
-  (`input_port`, `output_port`, `parameter_port`) that create passive `PortRef`
-  metadata while preserving the compact DPG tag format.
+- `DpgNodeBase` also has typed port declaration APIs (`input_port`,
+  `output_port`, `parameter_port`) that create passive `PortRef` metadata using
+  `PortDirection` and `PortDataType` enum values while preserving the compact DPG
+  tag format.
+- `node.port_model` now includes `PortSpec`, `InputPort` / `OutputPort`,
+  `PortSpecs`, and `PortHandles` for the Option A typed handle layer.
+- Compact port tag construction/parsing has started moving into the
+  `node.port_serialization` boundary module.
 - `DeclarativeImageProcessNodeBase` uses typed `PortRef` declarations for its
   standard image input/output, elapsed-time output, and declared parameter ports;
   cache/result toggles still use value tags because they are toolbar controls,
@@ -39,7 +44,9 @@ Implemented so far:
   preserving existing compact tag strings.
 - Direct non-declarative node `update()` implementations now iterate typed
   connection info records through `_iter_connection_infos()` instead of the legacy
-  `_iter_connections()` adapter.
+  `_iter_connections()` adapter. Source value nodes and the still-image node now
+  use base-owned `PortSpecs` / `PortHandles` and read value tags from generated
+  handles in setting/update paths.
 - `DpgNodeABC` is back to the abstract lifecycle contract, shared metadata, shared
   type constants, and the optional editor hook.
 - The editor imports the shared `node.port_model` records, registers node-owned
@@ -48,20 +55,77 @@ Implemented so far:
   parsing remains as a compatibility boundary for imported graphs, callback
   aliases, and undo/redo data.
 
-Important limitation of the current implementation:
+Current implementation note:
 
 - The editor now exports and imports typed `link_refs` directly; graph sorting,
   cycle detection, delete-through-node reconnection, the runtime scheduler,
   undo/redo link history, and the node `update()` connection boundary all consume
-  or preserve typed `LinkRef` data when it is available. The declarative image
-  process base and direct non-declarative nodes now read typed connection-info
-  records, while `_iter_connections()` remains only as a legacy compatibility
-  adapter for external callers and tests that explicitly cover that boundary.
+  or preserve typed `LinkRef` data. The editor stores canonical links in
+  `_link_refs`; `_node_link_list` remains only as a legacy compact-pair adapter
+  for compatibility with older tests/integrations and DearPyGui boundary code. The
+  declarative image process base and direct non-declarative nodes read typed
+  connection-info records, while `_iter_connections()` remains only as a legacy
+  compatibility adapter for external callers and tests that explicitly cover that
+  boundary.
+
+## Chosen near-term architecture: Option A
+
+After discussion, the refactor will **not** switch immediately to one Python
+object per graph node. The current plugin/editor architecture keeps one node
+object per node type and passes `node_id` into lifecycle methods. That shape is
+confusing for per-node state, but rewriting it now would touch node loading, the
+runtime loop, history, import/export, and callbacks all at once.
+
+Instead, use Option A as the near-term plan:
+
+- Keep the existing editor/runtime lifecycle and one-node-object-per-node-type
+  plugin model for now.
+- Stop doing broad mechanical conversions that merely replace one compact string
+  lookup with another compact or semantic string lookup.
+- Add a base-owned, typed per-node port-handle layer so node implementations can
+  keep using `node_id` lifecycle methods while accessing ports through handles
+  created by `DpgNodeBase`, not through node-local dictionaries.
+- Introduce typed `PortSpec` / `PortDataType` declarations before migrating more
+  nodes, so `Input01` / `Output01` and data-type strings are derived at the
+  DearPyGui/import/export boundary instead of being authored throughout node
+  implementations.
+- Keep compact DPG aliases and legacy pair adapters only at explicit boundary
+  functions: DearPyGui item creation/callbacks, import/export, compatibility
+  tests, and old history payload replay.
+
+The intended node authoring style after this foundation is closer to:
+
+```python
+class Node(DpgNodeBase):
+    port_specs = PortSpecs(
+        value=OutputPort(PortDataType.INT),
+    )
+
+    def add_node(...):
+        ports = self.create_ports(node_id)
+        dpg.add_input_int(tag=ports.value.value_tag)
+
+    def get_setting_dict(self, node_id):
+        ports = self.ports(node_id)
+        return {ports.value.value_tag: dpg_get_value(ports.value.value_tag)}
+```
+
+Normal node code should not repeatedly call string-keyed helpers such as
+`port_handle(node_id, "value")`, and it should not define ad hoc maps such as
+`self._output_ports[str(node_id)]`. A string key may appear once in a declaration
+(`value=...` or equivalent), but regular node logic should use generated handle
+attributes (`ports.value`).
 
 ## Next work
 
-1. Continue shrinking legacy compact-tag helper usage inside node implementations
-   where the tag is not part of a DearPyGui UI boundary.
+1. Expand use of `PortDataType`, keeping compatibility aliases for the existing
+   `TYPE_*` constants until all node code can move to enum values.
+2. Continue hardening `PortSpec` / `InputPort` / `OutputPort` declarations and
+   the base-owned per-`node_id` port-handle registry on `DpgNodeBase`.
+3. Continue moving compact tag build/parse functions into the explicit
+   `node.port_serialization` boundary module.
+4. Review the converted `IntValue`, `FloatValue`, and `Image` source nodes for
+   authoring ergonomics before continuing the broader node migration.
 
 ## Step 1: Split the abstract interface from concrete node behavior
 
@@ -89,21 +153,25 @@ Move concrete behavior to `DpgNodeBase`:
 - new typed port declaration/registration helpers.
 
 The new base should provide explicit port declaration APIs that create both the
-compact DearPyGui tag and typed metadata in one place. Suggested shape:
+compact DearPyGui tag and typed metadata in one place. The initial helpers accept
+legacy `TYPE_*` data-type values and optional compatibility port names, but the
+Option A target is to declare ports by semantic spec/handle and let the base
+derive legacy names from direction plus numeric index:
 
 ```python
-image_in = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
-image_out = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
-threshold = self.parameter_port(node_id, self.TYPE_INT, 'Input02')
+ports = self.create_ports(node_id)
+image_in = ports.image
+image_out = ports.result
+threshold = ports.threshold
 ```
 
-Each returned object should expose at least:
+Each returned or generated port handle should expose at least:
 
 - `node_ref`,
-- `direction`,
-- `data_type`,
-- `index` / port name,
-- `dpg_tag`,
+- typed `direction`,
+- typed `data_type`,
+- numeric `index`,
+- boundary `dpg_tag`,
 - optional value/control tags for parameter widgets.
 
 The editor should receive these declarations through a registration callback or
@@ -175,27 +243,42 @@ Boundary-only parsing is still acceptable for:
 - undo/redo payloads until history commands are migrated,
 - tests that intentionally exercise malformed serialized data.
 
-## Step 5: Migrate all remaining nodes to the concrete base in one mechanical wave
+## Step 5: Add typed port specs and base-owned per-node handles before more node migration
 
-Do one broad, mechanical pass changing direct `DpgNodeABC` subclasses to inherit
-from `DpgNodeBase` and use the typed port helpers.
+Do **not** continue a broad mechanical pass that only swaps compact string
+helpers for another lookup helper. Before migrating more nodes, add the small
+foundation needed for consistent node authoring inside the current architecture.
 
-There is no need to introduce extra source/capture/model/sink/dynamic-slot base
-families as part of this step. The current nodes already work because they share
-the same tag construction convention, so this migration should be mostly
-risk-controlled and repetitive:
+Near-term target:
 
-1. replace direct `_port_tag(...)` / `_value_tag(...)` construction with concrete
-   base port helper calls,
-2. keep existing UI layout and business logic intact,
-3. register static ports during `add_node()`,
-4. register dynamic ports at the same time they are added to DearPyGui,
-5. preserve existing external tag strings for compatibility during the first
-   pass.
+1. Done initially: add `PortDataType` for `Int`, `Float`, `Image`, `TimeMS`, and
+   `Text`, while keeping existing `TYPE_*` constants as compatibility aliases
+   during migration.
+2. Done initially: add `PortSpec` declarations for static graph ports. A spec
+   describes a semantic handle name, direction, data type, optional index
+   override, and UI label/control metadata if needed.
+3. Done initially: add base-owned per-`node_id` handle storage on `DpgNodeBase`,
+   so node code can call `ports = self.create_ports(node_id)` in `add_node()` and
+   `ports = self.ports(node_id)` in later lifecycle methods.
+4. Done initially: generate attribute-style handles from declarations
+   (`ports.value`, `ports.image`, `ports.elapsed`) rather than requiring repeated
+   string-keyed calls such as `port_handle(node_id, "value")`.
+5. In progress: derive legacy `Input01` / `Output01` names from `PortDirection`
+   plus numeric index. `port_name` should become a compatibility/serialization
+   value, not the node-authored source of truth.
+6. In progress: move compact DPG tag serialization/deserialization into an
+   explicit boundary helper/module. Normal node logic should work with `PortRef`
+   handles; only DearPyGui aliases, import/export, and legacy compatibility paths
+   should build or parse compact strings.
 
-If family-specific abstractions are useful later, add them only after this
-migration exposes real duplication. They are not required to make `PortRef`
-authoritative.
+Only after this foundation proves ergonomic should remaining nodes be migrated.
+`IntValue`, `FloatValue`, and `Image` are the first validation nodes; if this
+style is not simpler than node-local `_output_ports` maps, pause and revisit the
+design before touching more files.
+
+Family-specific abstractions can still be added later if repeated UI/state
+patterns emerge, but they should build on the same typed spec/handle layer rather
+than introducing separate graph identity conventions.
 
 ## Step 6: Move runtime/history/import/export to typed graph data
 
@@ -298,11 +381,17 @@ plus a readable compact boundary string.
 - Done: replace hovered-port discovery and node-port lookup with registered
   `PortRef` iteration; legacy compact-tag scanning has been removed from these
   normal paths.
-- Done: add typed `LinkRef` registry entries while preserving legacy `_node_link_list`
-  pairs for existing history/runtime code.
+- Done: add canonical typed `LinkRef` storage in `_link_refs` while preserving
+  legacy `_node_link_list` compact pairs as a compatibility adapter.
 - Done: add typed `link_refs` import/export schema and remove normal-path legacy
   `link_list` import/export fallback after fixture conversion.
 - Done: move graph sorting, cycle detection, delete-through-node reconnection, and
   runtime scheduling onto typed `LinkRef` iteration.
-- Next: migrate history payloads and node `update()` connection consumers from
+- Done: migrate history payloads and node `update()` connection consumers from
   string pairs to typed refs.
+- In progress: Option A foundation is underway. `PortDataType`, typed
+  `PortSpec` declarations, base-owned per-node port handles, and the
+  `node.port_serialization` boundary module have been introduced; `IntValue`,
+  `FloatValue`, and `Image` now use generated handles. Continue reviewing the
+  authoring style before touching the remaining compact-tag-heavy node
+  implementations.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -156,11 +156,11 @@ node-by-node graph-port migration:
    parameter definitions are still dictionaries (`type`, `port`, `widget`,
    `default`, etc.). If those dictionaries remain annoying, introduce a typed
    `ParameterSpec`/widget metadata object; otherwise leave them alone.
-4. **Reduce test coupling to `_node_link_list`.** `_link_refs` is canonical, and
-   `_node_link_list` is only a computed compatibility view. Core editor tests now
-   assert typed link pairs for normal graph operations; continue converting
-   import/export tests where they are not explicitly testing backward
-   compatibility.
+4. **Keep tests focused on typed links.** `_link_refs` is canonical, and
+   `_node_link_list` is only a computed compatibility view. Core editor and
+   import/export tests now assert typed link pairs for normal graph operations;
+   direct `_node_link_list` usage should stay limited to explicit legacy seeding
+   or compatibility-view tests.
 5. **Audit disabled/legacy nodes when re-enabling them.** `*.py.disable` files
    such as the disabled QR-code node are outside the active migration. If one is
    re-enabled, migrate its graph ports to `PortSpecs` first.
@@ -434,8 +434,8 @@ plus a readable compact boundary string.
   normal paths.
 - Done: add canonical typed `LinkRef` storage in `_link_refs` while keeping
   `_node_link_list` as a computed compatibility view over typed links and seeded
-  legacy compact pairs. Normal editor-core link assertions now prefer typed link
-  pairs.
+  legacy compact pairs. Normal editor-core and import/export link assertions now
+  prefer typed link pairs.
 - Done: add typed `link_refs` import/export schema and remove normal-path legacy
   `link_list` import/export fallback after fixture conversion.
 - Done: move graph sorting, cycle detection, delete-through-node reconnection, and
@@ -460,5 +460,8 @@ plus a readable compact boundary string.
 - Done: remove the public graph declaration adapters (`input_port()`,
   `output_port()`, `parameter_port()`) after active nodes and tests moved to
   `PortSpecs`/`create_port()`.
+- Done: reduce normal import/export test coupling to `_node_link_list`; the
+  remaining direct assignments seed legacy compatibility state before export or
+  import-collision scenarios.
 - Remaining: finish reviewing compact static/control tags and compatibility
   helper usage.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -44,10 +44,10 @@ Implemented so far:
   preserving existing compact tag strings.
 - Direct non-declarative node `update()` implementations now iterate typed
   connection info records through `_iter_connection_infos()` instead of the legacy
-  `_iter_connections()` adapter. Source value nodes, sink/draw utility nodes,
-  and selected video/control nodes now use base-owned `PortSpecs` /
-  `PortHandles` and read value tags from generated handles in setting/update
-  paths.
+  `_iter_connections()` adapter. All direct `DpgNodeBase` node classes now
+  declare their static graph ports with base-owned `PortSpecs` / `PortHandles` and read value tags from generated
+  handles in setting/update paths; only dynamic slot creation still calls the
+  legacy declaration adapters at runtime.
 - `DpgNodeABC` is back to the abstract lifecycle contract, shared metadata, shared
   type constants, and the optional editor hook.
 - The editor imports the shared `node.port_model` records, registers node-owned
@@ -273,12 +273,10 @@ Near-term target:
    should build or parse compact strings.
 
 Only after this foundation proves ergonomic should remaining nodes be migrated.
-`IntValue`, `FloatValue`, `Image`, `ResultImage`, `ResultImageLarge`,
-`ScreenCapture`, `WebCam`, `RTSPInput`, `Video`, `VideoSetFramePos`,
-`DrawInformation`, `ImageAlphaBlend`, and `OnOffSwitch` are the first validation
-nodes; if this style is not simpler than node-local `_output_ports` maps or
-repeated compact tag reconstruction, pause and revisit the design before touching
-more files.
+All direct `DpgNodeBase` node classes now serve as the validation set for this
+style. Dynamic-slot nodes may still declare additional ports at runtime through
+the compatibility declaration adapters, but static graph ports should be authored
+through `PortSpecs` going forward.
 
 Family-specific abstractions can still be added later if repeated UI/state
 patterns emerge, but they should build on the same typed spec/handle layer rather
@@ -395,7 +393,7 @@ plus a readable compact boundary string.
   string pairs to typed refs.
 - In progress: Option A foundation is underway. `PortDataType`, typed
   `PortSpec` declarations, base-owned per-node port handles, and the
-  `node.port_serialization` boundary module have been introduced; thirteen
-  direct nodes now use generated handles for graph ports. Continue reviewing the
-  authoring style before touching the remaining compact-tag-heavy node
-  implementations.
+  `node.port_serialization` boundary module have been introduced; all direct
+  `DpgNodeBase` node classes now use generated handles for static graph ports.
+  Continue reviewing dynamic-slot behavior and remaining compact static/control
+  tags before removing the legacy declaration adapters.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -33,6 +33,10 @@ Implemented so far:
   tag format.
 - `node.port_model` now includes `PortSpec`, `InputPort` / `OutputPort`,
   `PortSpecs`, and `PortHandles` for the Option A typed handle layer.
+- `DpgNodeBase.create_port()` can now create one data-driven or dynamic
+  `PortSpec` at runtime and store it either as a named handle or in a per-node
+  handle collection, reusing the same declaration/registration path as static
+  `create_ports()`.
 - Compact port tag construction/parsing has started moving into the
   `node.port_serialization` boundary module.
 - `DeclarativeImageProcessNodeBase` uses typed `PortRef` declarations for its
@@ -125,12 +129,12 @@ for static graph ports and uses generated handles for those ports in normal
 lifecycle code. Remaining work is narrower and should be treated as cleanup and
 boundary-hardening rather than another broad node pass:
 
-1. **Dynamic ports:** decide whether dynamic-slot nodes need first-class dynamic
-   `PortSpec` support. `ImageConcat` still calls `input_port()` when users add
-   extra image slots at runtime, and `FPS` still builds some dynamic slot aliases
-   directly. This is acceptable for now because those ports are created after the
-   initial static handle set, but it is the main remaining graph-port ergonomics
-   gap.
+1. **Dynamic ports:** first-class dynamic `PortSpec` creation now exists through
+   `DpgNodeBase.create_port()`, but dynamic-slot nodes still need to adopt it.
+   `ImageConcat` still calls `input_port()` when users add extra image slots at
+   runtime, and `FPS` still builds some dynamic slot aliases directly. Convert
+   these to `create_port(..., collection=...)` before narrowing the legacy
+   declaration adapters.
 2. **Declarative process base:** `DeclarativeImageProcessNodeBase` still declares
    its standard image/elapsed ports and parameter ports through the lower-level
    declaration helpers because its parameters are data-driven. Either keep that
@@ -147,9 +151,9 @@ boundary-hardening rather than another broad node pass:
    import/export, history compatibility, tests for malformed data, and dynamic UI
    boundary points.
 5. **Compatibility aliases:** keep `TYPE_*`, `input_port()`, `output_port()`, and
-   `parameter_port()` as compatibility/dynamic declaration adapters until the
-   dynamic-port story is settled. Static node-authored graph ports should use
-   `PortSpecs` going forward.
+   `parameter_port()` as compatibility/declaration adapters while dynamic-slot
+   and declarative-parameter call sites are migrated onto `create_port()`. Static
+   node-authored graph ports should use `PortSpecs` going forward.
 6. **Disabled/legacy nodes:** `*.py.disable` files such as the disabled QR-code
    node are not part of the active migration. If they are re-enabled, migrate
    their static graph ports to `PortSpecs` before adding them back to the active
@@ -296,7 +300,11 @@ Near-term target:
    `PortDirection` plus numeric index. `port_name` is now primarily a
    compatibility/serialization value for static `PortSpecs`; dynamic/data-driven
    declaration paths may still pass explicit legacy names.
-6. In progress: compact DPG tag serialization/deserialization lives partly in the
+6. Done initially: add `DpgNodeBase.create_port()` for one-off data-driven and
+   dynamic `PortSpec` declarations. It stores generated refs either as named
+   handles or in a per-node handle collection while reusing the same typed
+   declaration/registration path as `create_ports()`.
+7. In progress: compact DPG tag serialization/deserialization lives partly in the
    explicit `node.port_serialization` boundary module, but many static/control UI
    aliases still call base tag helpers. Normal graph-port logic should work with
    `PortRef` handles; only DearPyGui aliases, import/export, legacy compatibility
@@ -304,8 +312,9 @@ Near-term target:
 
 All active direct `DpgNodeBase` node classes now serve as the validation set for
 this style. Dynamic-slot nodes may still declare additional ports at runtime
-through the compatibility declaration adapters, but static graph ports should be
-authored through `PortSpecs` going forward.
+through compatibility declaration adapters, but new dynamic/data-driven graph
+ports should use `create_port()` and static graph ports should be authored
+through `PortSpecs` going forward.
 
 Family-specific abstractions can still be added later if repeated UI/state
 patterns emerge, but they should build on the same typed spec/handle layer rather
@@ -425,6 +434,8 @@ plus a readable compact boundary string.
   `node.port_serialization` boundary module have been introduced; all active
   direct `DpgNodeBase` node classes now use generated handles for static graph
   ports.
-- Remaining: review dynamic-slot behavior, the declarative parameter-port path,
-  and remaining compact static/control tags before removing or narrowing the
-  legacy declaration adapters.
+- Done initially: add `DpgNodeBase.create_port()` for one-off dynamic and
+  data-driven `PortSpec` declarations.
+- Remaining: migrate dynamic-slot behavior and the declarative parameter-port
+  path to `create_port()`, then review compact static/control tags before
+  removing or narrowing the legacy declaration adapters.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -157,9 +157,10 @@ node-by-node graph-port migration:
    `default`, etc.). If those dictionaries remain annoying, introduce a typed
    `ParameterSpec`/widget metadata object; otherwise leave them alone.
 4. **Reduce test coupling to `_node_link_list`.** `_link_refs` is canonical, and
-   `_node_link_list` is only a computed compatibility view. Many tests still
-   assert that view; convert tests to assert typed `LinkRef` state where they are
-   not explicitly testing backward compatibility.
+   `_node_link_list` is only a computed compatibility view. Core editor tests now
+   assert typed link pairs for normal graph operations; continue converting
+   import/export tests where they are not explicitly testing backward
+   compatibility.
 5. **Audit disabled/legacy nodes when re-enabling them.** `*.py.disable` files
    such as the disabled QR-code node are outside the active migration. If one is
    re-enabled, migrate its graph ports to `PortSpecs` first.
@@ -433,7 +434,8 @@ plus a readable compact boundary string.
   normal paths.
 - Done: add canonical typed `LinkRef` storage in `_link_refs` while keeping
   `_node_link_list` as a computed compatibility view over typed links and seeded
-  legacy compact pairs.
+  legacy compact pairs. Normal editor-core link assertions now prefer typed link
+  pairs.
 - Done: add typed `link_refs` import/export schema and remove normal-path legacy
   `link_list` import/export fallback after fixture conversion.
 - Done: move graph sorting, cycle detection, delete-through-node reconnection, and

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -36,13 +36,15 @@ Implemented so far:
 - `DpgNodeBase.create_port()` can now create one data-driven or dynamic
   `PortSpec` at runtime and store it either as a named handle or in a per-node
   handle collection, reusing the same declaration/registration path as static
-  `create_ports()`.
+  `create_ports()`. `PortSpec` also supports parameter-style default control
+  tags for value widgets through `ParameterPort`.
 - Compact port tag construction/parsing has started moving into the
   `node.port_serialization` boundary module.
-- `DeclarativeImageProcessNodeBase` uses typed `PortRef` declarations for its
-  standard image input/output, elapsed-time output, and declared parameter ports;
-  cache/result toggles still use value tags because they are toolbar controls,
-  not graph ports.
+- `DeclarativeImageProcessNodeBase` now creates its standard image
+  input/output, optional elapsed-time output, and data-driven parameter graph
+  ports through `create_port()` handles. Parameter handles are stored under a
+  `ports(node_id).parameters` collection, while cache/result toggles still use
+  value tags because they are toolbar controls, not graph ports.
 - Direct non-declarative node `add_node()` implementations now declare their DPG
   input/output graph attributes through `input_port()` / `output_port()` while
   preserving existing compact tag strings.
@@ -129,15 +131,16 @@ for static graph ports and uses generated handles for those ports in normal
 lifecycle code. Remaining work is narrower and should be treated as cleanup and
 boundary-hardening rather than another broad node pass:
 
-1. **Dynamic ports:** first-class dynamic `PortSpec` creation now exists through
-   `DpgNodeBase.create_port()`, and the active dynamic-slot nodes (`ImageConcat`
-   and `FPS`) use it for runtime-added graph inputs. Continue validating the
-   collection-handle shape before narrowing the legacy declaration adapters.
-2. **Declarative process base:** `DeclarativeImageProcessNodeBase` still declares
-   its standard image/elapsed ports and parameter ports through the lower-level
-   declaration helpers because its parameters are data-driven. Either keep that
-   as the dynamic/data-driven declaration path or add a `PortSpec` builder for
-   declarative parameter metadata.
+1. **Dynamic/data-driven ports:** first-class dynamic `PortSpec` creation now
+   exists through `DpgNodeBase.create_port()`. Active dynamic-slot nodes
+   (`ImageConcat` and `FPS`) use it for runtime-added graph inputs, and
+   `DeclarativeImageProcessNodeBase` uses the same path for standard graph ports
+   plus data-driven parameter ports. Continue validating collection-handle shape
+   before narrowing the legacy declaration adapters.
+2. **Declarative parameter ergonomics:** parameters still originate from legacy
+   dictionaries (`type`, `port`, `widget`, etc.). The graph identity now flows
+   through `ParameterPort`/`create_port()`, but a later cleanup can introduce a
+   typed parameter metadata object if the dictionaries remain hard to maintain.
 3. **Static/control UI tags:** many non-graph controls still use compact tags
    (`Input02` model selectors, `Provider`, `Button`, `ColorEdit`, cache/result
    toggles, etc.). These are DearPyGui UI/control aliases rather than graph
@@ -309,9 +312,10 @@ Near-term target:
    paths, tests, and dynamic UI boundaries should build or parse compact strings.
 
 All active direct `DpgNodeBase` node classes now serve as the validation set for
-this style. Active dynamic-slot nodes now declare runtime graph ports through
-`create_port()`. New dynamic/data-driven graph ports should use `create_port()`,
-and static graph ports should be authored through `PortSpecs` going forward.
+this style. Active dynamic-slot nodes and the declarative process-node base now
+declare runtime/data-driven graph ports through `create_port()`. New
+dynamic/data-driven graph ports should use `create_port()`, and static graph
+ports should be authored through `PortSpecs` going forward.
 
 Family-specific abstractions can still be added later if repeated UI/state
 patterns emerge, but they should build on the same typed spec/handle layer rather
@@ -431,10 +435,12 @@ plus a readable compact boundary string.
   `node.port_serialization` boundary module have been introduced; all active
   direct `DpgNodeBase` node classes now use generated handles for static graph
   ports.
-- Done initially: add `DpgNodeBase.create_port()` for one-off dynamic and
-  data-driven `PortSpec` declarations.
-- Done initially: migrate active dynamic-slot graph inputs (`ImageConcat` and
-  `FPS`) to `create_port(..., collection=...)`.
-- Remaining: migrate the declarative parameter-port path to `create_port()`, then
-  review compact static/control tags before removing or narrowing the legacy
-  declaration adapters.
+- Done: add `DpgNodeBase.create_port()` for one-off dynamic and data-driven
+  `PortSpec` declarations.
+- Done: migrate active dynamic-slot graph inputs (`ImageConcat` and `FPS`) to
+  `create_port(..., collection=...)`.
+- Done: migrate `DeclarativeImageProcessNodeBase` standard graph ports and
+  parameter graph ports to `create_port()` handles, including parameter
+  collection handles.
+- Remaining: review compact static/control tags and compatibility helper usage
+  before removing or narrowing the legacy declaration adapters.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -128,45 +128,43 @@ attributes (`ports.value`).
 
 ## What is left
 
-The broad static graph-port migration is done for active `DpgNodeBase` node
-classes: every active direct node now has a class-level `port_specs` declaration
-for static graph ports and uses generated handles for those ports in normal
-lifecycle code. Remaining work is narrower and should be treated as cleanup and
-boundary-hardening rather than another broad node pass:
+The graph-port part of the refactor is effectively complete for active nodes.
+Static graph ports use `PortSpecs`/`PortHandles`, dynamic graph slots and
+declarative process parameters use `create_port()`, editor graph internals use
+typed `LinkRef` storage, and import/export writes typed `link_refs`. It is
+reasonable to stop the broad migration here if the remaining compact strings are
+kept at explicit boundaries.
 
-1. **Control aliases:** compact aliases for non-graph UI controls now have
-   explicit helpers and the declarative process toolbar controls plus initial
-   direct control nodes (`VideoWriter`, `OnOffSwitch`) use them. Continue
-   migrating remaining static/control UI aliases to those helpers so `_port_tag()`
-   is reserved for compatibility and graph-port boundary code.
-2. **Dynamic/data-driven ports:** first-class dynamic `PortSpec` creation now
-   exists through `DpgNodeBase.create_port()`. Active dynamic-slot nodes
-   (`ImageConcat` and `FPS`) use it for runtime-added graph inputs, and
-   `DeclarativeImageProcessNodeBase` uses the same path for standard graph ports
-   plus data-driven parameter ports. Continue validating collection-handle shape
-   before narrowing the legacy declaration adapters.
-3. **Declarative parameter ergonomics:** parameters still originate from legacy
-   dictionaries (`type`, `port`, `widget`, etc.). The graph identity now flows
-   through `ParameterPort`/`create_port()`, but a later cleanup can introduce a
-   typed parameter metadata object if the dictionaries remain hard to maintain.
-3. **Static/control UI tags:** many non-graph controls still use compact tags
-   (`Input02` model selectors, `Provider`, `Button`, `ColorEdit`, cache/result
-   toggles, etc.). These are DearPyGui UI/control aliases rather than graph
-   endpoint identity. Do not convert them mechanically unless a separate typed
-   control/widget model is introduced.
-4. **Legacy helper containment:** keep pushing compact tag construction/parsing
-   into `node.port_serialization` or narrowly named boundary helpers. The target
-   is not zero compact strings; it is compact strings only at DearPyGui,
-   import/export, history compatibility, tests for malformed data, and dynamic UI
-   boundary points.
-5. **Compatibility aliases:** keep `TYPE_*`, `input_port()`, `output_port()`, and
-   `parameter_port()` as compatibility/declaration adapters while dynamic-slot
-   and declarative-parameter call sites are migrated onto `create_port()`. Static
-   node-authored graph ports should use `PortSpecs` going forward.
-6. **Disabled/legacy nodes:** `*.py.disable` files such as the disabled QR-code
-   node are not part of the active migration. If they are re-enabled, migrate
-   their static graph ports to `PortSpecs` before adding them back to the active
-   node set.
+The remaining work is cleanup and boundary-hardening, not another mechanical
+node-by-node graph-port migration:
+
+1. **Finish non-graph control alias cleanup.** Many remaining compact tags are
+   UI controls rather than graph endpoints: model selectors, provider selectors,
+   buttons, color editors, cache/result toggles, and similar DearPyGui widgets.
+   Continue moving those call sites from generic `_port_tag()` / `_value_tag()`
+   calls to `_control_tag()` / `_control_value_tag()` so control aliases are
+   explicit. Do not convert them to `PortSpec` unless they become graph ports.
+2. **Keep legacy graph declaration adapters, but stop expanding their use.**
+   `input_port()`, `output_port()`, and `parameter_port()` can remain as
+   compatibility/declaration adapters for old tests, disabled nodes, or unusual
+   boundary paths. New static graph ports should use `PortSpecs`; new dynamic or
+   data-driven graph ports should use `create_port()`.
+3. **Optionally improve declarative parameter metadata.** Declarative process
+   graph identity now flows through `ParameterPort`/`create_port()`, but the
+   parameter definitions are still dictionaries (`type`, `port`, `widget`,
+   `default`, etc.). If those dictionaries remain annoying, introduce a typed
+   `ParameterSpec`/widget metadata object; otherwise leave them alone.
+4. **Reduce test coupling to `_node_link_list`.** `_link_refs` is canonical, but
+   many tests still assert the legacy compact-pair adapter. Convert tests to
+   assert typed `LinkRef` state where they are not explicitly testing backward
+   compatibility.
+5. **Audit disabled/legacy nodes when re-enabling them.** `*.py.disable` files
+   such as the disabled QR-code node are outside the active migration. If one is
+   re-enabled, migrate its graph ports to `PortSpecs` first.
+
+Suggested next implementation step: continue item 1 by migrating direct node UI
+controls such as model/provider selectors and color editors to the explicit
+control-tag helpers.
 
 ## Step 1: Split the abstract interface from concrete node behavior
 

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -130,11 +130,9 @@ lifecycle code. Remaining work is narrower and should be treated as cleanup and
 boundary-hardening rather than another broad node pass:
 
 1. **Dynamic ports:** first-class dynamic `PortSpec` creation now exists through
-   `DpgNodeBase.create_port()`, but dynamic-slot nodes still need to adopt it.
-   `ImageConcat` still calls `input_port()` when users add extra image slots at
-   runtime, and `FPS` still builds some dynamic slot aliases directly. Convert
-   these to `create_port(..., collection=...)` before narrowing the legacy
-   declaration adapters.
+   `DpgNodeBase.create_port()`, and the active dynamic-slot nodes (`ImageConcat`
+   and `FPS`) use it for runtime-added graph inputs. Continue validating the
+   collection-handle shape before narrowing the legacy declaration adapters.
 2. **Declarative process base:** `DeclarativeImageProcessNodeBase` still declares
    its standard image/elapsed ports and parameter ports through the lower-level
    declaration helpers because its parameters are data-driven. Either keep that
@@ -311,10 +309,9 @@ Near-term target:
    paths, tests, and dynamic UI boundaries should build or parse compact strings.
 
 All active direct `DpgNodeBase` node classes now serve as the validation set for
-this style. Dynamic-slot nodes may still declare additional ports at runtime
-through compatibility declaration adapters, but new dynamic/data-driven graph
-ports should use `create_port()` and static graph ports should be authored
-through `PortSpecs` going forward.
+this style. Active dynamic-slot nodes now declare runtime graph ports through
+`create_port()`. New dynamic/data-driven graph ports should use `create_port()`,
+and static graph ports should be authored through `PortSpecs` going forward.
 
 Family-specific abstractions can still be added later if repeated UI/state
 patterns emerge, but they should build on the same typed spec/handle layer rather
@@ -436,6 +433,8 @@ plus a readable compact boundary string.
   ports.
 - Done initially: add `DpgNodeBase.create_port()` for one-off dynamic and
   data-driven `PortSpec` declarations.
-- Remaining: migrate dynamic-slot behavior and the declarative parameter-port
-  path to `create_port()`, then review compact static/control tags before
-  removing or narrowing the legacy declaration adapters.
+- Done initially: migrate active dynamic-slot graph inputs (`ImageConcat` and
+  `FPS`) to `create_port(..., collection=...)`.
+- Remaining: migrate the declarative parameter-port path to `create_port()`, then
+  review compact static/control tags before removing or narrowing the legacy
+  declaration adapters.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -22,7 +22,10 @@ Implemented so far:
 - Direct node/base subclasses under `node/` now inherit from `DpgNodeBase`
   instead of `DpgNodeABC`, while preserving existing behavior and tag strings.
 - Existing concrete helper methods for tag construction, legacy connection/tag
-  parsing, and the standard editor toolbar now live on `DpgNodeBase`.
+  parsing, and the standard editor toolbar now live on `DpgNodeBase`; non-graph
+  UI control aliases now have explicit `_control_tag()` / `_control_value_tag()`
+  helpers so graph-port tags and toolbar/control tags are separated in code even
+  while they share the compact DearPyGui alias format.
 - `DpgNodeBase` now has composed node/port/value tag helpers that accept a
   `node_id` directly, reducing repeated nested tag construction in node code.
 - `node.port_model` defines the first reusable passive `NodeRef` / `PortRef`
@@ -131,13 +134,18 @@ for static graph ports and uses generated handles for those ports in normal
 lifecycle code. Remaining work is narrower and should be treated as cleanup and
 boundary-hardening rather than another broad node pass:
 
-1. **Dynamic/data-driven ports:** first-class dynamic `PortSpec` creation now
+1. **Control aliases:** compact aliases for non-graph UI controls now have
+   explicit helpers and the declarative process toolbar controls plus initial
+   direct control nodes (`VideoWriter`, `OnOffSwitch`) use them. Continue
+   migrating remaining static/control UI aliases to those helpers so `_port_tag()`
+   is reserved for compatibility and graph-port boundary code.
+2. **Dynamic/data-driven ports:** first-class dynamic `PortSpec` creation now
    exists through `DpgNodeBase.create_port()`. Active dynamic-slot nodes
    (`ImageConcat` and `FPS`) use it for runtime-added graph inputs, and
    `DeclarativeImageProcessNodeBase` uses the same path for standard graph ports
    plus data-driven parameter ports. Continue validating collection-handle shape
    before narrowing the legacy declaration adapters.
-2. **Declarative parameter ergonomics:** parameters still originate from legacy
+3. **Declarative parameter ergonomics:** parameters still originate from legacy
    dictionaries (`type`, `port`, `widget`, etc.). The graph identity now flows
    through `ParameterPort`/`create_port()`, but a later cleanup can introduce a
    typed parameter metadata object if the dictionaries remain hard to maintain.
@@ -442,5 +450,8 @@ plus a readable compact boundary string.
 - Done: migrate `DeclarativeImageProcessNodeBase` standard graph ports and
   parameter graph ports to `create_port()` handles, including parameter
   collection handles.
-- Remaining: review compact static/control tags and compatibility helper usage
-  before removing or narrowing the legacy declaration adapters.
+- In progress: migrate non-graph static/control aliases to `_control_tag()` /
+  `_control_value_tag()` helpers; declarative process toolbar controls and the
+  `VideoWriter`/`OnOffSwitch` control widgets are now on that explicit boundary.
+- Remaining: finish reviewing compact static/control tags and compatibility
+  helper usage before removing or narrowing the legacy declaration adapters.

--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -72,8 +72,9 @@ Current implementation note:
   cycle detection, delete-through-node reconnection, the runtime scheduler,
   undo/redo link history, and the node `update()` connection boundary all consume
   or preserve typed `LinkRef` data. The editor stores canonical links in
-  `_link_refs`; `_node_link_list` remains only as a legacy compact-pair adapter
-  for compatibility with older tests/integrations and DearPyGui boundary code. The
+  `_link_refs`; `_node_link_list` is now a computed legacy compact-pair view over
+  typed links plus directly seeded legacy pairs for older tests/integrations and
+  DearPyGui boundary code. The
   declarative image process base and direct non-declarative nodes read typed
   connection-info records, while `_iter_connections()` remains only as a legacy
   compatibility adapter for external callers and tests that explicitly cover that
@@ -155,10 +156,10 @@ node-by-node graph-port migration:
    parameter definitions are still dictionaries (`type`, `port`, `widget`,
    `default`, etc.). If those dictionaries remain annoying, introduce a typed
    `ParameterSpec`/widget metadata object; otherwise leave them alone.
-4. **Reduce test coupling to `_node_link_list`.** `_link_refs` is canonical, but
-   many tests still assert the legacy compact-pair adapter. Convert tests to
-   assert typed `LinkRef` state where they are not explicitly testing backward
-   compatibility.
+4. **Reduce test coupling to `_node_link_list`.** `_link_refs` is canonical, and
+   `_node_link_list` is only a computed compatibility view. Many tests still
+   assert that view; convert tests to assert typed `LinkRef` state where they are
+   not explicitly testing backward compatibility.
 5. **Audit disabled/legacy nodes when re-enabling them.** `*.py.disable` files
    such as the disabled QR-code node are outside the active migration. If one is
    re-enabled, migrate its graph ports to `PortSpecs` first.
@@ -268,8 +269,9 @@ shifting editor internals from string pairs toward typed objects.
 Implemented model:
 
 - `_link_refs` is the canonical in-memory list of typed `LinkRef` records,
-- `_node_link_list` remains only as a legacy compact-pair adapter for older tests,
-  integrations, and DearPyGui boundary code,
+- `_node_link_list` is a computed legacy compact-pair view over typed links plus
+  directly seeded legacy pairs for older tests, integrations, and DearPyGui
+  boundary code,
 - `_mdl_add_link()` accepts string aliases or `PortRef` endpoints and normalizes
   successful links to `LinkRef`,
 - graph sorting, cycle detection, delete/reconnect, runtime scheduling, history
@@ -429,8 +431,9 @@ plus a readable compact boundary string.
 - Done: replace hovered-port discovery and node-port lookup with registered
   `PortRef` iteration; legacy compact-tag scanning has been removed from these
   normal paths.
-- Done: add canonical typed `LinkRef` storage in `_link_refs` while preserving
-  legacy `_node_link_list` compact pairs as a compatibility adapter.
+- Done: add canonical typed `LinkRef` storage in `_link_refs` while keeping
+  `_node_link_list` as a computed compatibility view over typed links and seeded
+  legacy compact pairs.
 - Done: add typed `link_refs` import/export schema and remove normal-path legacy
   `link_list` import/export fallback after fixture conversion.
 - Done: move graph sorting, cycle detection, delete-through-node reconnection, and

--- a/node/analysis_node/node_BRISQUE.py
+++ b/node/analysis_node/node_BRISQUE.py
@@ -10,6 +10,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -30,6 +31,12 @@ class Node(DpgNodeBase):
 
     _opencv_setting_dict = None
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
+
     def __init__(self):
         pass
 
@@ -43,15 +50,16 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
-        tag_node_input01_value_name = self._value_tag(tag_node_input01_name)
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
-        tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
-        tag_node_output02_value_name = self._value_tag(tag_node_output02_name)
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
         tag_node_score_name = self._port_tag(tag_node_name, self.TYPE_TEXT,
                                             'Score')
@@ -134,10 +142,9 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        output_value01_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        ports = self.ports(node_id)
+        output_value01_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
 
         tag_node_score_value_name = self._value_tag(
             self._port_tag(tag_node_name, self.TYPE_TEXT, 'Score'))

--- a/node/analysis_node/node_fps.py
+++ b/node/analysis_node/node_fps.py
@@ -8,6 +8,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 
 
 class Node(DpgNodeBase):
@@ -24,6 +25,11 @@ class Node(DpgNodeBase):
     _max_slot_number = 10
     _slot_id = {}
 
+    port_specs = PortSpecs(
+        elapsed_input=InputPort(PortDataType.TIME_MS),
+        elapsed=OutputPort(PortDataType.TIME_MS, index=2),
+    )
+
     def __init__(self):
         pass
 
@@ -39,13 +45,16 @@ class Node(DpgNodeBase):
 
         # Tag names
         tag_node_name = self._node_name(node_id)
+        ports = self.create_ports(node_id)
         tag_node_input00_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input00')
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_TIME_MS, 'Input01')
+        tag_node_input01_name_port = ports.elapsed_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
         tag_node_output01_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Output01')
-        tag_node_output01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Output01'))
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output01_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Output01')
+        )
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -113,8 +122,10 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        output_value01_tag = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Output01')
+        )
+        output_value02_tag = self.ports(node_id).elapsed.value_tag
 
         total_elapsed_time = 0
 

--- a/node/analysis_node/node_fps.py
+++ b/node/analysis_node/node_fps.py
@@ -230,17 +230,22 @@ class Node(DpgNodeBase):
         if self._max_slot_number > self._slot_id[tag_node_name]:
             self._slot_id[tag_node_name] += 1
 
+            node_id = self._extract_node_id(tag_node_name)
+            slot_number = self._slot_id[tag_node_name]
+
             # Generate insertion destination tag name
             before_tag = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input')
-            before_tag += str(self._slot_id[tag_node_name] - 1).zfill(2)
+            before_tag += str(slot_number - 1).zfill(2)
 
             # Generate added slot tag
-            tag_node_inputXX_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input')
-            tag_node_inputXX_name += str(self._slot_id[tag_node_name]).zfill(2)
-
-            tag_node_inputXX_value_name = self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input')
-            tag_node_inputXX_value_name += str(
-                self._slot_id[tag_node_name]).zfill(2) + 'Value'
+            input_port = self.create_port(
+                node_id,
+                slot_number,
+                InputPort(PortDataType.TIME_MS, index=slot_number),
+                collection='elapsed_inputs',
+            )
+            tag_node_inputXX_name = input_port.dpg_tag
+            tag_node_inputXX_value_name = input_port.value_tag
 
             # Add slot
             with dpg.node_attribute(

--- a/node/analysis_node/node_rgb_histgram.py
+++ b/node/analysis_node/node_rgb_histgram.py
@@ -7,6 +7,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, PortDataType, PortSpecs
 
 
 class Node(DpgNodeBase):
@@ -21,6 +22,10 @@ class Node(DpgNodeBase):
     _default_xdata = None
     _default_ydata = None
 
+    port_specs = PortSpecs(
+        image=InputPort(PortDataType.IMAGE),
+    )
+
     def __init__(self):
         pass
 
@@ -34,10 +39,10 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
-        tag_node_input01_value_name = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -111,9 +116,7 @@ class Node(DpgNodeBase):
         node_image_dict,
         node_result_dict,
     ):
-        tag_node_name = self._node_name(node_id)
-        tag_node_input01_value_name = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
+        tag_node_input01_value_name = self.ports(node_id).image.value_tag
 
         # Get source node name for image (with ID)
         connection_info_src = ''

--- a/node/base/declarative_node_base.py
+++ b/node/base/declarative_node_base.py
@@ -7,6 +7,7 @@ import dearpygui.dearpygui as dpg
 import numpy as np
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, ParameterPort, PortDirection
 from node_editor.util import convert_cv_to_dpg, dpg_get_value, dpg_set_value
 
 
@@ -43,11 +44,13 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
         small_window_h = self._opencv_setting_dict['process_height']
         use_pref_counter = self._opencv_setting_dict['use_pref_counter']
 
-        input_image_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
-        output_image_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
-        elapsed_port = None
-        if self.show_elapsed_time and use_pref_counter:
-            elapsed_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        ports = self._ensure_declarative_port_handles(
+            node_id,
+            include_elapsed=self.show_elapsed_time and use_pref_counter,
+        )
+        input_image_port = ports.image_input
+        output_image_port = ports.image
+        elapsed_port = getattr(ports, 'elapsed', None)
         cache_toggle_value_tag = self._node_value_tag(
             node_id, self.TYPE_TEXT, 'Cache'
         )
@@ -122,6 +125,70 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
         self.on_node_added(tag_node_name)
         return tag_node_name
 
+    def _ensure_declarative_port_handles(self, node_id, include_elapsed=False):
+        try:
+            ports = self.ports(node_id)
+        except KeyError:
+            ports = None
+
+        if ports is None or not hasattr(ports, 'image_input'):
+            self.create_port(
+                node_id,
+                'image_input',
+                InputPort(self.TYPE_IMAGE, index=1),
+            )
+        if ports is None or not hasattr(self.ports(node_id), 'image'):
+            self.create_port(
+                node_id,
+                'image',
+                OutputPort(self.TYPE_IMAGE, index=1),
+            )
+        if include_elapsed and not hasattr(self.ports(node_id), 'elapsed'):
+            self.create_port(
+                node_id,
+                'elapsed',
+                OutputPort(self.TYPE_TIME_MS, index=2),
+            )
+
+        for parameter in self.parameters:
+            self._parameter_port_ref(node_id, parameter)
+
+        return self.ports(node_id)
+
+    def _parameter_port_ref(self, node_id, parameter, attribute_type=None):
+        self._ensure_port_declaration_state()
+        parameter_key = str(parameter['name'])
+        try:
+            parameter_ports = self.ports(node_id).parameters
+        except (AttributeError, KeyError):
+            parameter_ports = {}
+
+        if parameter_key in parameter_ports:
+            return parameter_ports[parameter_key]
+
+        input_attr = getattr(dpg, 'mvNode_Attr_Input', None)
+        output_attr = getattr(dpg, 'mvNode_Attr_Output', None)
+        if attribute_type is None:
+            attribute_type = parameter.get('attribute_type', input_attr)
+        if output_attr is not None and attribute_type == output_attr:
+            direction = PortDirection.OUTPUT
+            spec = OutputPort(
+                parameter['type'],
+                index=self._port_index(parameter['port'], direction),
+            )
+        else:
+            direction = PortDirection.INPUT
+            spec = ParameterPort(
+                parameter['type'],
+                index=self._port_index(parameter['port'], direction),
+            )
+        return self.create_port(
+            node_id,
+            parameter_key,
+            spec,
+            collection='parameters',
+        )
+
     def _add_image_toolbar_controls(
         self,
         node_id,
@@ -164,12 +231,15 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
         del node_result_dict
 
         tag_node_name = self._node_name(node_id)
-        output_image_value_tag = self._node_value_tag(
-            node_id, self.TYPE_IMAGE, 'Output01'
+        ports = self._ensure_declarative_port_handles(
+            node_id,
+            include_elapsed=self.show_elapsed_time
+            and self._opencv_setting_dict.get('use_pref_counter', False),
         )
-        elapsed_value_tag = self._node_value_tag(
-            node_id, self.TYPE_TIME_MS, 'Output02'
-        )
+        output_image_value_tag = ports.image.value_tag
+        elapsed_value_tag = getattr(ports, 'elapsed', None)
+        if elapsed_value_tag is not None:
+            elapsed_value_tag = elapsed_value_tag.value_tag
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -192,7 +262,7 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
                     connection_info_src = self._extract_source_node_key(source_tag)
 
         frame = node_image_dict.get(connection_info_src, None)
-        parameter_values = self._get_parameter_values(tag_node_name)
+        parameter_values = self._get_parameter_values(node_id)
         parameter_values = self.normalize_parameter_values(tag_node_name, parameter_values)
 
         start_time = None
@@ -219,12 +289,15 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
             return
 
         start_time = time.perf_counter()
-        output_image_value_tag = self._node_value_tag(
-            node_id, self.TYPE_IMAGE, 'Output01'
+        ports = self._ensure_declarative_port_handles(
+            node_id,
+            include_elapsed=self.show_elapsed_time
+            and self._opencv_setting_dict.get('use_pref_counter', False),
         )
-        elapsed_value_tag = self._node_value_tag(
-            node_id, self.TYPE_TIME_MS, 'Output02'
-        )
+        output_image_value_tag = ports.image.value_tag
+        elapsed_value_tag = getattr(ports, 'elapsed', None)
+        if elapsed_value_tag is not None:
+            elapsed_value_tag = elapsed_value_tag.value_tag
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
         use_pref_counter = self._opencv_setting_dict['use_pref_counter']
@@ -246,9 +319,9 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
         }
 
         for parameter in self.parameters:
-            parameter_value_tag = self._port_value_tag(
-                tag_node_name, parameter['type'], parameter['port']
-            )
+            parameter_value_tag = self._parameter_port_ref(
+                node_id, parameter
+            ).value_tag
             setting_dict[parameter_value_tag] = dpg_get_value(parameter_value_tag)
 
         setting_dict.update(self.get_custom_setting_dict(tag_node_name, node_id))
@@ -268,9 +341,9 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
         tag_node_name = self._node_name(node_id)
 
         for parameter in self.parameters:
-            parameter_value_tag = self._port_value_tag(
-                tag_node_name, parameter['type'], parameter['port']
-            )
+            parameter_value_tag = self._parameter_port_ref(
+                node_id, parameter
+            ).value_tag
             if parameter_value_tag not in setting_dict:
                 continue
             value = self._cast_parameter_value(parameter, setting_dict[parameter_value_tag])
@@ -455,14 +528,18 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
 
             value = self._cast_parameter_value(parameter, source_value)
             value = self._clamp_parameter_value(parameter, value)
-            dpg_set_value(self._value_tag(destination_tag), value)
+            if destination_ref is not None and destination_ref.value_tag:
+                destination_value_tag = destination_ref.value_tag
+            else:
+                destination_value_tag = self._value_tag(destination_tag)
+            dpg_set_value(destination_value_tag, value)
 
-    def _get_parameter_values(self, tag_node_name):
+    def _get_parameter_values(self, node_id):
         values = {}
         for parameter in self.parameters:
-            parameter_value_tag = self._port_value_tag(
-                tag_node_name, parameter['type'], parameter['port']
-            )
+            parameter_value_tag = self._parameter_port_ref(
+                node_id, parameter
+            ).value_tag
             value = dpg_get_value(parameter_value_tag)
             value = self._cast_parameter_value(parameter, value)
             value = self._clamp_parameter_value(parameter, value)
@@ -471,19 +548,11 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
 
     def _add_parameter_ui(self, node_id, parameter, width, callback):
         tag_node_name = self._node_name(node_id)
-        attribute_type = parameter.get('attribute_type', dpg.mvNode_Attr_Input)
-        if attribute_type == dpg.mvNode_Attr_Output:
-            port_ref = self.output_port(
-                node_id,
-                parameter['type'],
-                parameter['port'],
-            )
-        else:
-            port_ref = self.parameter_port(
-                node_id,
-                parameter['type'],
-                parameter['port'],
-            )
+        attribute_type = parameter.get(
+            'attribute_type',
+            getattr(dpg, 'mvNode_Attr_Input', None),
+        )
+        port_ref = self._parameter_port_ref(node_id, parameter, attribute_type)
         port_tag = port_ref.dpg_tag
         value_tag = port_ref.value_tag
         callback_payload = {

--- a/node/base/declarative_node_base.py
+++ b/node/base/declarative_node_base.py
@@ -51,13 +51,13 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
         input_image_port = ports.image_input
         output_image_port = ports.image
         elapsed_port = getattr(ports, 'elapsed', None)
-        cache_toggle_value_tag = self._node_value_tag(
+        cache_toggle_value_tag = self._node_control_value_tag(
             node_id, self.TYPE_TEXT, 'Cache'
         )
-        result_image_toggle_value_tag = self._node_value_tag(
+        result_image_toggle_value_tag = self._node_control_value_tag(
             node_id, self.TYPE_TEXT, 'ResultImage'
         )
-        result_large_image_toggle_value_tag = self._node_value_tag(
+        result_large_image_toggle_value_tag = self._node_control_value_tag(
             node_id, self.TYPE_TEXT, 'ResultImageLarge'
         )
 
@@ -352,13 +352,13 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
 
         self.set_custom_setting_dict(tag_node_name, node_id, setting_dict)
 
-        cache_toggle_value_tag = self._node_value_tag(
+        cache_toggle_value_tag = self._node_control_value_tag(
             node_id, self.TYPE_TEXT, 'Cache'
         )
-        result_image_toggle_value_tag = self._node_value_tag(
+        result_image_toggle_value_tag = self._node_control_value_tag(
             node_id, self.TYPE_TEXT, 'ResultImage'
         )
-        result_large_image_toggle_value_tag = self._node_value_tag(
+        result_large_image_toggle_value_tag = self._node_control_value_tag(
             node_id, self.TYPE_TEXT, 'ResultImageLarge'
         )
         cache_enabled = bool(setting_dict.get(self._cache_toggle_setting_key, True))
@@ -410,7 +410,9 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
                 'parameter_changed',
                 {
                     'node_id_name': node_id_name,
-                    'port_tag': self._port_tag(node_id_name, self.TYPE_TEXT, 'Cache'),
+                    'port_tag': self._control_tag(
+                        node_id_name, self.TYPE_TEXT, 'Cache'
+                    ),
                     'value_tag': sender,
                     'before_value': bool(before_value),
                     'after_value': bool(app_data),
@@ -428,7 +430,9 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
                 'parameter_changed',
                 {
                     'node_id_name': node_id_name,
-                    'port_tag': self._port_tag(node_id_name, self.TYPE_TEXT, 'ResultImage'),
+                    'port_tag': self._control_tag(
+                        node_id_name, self.TYPE_TEXT, 'ResultImage'
+                    ),
                     'value_tag': sender,
                     'before_value': bool(before_value),
                     'after_value': enabled,
@@ -447,7 +451,9 @@ class DeclarativeImageProcessNodeBase(DpgNodeBase):
                 'parameter_changed',
                 {
                     'node_id_name': node_id_name,
-                    'port_tag': self._port_tag(node_id_name, self.TYPE_TEXT, 'ResultImageLarge'),
+                    'port_tag': self._control_tag(
+                        node_id_name, self.TYPE_TEXT, 'ResultImageLarge'
+                    ),
                     'value_tag': sender,
                     'before_value': bool(before_value),
                     'after_value': enabled,

--- a/node/deep_learning_node/node_classification.py
+++ b/node/deep_learning_node/node_classification.py
@@ -10,6 +10,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.classification.MobileNetV3.mobilenet_v3 import MobileNetV3
@@ -55,6 +56,12 @@ class Node(DpgNodeBase):
     _model_instance = {}
     _class_name_dict = None
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
+
     def __init__(self):
         pass
 
@@ -68,15 +75,16 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
         tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -174,9 +182,10 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
+        ports = self.ports(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        output_value01_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
 
         tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
 

--- a/node/deep_learning_node/node_face_detection.py
+++ b/node/deep_learning_node/node_face_detection.py
@@ -10,6 +10,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.face_detection.YuNet.yunet import YuNet
@@ -56,6 +57,13 @@ class Node(DpgNodeBase):
 
     _model_instance = {}
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        threshold=InputPort(PortDataType.FLOAT, index=3),
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
+
     def __init__(self):
         pass
 
@@ -69,18 +77,19 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
         tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_FLOAT, 'Input03')
+        tag_node_input03_name_port = ports.threshold
         tag_node_input03_name = tag_node_input03_name_port.dpg_tag
         tag_node_input03_value_name = tag_node_input03_name_port.value_tag
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -192,10 +201,11 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
+        ports = self.ports(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value03_tag = self.ports(node_id).threshold.value_tag
+        output_value01_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
 
         tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
 
@@ -300,7 +310,7 @@ class Node(DpgNodeBase):
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value03_tag = self.ports(node_id).threshold.value_tag
 
         # Selected model
         model_name = dpg_get_value(input_value02_tag)
@@ -320,7 +330,7 @@ class Node(DpgNodeBase):
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value03_tag = self.ports(node_id).threshold.value_tag
 
         model_name = setting_dict[input_value02_tag]
         score_th = setting_dict[input_value03_tag]

--- a/node/deep_learning_node/node_low_light_image_enhancement.py
+++ b/node/deep_learning_node/node_low_light_image_enhancement.py
@@ -9,6 +9,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.low_light_image_enhancement.TBEFN.tbefn import TBEFN
@@ -51,6 +52,12 @@ class Node(DpgNodeBase):
 
     _model_instance = {}
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
+
     def __init__(self):
         pass
 
@@ -64,15 +71,16 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
         tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -170,9 +178,10 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
+        ports = self.ports(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        output_value01_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
 
         tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
 

--- a/node/deep_learning_node/node_monocular_depth_estimation.py
+++ b/node/deep_learning_node/node_monocular_depth_estimation.py
@@ -10,6 +10,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.monocular_depth_estimation.FSRE_Depth.fsre_depth import FSRE_Depth
@@ -49,6 +50,12 @@ class Node(DpgNodeBase):
 
     _model_instance = {}
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
+
     def __init__(self):
         pass
 
@@ -62,15 +69,16 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
         tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -168,9 +176,10 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
+        ports = self.ports(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        output_value01_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
 
         tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
 

--- a/node/deep_learning_node/node_object_detection.py
+++ b/node/deep_learning_node/node_object_detection.py
@@ -10,6 +10,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.object_detection.YOLOX.yolox import YOLOX
@@ -69,6 +70,13 @@ class Node(DpgNodeBase):
 
     _model_instance = {}
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        threshold=InputPort(PortDataType.FLOAT, index=3),
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
+
     def __init__(self):
         pass
 
@@ -82,18 +90,19 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
         tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_FLOAT, 'Input03')
+        tag_node_input03_name_port = ports.threshold
         tag_node_input03_name = tag_node_input03_name_port.dpg_tag
         tag_node_input03_value_name = tag_node_input03_name_port.value_tag
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -205,10 +214,11 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
+        ports = self.ports(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value03_tag = self.ports(node_id).threshold.value_tag
+        output_value01_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
 
         tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
 
@@ -325,7 +335,7 @@ class Node(DpgNodeBase):
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value03_tag = self.ports(node_id).threshold.value_tag
 
         # Selected model
         model_name = dpg_get_value(input_value02_tag)
@@ -345,7 +355,7 @@ class Node(DpgNodeBase):
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value03_tag = self.ports(node_id).threshold.value_tag
 
         model_name = setting_dict[input_value02_tag]
         score_th = setting_dict[input_value03_tag]

--- a/node/deep_learning_node/node_pose_estimation.py
+++ b/node/deep_learning_node/node_pose_estimation.py
@@ -10,6 +10,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.pose_estimation.movenet.movenet import (
@@ -69,6 +70,13 @@ class Node(DpgNodeBase):
 
     _model_instance = {}
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        threshold=InputPort(PortDataType.FLOAT, index=3),
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
+
     def __init__(self):
         pass
 
@@ -82,18 +90,19 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
         tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_FLOAT, 'Input03')
+        tag_node_input03_name_port = ports.threshold
         tag_node_input03_name = tag_node_input03_name_port.dpg_tag
         tag_node_input03_value_name = tag_node_input03_name_port.value_tag
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -205,10 +214,11 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
+        ports = self.ports(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value03_tag = self.ports(node_id).threshold.value_tag
+        output_value01_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
 
         tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
 
@@ -313,7 +323,7 @@ class Node(DpgNodeBase):
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value03_tag = self.ports(node_id).threshold.value_tag
 
         # Selected model
         model_name = dpg_get_value(input_value02_tag)
@@ -333,7 +343,7 @@ class Node(DpgNodeBase):
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value03_tag = self.ports(node_id).threshold.value_tag
 
         model_name = setting_dict[input_value02_tag]
         score_th = setting_dict[input_value03_tag]

--- a/node/deep_learning_node/node_semantic_segmentation.py
+++ b/node/deep_learning_node/node_semantic_segmentation.py
@@ -9,6 +9,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 from node.deep_learning_node.semantic_segmentation.deeplab_v3.deeplab_v3 import DeepLabV3
@@ -59,6 +60,13 @@ class Node(DpgNodeBase):
     }
     _model_instance = {}
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        threshold=InputPort(PortDataType.FLOAT, index=3),
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
+
     def __init__(self):
         pass
 
@@ -72,18 +80,19 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
         tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_FLOAT, 'Input03')
+        tag_node_input03_name_port = ports.threshold
         tag_node_input03_name = tag_node_input03_name_port.dpg_tag
         tag_node_input03_value_name = tag_node_input03_name_port.value_tag
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -195,10 +204,11 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
+        ports = self.ports(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        input_value03_tag = self.ports(node_id).threshold.value_tag
+        output_value01_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
 
         tag_provider_select_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Provider'))
 
@@ -304,7 +314,7 @@ class Node(DpgNodeBase):
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value03_tag = self.ports(node_id).threshold.value_tag
 
         # Selected model
         model_name = dpg_get_value(input_value02_tag)
@@ -324,7 +334,7 @@ class Node(DpgNodeBase):
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
+        input_value03_tag = self.ports(node_id).threshold.value_tag
 
         model_name = setting_dict[input_value02_tag]
         score_th = setting_dict[input_value03_tag]

--- a/node/draw_node/node_draw_information.py
+++ b/node/draw_node/node_draw_information.py
@@ -6,6 +6,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 from node.draw_node.draw_util.draw_util import draw_info
 
@@ -17,6 +18,11 @@ class Node(DpgNodeBase):
     node_tag = 'DrawInformation'
 
     _opencv_setting_dict = None
+
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        image=OutputPort(PortDataType.IMAGE),
+    )
 
     def __init__(self):
         pass
@@ -31,12 +37,13 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
-        tag_node_input01_value_name = self._value_tag(tag_node_input01_name)
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
-        tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -96,9 +103,7 @@ class Node(DpgNodeBase):
         node_image_dict,
         node_result_dict,
     ):
-        tag_node_name = self._node_name(node_id)
-        output_value01_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
+        output_value01_tag = self.ports(node_id).image.value_tag
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']

--- a/node/draw_node/node_image_alpha_blend.py
+++ b/node/draw_node/node_image_alpha_blend.py
@@ -9,6 +9,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 from node.draw_node.draw_util.draw_util import draw_info
 
@@ -79,6 +80,16 @@ class Node(DpgNodeBase):
 
     _opencv_setting_dict = None
 
+    port_specs = PortSpecs(
+        image_a=InputPort(PortDataType.IMAGE),
+        image_b=InputPort(PortDataType.IMAGE),
+        alpha=InputPort(PortDataType.FLOAT),
+        beta=InputPort(PortDataType.FLOAT),
+        gamma=InputPort(PortDataType.INT),
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
+
     def __init__(self):
         pass
 
@@ -92,25 +103,26 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_a
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
-        tag_node_input02_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input02')
+        tag_node_input02_name_port = ports.image_b
         tag_node_input02_name = tag_node_input02_name_port.dpg_tag
         tag_node_input02_value_name = tag_node_input02_name_port.value_tag
-        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_FLOAT, 'Input03')
+        tag_node_input03_name_port = ports.alpha
         tag_node_input03_name = tag_node_input03_name_port.dpg_tag
         tag_node_input03_value_name = tag_node_input03_name_port.value_tag
-        tag_node_input04_name_port = self.input_port(node_id, self.TYPE_FLOAT, 'Input04')
+        tag_node_input04_name_port = ports.beta
         tag_node_input04_name = tag_node_input04_name_port.dpg_tag
         tag_node_input04_value_name = tag_node_input04_name_port.value_tag
-        tag_node_input05_name_port = self.input_port(node_id, self.TYPE_INT, 'Input05')
+        tag_node_input05_name_port = ports.gamma
         tag_node_input05_name = tag_node_input05_name_port.dpg_tag
         tag_node_input05_value_name = tag_node_input05_name_port.value_tag
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -233,12 +245,12 @@ class Node(DpgNodeBase):
         node_image_dict,
         node_result_dict,
     ):
-        tag_node_name = self._node_name(node_id)
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input03'))
-        input_value04_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Input04'))
-        input_value05_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input05'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        ports = self.ports(node_id)
+        input_value03_tag = ports.alpha.value_tag
+        input_value04_tag = ports.beta.value_tag
+        input_value05_tag = ports.gamma.value_tag
+        output_value01_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
@@ -346,23 +358,22 @@ class Node(DpgNodeBase):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
+        input_value03_tag = self.ports(node_id).alpha.value_tag
 
-        kernel_size = dpg_get_value(input_value03_tag)
+        alpha_value = dpg_get_value(input_value03_tag)
 
         pos = dpg.get_item_pos(tag_node_name)
 
         setting_dict = {}
         setting_dict['ver'] = self._ver
         setting_dict['pos'] = pos
-        setting_dict[input_value03_tag] = kernel_size
+        setting_dict[input_value03_tag] = alpha_value
 
         return setting_dict
 
     def set_setting_dict(self, node_id, setting_dict):
-        tag_node_name = self._node_name(node_id)
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input02'))
+        input_value03_tag = self.ports(node_id).alpha.value_tag
 
-        kernel_size = int(setting_dict[input_value03_tag])
+        alpha_value = float(setting_dict[input_value03_tag])
 
-        dpg_set_value(input_value03_tag, kernel_size)
+        dpg_set_value(input_value03_tag, alpha_value)

--- a/node/draw_node/node_image_concat.py
+++ b/node/draw_node/node_image_concat.py
@@ -10,6 +10,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 from node.draw_node.draw_util.draw_util import draw_info
 
@@ -131,6 +132,11 @@ class Node(DpgNodeBase):
     _max_slot_number = 9
     _slot_id = {}
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        image=OutputPort(PortDataType.IMAGE),
+    )
+
     def __init__(self):
         pass
 
@@ -146,11 +152,12 @@ class Node(DpgNodeBase):
 
         # Tag names
         tag_node_name = self._node_name(node_id)
+        ports = self.create_ports(node_id)
         tag_node_input00_name = self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input00')
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
 
@@ -227,7 +234,7 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
+        output_value01_tag = self.ports(node_id).image.value_tag
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']
         resize_width = self._opencv_setting_dict['result_width']

--- a/node/draw_node/node_image_concat.py
+++ b/node/draw_node/node_image_concat.py
@@ -347,7 +347,13 @@ class Node(DpgNodeBase):
             )
 
             # Generate added slot tag
-            input_port = self.input_port(node_id, self.TYPE_IMAGE, port_name)
+            slot_number = self._slot_id[tag_node_name]
+            input_port = self.create_port(
+                node_id,
+                slot_number,
+                InputPort(PortDataType.IMAGE, index=slot_number),
+                collection='image_inputs',
+            )
             tag_node_inputXX_name = input_port.dpg_tag
             tag_node_inputXX_value_name = input_port.value_tag
 

--- a/node/draw_node/node_puttext.py
+++ b/node/draw_node/node_puttext.py
@@ -7,6 +7,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 from node.draw_node.draw_util.draw_util import draw_info
 
@@ -57,6 +58,13 @@ class Node(DpgNodeBase):
 
     _opencv_setting_dict = None
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        text=InputPort(PortDataType.TEXT),
+        elapsed_input=InputPort(PortDataType.TIME_MS),
+        image=OutputPort(PortDataType.IMAGE),
+    )
+
     def __init__(self):
         pass
 
@@ -70,16 +78,17 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
-        tag_node_input02_name_port = self.input_port(node_id, self.TYPE_TEXT, 'Input02')
+        tag_node_input02_name_port = ports.text
         tag_node_input02_name = tag_node_input02_name_port.dpg_tag
         tag_node_input02_value_name = tag_node_input02_name_port.value_tag
-        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_TIME_MS, 'Input03')
+        tag_node_input03_name_port = ports.elapsed_input
         tag_node_input03_name = tag_node_input03_name_port.dpg_tag
         tag_node_input03_value_name = tag_node_input03_name_port.value_tag
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
 
@@ -167,9 +176,10 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        input_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Input03'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
+        ports = self.ports(node_id)
+        input_value02_tag = ports.text.value_tag
+        input_value03_tag = ports.elapsed_input.value_tag
+        output_value01_tag = ports.image.value_tag
 
         tag_color_edit_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'ColorEdit'))
 
@@ -245,7 +255,7 @@ class Node(DpgNodeBase):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
+        input_value02_tag = self.ports(node_id).text.value_tag
         tag_color_edit_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'ColorEdit'))
 
         text = dpg_get_value(input_value02_tag)
@@ -263,7 +273,7 @@ class Node(DpgNodeBase):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
+        input_value02_tag = self.ports(node_id).text.value_tag
         tag_color_edit_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'ColorEdit'))
 
         text = setting_dict[input_value02_tag]

--- a/node/draw_node/node_result_image.py
+++ b/node/draw_node/node_result_image.py
@@ -6,6 +6,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 from node.draw_node.draw_util.draw_util import draw_info
 
@@ -17,6 +18,10 @@ class Node(DpgNodeBase):
     node_tag = 'ResultImage'
 
     _opencv_setting_dict = None
+
+    port_specs = PortSpecs(
+        image=InputPort(PortDataType.IMAGE),
+    )
 
     def __init__(self):
         self._display_size_dict = {}
@@ -47,9 +52,10 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
-        tag_node_input01_image_name = self._value_tag(tag_node_input01_name)
+        tag_node_input01_image_name = tag_node_input01_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -111,9 +117,7 @@ class Node(DpgNodeBase):
         node_image_dict,
         node_result_dict,
     ):
-        tag_node_name = self._node_name(node_id)
-        input_image_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
+        input_image_tag = self.ports(node_id).image.value_tag
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         draw_info_on_result = self._opencv_setting_dict['draw_info_on_result']

--- a/node/draw_node/node_result_large_image.py
+++ b/node/draw_node/node_result_large_image.py
@@ -7,6 +7,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 from node.draw_node.draw_util.draw_util import draw_info
 
@@ -20,6 +21,10 @@ class Node(DpgNodeBase):
     _ratio = 2
 
     _opencv_setting_dict = None
+
+    port_specs = PortSpecs(
+        image=InputPort(PortDataType.IMAGE),
+    )
 
     def __init__(self):
         self._display_size_dict = {}
@@ -53,9 +58,10 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
-        tag_node_input01_image_name = self._value_tag(tag_node_input01_name)
+        tag_node_input01_image_name = tag_node_input01_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -113,9 +119,7 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         # Tag names
-        tag_node_name = self._node_name(node_id)
-        input_image_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
+        input_image_tag = self.ports(node_id).image.value_tag
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         # OpenCV settings

--- a/node/input_node/node_float_value.py
+++ b/node/input_node/node_float_value.py
@@ -5,6 +5,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import OutputPort, PortDataType, PortSpecs
 
 
 class Node(DpgNodeBase):
@@ -12,6 +13,10 @@ class Node(DpgNodeBase):
 
     node_label = 'Float Value'
     node_tag = 'FloatValue'
+
+    port_specs = PortSpecs(
+        value=OutputPort(PortDataType.FLOAT),
+    )
 
     def __init__(self):
         pass
@@ -26,9 +31,10 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_FLOAT, 'Output01')
+        ports = self.create_ports(node_id)
+        tag_node_output01_name_port = ports.value
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
-        tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
 
         # Settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -70,9 +76,7 @@ class Node(DpgNodeBase):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        output_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Output01')
-        )
+        output_value_tag = self.ports(node_id).value.value_tag
 
         output_value = round((dpg_get_value(output_value_tag)), 3)
 
@@ -86,10 +90,7 @@ class Node(DpgNodeBase):
         return setting_dict
 
     def set_setting_dict(self, node_id, setting_dict):
-        tag_node_name = self._node_name(node_id)
-        output_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_FLOAT, 'Output01')
-        )
+        output_value_tag = self.ports(node_id).value.value_tag
 
         output_value = float(setting_dict[output_value_tag])
 

--- a/node/input_node/node_int_value.py
+++ b/node/input_node/node_int_value.py
@@ -5,6 +5,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import OutputPort, PortDataType, PortSpecs
 
 
 class Node(DpgNodeBase):
@@ -12,6 +13,10 @@ class Node(DpgNodeBase):
 
     node_label = 'Int Value'
     node_tag = 'IntValue'
+
+    port_specs = PortSpecs(
+        value=OutputPort(PortDataType.INT),
+    )
 
     def __init__(self):
         pass
@@ -26,9 +31,10 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_INT, 'Output01')
+        ports = self.create_ports(node_id)
+        tag_node_output01_name_port = ports.value
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
-        tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
 
         # Settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -70,9 +76,7 @@ class Node(DpgNodeBase):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        output_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_INT, 'Output01')
-        )
+        output_value_tag = self.ports(node_id).value.value_tag
 
         output_value = round((dpg_get_value(output_value_tag)), 3)
 
@@ -86,10 +90,7 @@ class Node(DpgNodeBase):
         return setting_dict
 
     def set_setting_dict(self, node_id, setting_dict):
-        tag_node_name = self._node_name(node_id)
-        output_value_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_INT, 'Output01')
-        )
+        output_value_tag = self.ports(node_id).value.value_tag
 
         output_value = float(setting_dict[output_value_tag])
 

--- a/node/input_node/node_rtsp_input.py
+++ b/node/input_node/node_rtsp_input.py
@@ -10,6 +10,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -51,6 +52,11 @@ class Node(DpgNodeBase):
     _request = {}
     _process = {}
 
+    port_specs = PortSpecs(
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
+
     def __init__(self):
         self._display_size_dict = {}
         self._current_texture_tag_dict = {}
@@ -76,12 +82,15 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
+        ports = self.create_ports(node_id)
         tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input01'))
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_input01_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input01')
+        )
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_image_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -176,9 +185,12 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input01'))
-        output_image_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        ports = self.ports(node_id)
+        input_value01_tag = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input01')
+        )
+        output_image_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         small_window_w = self._opencv_setting_dict['input_window_width']

--- a/node/input_node/node_still_image.py
+++ b/node/input_node/node_still_image.py
@@ -9,6 +9,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -23,6 +24,10 @@ class Node(DpgNodeBase):
     _image = {}
     _image_filepath = {}
     _prev_image_filepath = {}
+
+    port_specs = PortSpecs(
+        image=OutputPort(PortDataType.IMAGE),
+    )
 
     def __init__(self):
         self._display_size_dict = {}
@@ -51,10 +56,13 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Input01')
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_input01_name = self._port_tag(
+            tag_node_name, self.TYPE_INT, 'Input01'
+        )
+        ports = self.create_ports(node_id)
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
-        tag_node_output01_image_name = self._value_tag(tag_node_output01_name)
+        tag_node_output01_image_name = tag_node_output01_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -135,9 +143,7 @@ class Node(DpgNodeBase):
         node_image_dict,
         node_result_dict,
     ):
-        tag_node_name = self._node_name(node_id)
-        output_image_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
+        output_image_tag = self.ports(node_id).image.value_tag
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         small_window_w = self._opencv_setting_dict['input_window_width']

--- a/node/input_node/node_video_input.py
+++ b/node/input_node/node_video_input.py
@@ -9,6 +9,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -30,6 +31,12 @@ class Node(DpgNodeBase):
 
     _min_val = 1
     _max_val = 10
+
+    port_specs = PortSpecs(
+        skip_rate=InputPort(PortDataType.INT, index=3),
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
 
     def __init__(self):
         self._display_size_dict = {}
@@ -58,20 +65,27 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
+        ports = self.create_ports(node_id)
         tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Input01')
         tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_name_port = self.input_port(node_id, self.TYPE_INT, 'Input03')
+        tag_node_input02_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
+        )
+        tag_node_input03_name_port = ports.skip_rate
         tag_node_input03_name = tag_node_input03_name_port.dpg_tag
         tag_node_input03_value_name = tag_node_input03_name_port.value_tag
         tag_node_input04_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04')
-        tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
+        tag_node_input04_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04')
+        )
         tag_node_input05_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05')
-        tag_node_input05_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05'))
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_input05_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05')
+        )
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_image_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -213,12 +227,19 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
-        tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
-        tag_node_input05_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05'))
-        output_image_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        ports = self.ports(node_id)
+        tag_node_input02_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
+        )
+        tag_node_input03_value_name = ports.skip_rate.value_tag
+        tag_node_input04_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04')
+        )
+        tag_node_input05_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05')
+        )
+        output_image_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         small_window_w = self._opencv_setting_dict['input_window_width']
@@ -405,10 +426,16 @@ class Node(DpgNodeBase):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
-        tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
-        tag_node_input05_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05'))
+        tag_node_input02_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
+        )
+        tag_node_input03_value_name = self.ports(node_id).skip_rate.value_tag
+        tag_node_input04_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04')
+        )
+        tag_node_input05_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05')
+        )
 
         pos = dpg.get_item_pos(tag_node_name)
 
@@ -431,10 +458,16 @@ class Node(DpgNodeBase):
 
     def set_setting_dict(self, node_id, setting_dict):
         tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_input03_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input03'))
-        tag_node_input04_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04'))
-        tag_node_input05_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05'))
+        tag_node_input02_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
+        )
+        tag_node_input03_value_name = self.ports(node_id).skip_rate.value_tag
+        tag_node_input04_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input04')
+        )
+        tag_node_input05_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input05')
+        )
 
         movie_path = setting_dict.get('movie_path', None)
         node_id = str(node_id)

--- a/node/input_node/node_video_set_frame_pos_input.py
+++ b/node/input_node/node_video_set_frame_pos_input.py
@@ -10,6 +10,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -31,6 +32,13 @@ class Node(DpgNodeBase):
     _max_val = 10000000
 
     _window_resize_rate = 1.5
+
+    port_specs = PortSpecs(
+        seek=InputPort(PortDataType.INT, index=2),
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+        frame_pos=OutputPort(PortDataType.INT, index=3),
+    )
 
     def __init__(self):
         self._display_size_dict = {}
@@ -57,17 +65,18 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
+        ports = self.create_ports(node_id)
         tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Input01')
-        tag_node_input02_name_port = self.input_port(node_id, self.TYPE_INT, 'Input02')
+        tag_node_input02_name_port = ports.seek
         tag_node_input02_name = tag_node_input02_name_port.dpg_tag
         tag_node_input02_value_name = tag_node_input02_name_port.value_tag
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_image_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
-        tag_node_output03_name_port = self.output_port(node_id, self.TYPE_INT, 'Output03')
+        tag_node_output03_name_port = ports.frame_pos
         tag_node_output03_name = tag_node_output03_name_port.dpg_tag
         tag_node_output03_value_name = tag_node_output03_name_port.value_tag
 
@@ -185,11 +194,11 @@ class Node(DpgNodeBase):
         node_image_dict,
         node_result_dict,
     ):
-        tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input02'))
-        output_image_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
-        output_value03_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Output03'))
+        ports = self.ports(node_id)
+        tag_node_input02_value_name = ports.seek.value_tag
+        output_image_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
+        output_value03_tag = ports.frame_pos.value_tag
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         small_window_w = self._opencv_setting_dict['input_window_width']
@@ -334,7 +343,7 @@ class Node(DpgNodeBase):
 
     def get_setting_dict(self, node_id):
         tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input02'))
+        tag_node_input02_value_name = self.ports(node_id).seek.value_tag
 
         pos = dpg.get_item_pos(tag_node_name)
 
@@ -348,8 +357,7 @@ class Node(DpgNodeBase):
         return setting_dict
 
     def set_setting_dict(self, node_id, setting_dict):
-        tag_node_name = self._node_name(node_id)
-        tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input02'))
+        tag_node_input02_value_name = self.ports(node_id).seek.value_tag
 
         seek_value = setting_dict[tag_node_input02_value_name]
 

--- a/node/input_node/node_webcam_input.py
+++ b/node/input_node/node_webcam_input.py
@@ -8,6 +8,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -18,6 +19,11 @@ class Node(DpgNodeBase):
     node_tag = 'WebCam'
 
     _opencv_setting_dict = None
+
+    port_specs = PortSpecs(
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
 
     def __init__(self):
         self._display_size_dict = {}
@@ -44,12 +50,15 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
+        ports = self.create_ports(node_id)
         tag_node_input01_name = self._port_tag(tag_node_name, self.TYPE_INT, 'Input01')
-        tag_node_input01_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input01'))
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_input01_value_name = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_INT, 'Input01')
+        )
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_image_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -133,9 +142,12 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_INT, 'Input01'))
-        output_image_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        ports = self.ports(node_id)
+        input_value01_tag = self._value_tag(
+            self._port_tag(tag_node_name, self.TYPE_INT, 'Input01')
+        )
+        output_image_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
         texture_tag = self._current_texture_tag_dict.get(node_id, None)
 
         device_no_list = self._opencv_setting_dict['device_no_list']

--- a/node/node_abc.py
+++ b/node/node_abc.py
@@ -204,26 +204,6 @@ class DpgNodeBase(DpgNodeABC):
             spec_key=spec.key,
         )
 
-    def input_port(self, node_id, data_type, port_name=None):
-        return self._declare_port(
-            node_id, data_type, PortDirection.INPUT, port_name
-        )
-
-    def output_port(self, node_id, data_type, port_name=None):
-        return self._declare_port(
-            node_id, data_type, PortDirection.OUTPUT, port_name
-        )
-
-    def parameter_port(self, node_id, data_type, port_name=None, control_tag=None):
-        return self._declare_port(
-            node_id,
-            data_type,
-            PortDirection.INPUT,
-            port_name,
-            control_tag=control_tag,
-            default_control_tag=True,
-        )
-
     def _declare_port(
         self,
         node_id,

--- a/node/node_abc.py
+++ b/node/node_abc.py
@@ -2,7 +2,20 @@ from abc import ABCMeta, abstractmethod
 
 import dearpygui.dearpygui as dpg
 
-from node.port_model import NodeRef, PortRef
+from node.port_model import (
+    NodeRef,
+    PortDataType,
+    PortDirection,
+    PortHandles,
+    PortRef,
+    normalize_port_data_type,
+    normalize_port_direction,
+)
+from node.port_serialization import (
+    legacy_port_name,
+    make_port_tag,
+    make_port_value_tag,
+)
 
 
 class _PortTagString(str):
@@ -18,11 +31,11 @@ class DpgNodeABC(metaclass=ABCMeta):
     node_label = ''
     node_tag = ''
 
-    TYPE_INT = 'Int'
-    TYPE_FLOAT = 'Float'
-    TYPE_IMAGE = 'Image'
-    TYPE_TIME_MS = 'TimeMS'
-    TYPE_TEXT = 'Text'
+    TYPE_INT = PortDataType.INT.value
+    TYPE_FLOAT = PortDataType.FLOAT.value
+    TYPE_IMAGE = PortDataType.IMAGE.value
+    TYPE_TIME_MS = PortDataType.TIME_MS.value
+    TYPE_TEXT = PortDataType.TEXT.value
 
     @abstractmethod
     def add_node(
@@ -79,13 +92,13 @@ class DpgNodeBase(DpgNodeABC):
         return f'{node_id}:{self.node_tag}'
 
     def _port_tag(self, node_name, value_type, port_name):
-        return f'{node_name}:{value_type}:{port_name}'
+        return make_port_tag(node_name, value_type, port_name)
 
     def _value_tag(self, port_tag):
         port_ref = getattr(port_tag, 'port_ref', None)
         if port_ref is not None and port_ref.value_tag:
             return port_ref.value_tag
-        return f'{port_tag}Value'
+        return make_port_value_tag(port_tag)
 
     def _node_port_tag(self, node_id, value_type, port_name):
         return self._port_tag(self._node_name(node_id), value_type, port_name)
@@ -113,17 +126,55 @@ class DpgNodeBase(DpgNodeABC):
         node_ports = self._declared_port_refs.get(self._node_name(node_id), {})
         return list(node_ports.values())
 
+    def create_ports(self, node_id):
+        self._ensure_port_declaration_state()
+        node_key = self._node_name(node_id)
+        handle_dict = {}
+        for spec in self._iter_port_specs():
+            port_ref = self._declare_port_from_spec(node_id, spec)
+            handle_dict[spec.key] = port_ref
+        handles = PortHandles(**handle_dict)
+        self._port_handles[node_key] = handles
+        return handles
+
+    def ports(self, node_id):
+        self._ensure_port_declaration_state()
+        node_key = self._node_name(node_id)
+        if node_key not in self._port_handles:
+            raise KeyError(f'Ports have not been created for {node_key}')
+        return self._port_handles[node_key]
+
+    def _iter_port_specs(self):
+        port_specs = getattr(self, 'port_specs', ())
+        if port_specs is None:
+            return iter(())
+        return iter(port_specs)
+
+    def _declare_port_from_spec(self, node_id, spec):
+        return self._declare_port(
+            node_id,
+            spec.data_type,
+            spec.direction,
+            index=spec.index,
+            control_tag=spec.control_tag,
+            spec_key=spec.key,
+        )
+
     def input_port(self, node_id, data_type, port_name=None):
-        return self._declare_port(node_id, data_type, 'Input', port_name)
+        return self._declare_port(
+            node_id, data_type, PortDirection.INPUT, port_name
+        )
 
     def output_port(self, node_id, data_type, port_name=None):
-        return self._declare_port(node_id, data_type, 'Output', port_name)
+        return self._declare_port(
+            node_id, data_type, PortDirection.OUTPUT, port_name
+        )
 
     def parameter_port(self, node_id, data_type, port_name=None, control_tag=None):
         return self._declare_port(
             node_id,
             data_type,
-            'Input',
+            PortDirection.INPUT,
             port_name,
             control_tag=control_tag,
             default_control_tag=True,
@@ -135,12 +186,18 @@ class DpgNodeBase(DpgNodeABC):
         data_type,
         direction,
         port_name=None,
+        index=None,
         control_tag=None,
         default_control_tag=False,
+        spec_key=None,
     ):
         self._ensure_port_declaration_state()
         node_ref = self.node_ref(node_id)
-        port_name, index = self._resolve_port_name(node_ref, direction, port_name)
+        direction = normalize_port_direction(direction)
+        data_type = normalize_port_data_type(data_type)
+        port_name, index = self._resolve_port_name(
+            node_ref, direction, port_name, index=index
+        )
         dpg_tag = self._port_tag(node_ref.node_id_name, data_type, port_name)
         value_tag = self._value_tag(dpg_tag)
         if control_tag is None and default_control_tag:
@@ -154,16 +211,28 @@ class DpgNodeBase(DpgNodeABC):
             dpg_tag=dpg_tag,
             value_tag=value_tag,
             control_tag=control_tag,
+            spec_key=spec_key,
         )
         self._remember_port_ref(port_ref)
         return port_ref
 
-    def _resolve_port_name(self, node_ref, direction, port_name):
-        counter_key = (node_ref.node_id_name, direction)
+    def _resolve_port_name(self, node_ref, direction, port_name, index=None):
+        direction_value = direction.value
+        counter_key = (node_ref.node_id_name, direction_value)
+        if index is not None:
+            index = int(index)
+            self._port_index_counters[counter_key] = max(
+                self._port_index_counters.get(counter_key, 0),
+                index,
+            )
+            if port_name is None:
+                port_name = legacy_port_name(direction, index)
+            return port_name, index
+
         if port_name is None:
             index = self._port_index_counters.get(counter_key, 0) + 1
             self._port_index_counters[counter_key] = index
-            return f'{direction}{index:02d}', index
+            return legacy_port_name(direction, index), index
 
         index = self._port_index(port_name, direction)
         self._port_index_counters[counter_key] = max(
@@ -173,16 +242,22 @@ class DpgNodeBase(DpgNodeABC):
         return port_name, index
 
     def _port_index(self, port_name, direction):
-        if not isinstance(port_name, str) or not port_name.startswith(direction):
+        direction_value = direction.value
+        if (
+            not isinstance(port_name, str)
+            or not port_name.startswith(direction_value)
+        ):
             raise ValueError(
-                f'{direction} port names must start with {direction}: {port_name}'
+                f'{direction_value} port names must start with '
+                f'{direction_value}: {port_name}'
             )
-        index_text = port_name[len(direction):]
+        index_text = port_name[len(direction_value):]
         try:
             return int(index_text)
         except ValueError as exc:
             raise ValueError(
-                f'{direction} port names must end with a numeric index: {port_name}'
+                f'{direction_value} port names must end with a numeric '
+                f'index: {port_name}'
             ) from exc
 
     def _remember_port_ref(self, port_ref):
@@ -202,6 +277,8 @@ class DpgNodeBase(DpgNodeABC):
             self._port_index_counters = {}
         if not hasattr(self, '_port_registration_callback'):
             self._port_registration_callback = None
+        if not hasattr(self, '_port_handles'):
+            self._port_handles = {}
 
     def _extract_source_node_key(self, source_tag):
         port_ref = getattr(source_tag, 'port_ref', None)

--- a/node/node_abc.py
+++ b/node/node_abc.py
@@ -137,6 +137,30 @@ class DpgNodeBase(DpgNodeABC):
         self._port_handles[node_key] = handles
         return handles
 
+    def create_port(self, node_id, key, spec, collection=None):
+        self._ensure_port_declaration_state()
+        handle_key = key if key is not None else spec.key
+        if handle_key is None:
+            raise ValueError('Dynamic port declarations require a handle key')
+
+        node_key = self._node_name(node_id)
+        handles = self._port_handles.setdefault(node_key, PortHandles())
+        port_ref = self._declare_port_from_spec(
+            node_id,
+            spec.with_key(str(handle_key)),
+        )
+
+        if collection is None:
+            setattr(handles, str(handle_key), port_ref)
+        else:
+            collection_name = str(collection)
+            port_collection = getattr(handles, collection_name, None)
+            if port_collection is None:
+                port_collection = {}
+                setattr(handles, collection_name, port_collection)
+            port_collection[handle_key] = port_ref
+        return port_ref
+
     def ports(self, node_id):
         self._ensure_port_declaration_state()
         node_key = self._node_name(node_id)

--- a/node/node_abc.py
+++ b/node/node_abc.py
@@ -109,6 +109,25 @@ class DpgNodeBase(DpgNodeABC):
     def _node_value_tag(self, node_id, value_type, port_name):
         return self._value_tag(self._node_port_tag(node_id, value_type, port_name))
 
+    def _control_tag(self, node_name, value_type, control_name):
+        """Return a compact DearPyGui alias for a non-graph UI control."""
+        return self._port_tag(node_name, value_type, control_name)
+
+    def _control_value_tag(self, node_name, value_type, control_name):
+        return self._value_tag(
+            self._control_tag(node_name, value_type, control_name)
+        )
+
+    def _node_control_tag(self, node_id, value_type, control_name):
+        return self._control_tag(
+            self._node_name(node_id), value_type, control_name
+        )
+
+    def _node_control_value_tag(self, node_id, value_type, control_name):
+        return self._value_tag(
+            self._node_control_tag(node_id, value_type, control_name)
+        )
+
     def node_ref(self, node_id):
         return NodeRef(str(node_id), self.node_tag)
 

--- a/node/node_abc.py
+++ b/node/node_abc.py
@@ -181,6 +181,7 @@ class DpgNodeBase(DpgNodeABC):
             spec.direction,
             index=spec.index,
             control_tag=spec.control_tag,
+            default_control_tag=spec.default_control_tag,
             spec_key=spec.key,
         )
 

--- a/node/other_node/node_on_off_switch.py
+++ b/node/other_node/node_on_off_switch.py
@@ -54,10 +54,12 @@ class Node(DpgNodeBase):
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
 
-        tag_switch_select_name = self._port_tag(tag_node_name, self.TYPE_TEXT,
-                                             'Switch')
-        tag_switch_select_value_name = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Switch'))
+        tag_switch_select_name = self._control_tag(
+            tag_node_name, self.TYPE_TEXT, 'Switch'
+        )
+        tag_switch_select_value_name = self._control_value_tag(
+            tag_node_name, self.TYPE_TEXT, 'Switch'
+        )
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -128,8 +130,9 @@ class Node(DpgNodeBase):
         tag_node_name = self._node_name(node_id)
         output_value01_tag = self.ports(node_id).image.value_tag
 
-        tag_switch_select_value_name = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TEXT, 'Switch'))
+        tag_switch_select_value_name = self._control_value_tag(
+            tag_node_name, self.TYPE_TEXT, 'Switch'
+        )
 
         small_window_w = int(self._opencv_setting_dict['process_width'] / 2)
         small_window_h = int(self._opencv_setting_dict['process_height'] / 2)

--- a/node/other_node/node_on_off_switch.py
+++ b/node/other_node/node_on_off_switch.py
@@ -9,6 +9,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -27,6 +28,11 @@ class Node(DpgNodeBase):
 
     _opencv_setting_dict = None
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        image=OutputPort(PortDataType.IMAGE),
+    )
+
     def __init__(self):
         pass
 
@@ -40,12 +46,13 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
-        tag_node_input01_value_name = self._value_tag(tag_node_input01_name)
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
-        tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
 
         tag_switch_select_name = self._port_tag(tag_node_name, self.TYPE_TEXT,
                                              'Switch')
@@ -119,8 +126,7 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        output_value01_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
+        output_value01_tag = self.ports(node_id).image.value_tag
 
         tag_switch_select_value_name = self._value_tag(
             self._port_tag(tag_node_name, self.TYPE_TEXT, 'Switch'))

--- a/node/other_node/node_video_writer.py
+++ b/node/other_node/node_video_writer.py
@@ -51,8 +51,12 @@ class Node(DpgNodeBase):
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
 
-        tag_node_button_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Button')
-        tag_node_button_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Button'))
+        tag_node_button_name = self._control_tag(
+            tag_node_name, self.TYPE_TEXT, 'Button'
+        )
+        tag_node_button_value_name = self._control_value_tag(
+            tag_node_name, self.TYPE_TEXT, 'Button'
+        )
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -114,7 +118,9 @@ class Node(DpgNodeBase):
     ):
         tag_node_name = self._node_name(node_id)
         input_value01_tag = self.ports(node_id).image.value_tag
-        tag_node_button_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Button'))
+        tag_node_button_value_name = self._control_value_tag(
+            tag_node_name, self.TYPE_TEXT, 'Button'
+        )
 
         # Get source node name for image (with ID)
         connection_info_src = ''
@@ -204,7 +210,9 @@ class Node(DpgNodeBase):
 
     def _recording_button(self, sender, data, user_data):
         tag_node_name = user_data
-        tag_node_button_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Button'))
+        tag_node_button_value_name = self._control_value_tag(
+            tag_node_name, self.TYPE_TEXT, 'Button'
+        )
 
         label = dpg.get_item_label(tag_node_button_value_name)
 

--- a/node/other_node/node_video_writer.py
+++ b/node/other_node/node_video_writer.py
@@ -11,6 +11,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -28,6 +29,10 @@ class Node(DpgNodeBase):
 
     _prev_frame_flag = False
 
+    port_specs = PortSpecs(
+        image=InputPort(PortDataType.IMAGE),
+    )
+
     def __init__(self):
         pass
 
@@ -41,7 +46,8 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
 
@@ -107,7 +113,7 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
-        input_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Input01'))
+        input_value01_tag = self.ports(node_id).image.value_tag
         tag_node_button_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Button'))
 
         # Get source node name for image (with ID)

--- a/node/port_model.py
+++ b/node/port_model.py
@@ -1,4 +1,37 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from enum import Enum
+from types import SimpleNamespace
+
+
+class PortDirection(str, Enum):
+    INPUT = 'Input'
+    OUTPUT = 'Output'
+
+
+class PortDataType(str, Enum):
+    INT = 'Int'
+    FLOAT = 'Float'
+    IMAGE = 'Image'
+    TIME_MS = 'TimeMS'
+    TEXT = 'Text'
+
+
+def enum_value(value):
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def normalize_port_direction(direction):
+    if isinstance(direction, PortDirection):
+        return direction
+    return PortDirection(direction)
+
+
+def normalize_port_data_type(data_type):
+    if isinstance(data_type, PortDataType):
+        return data_type
+    return PortDataType(data_type)
 
 
 @dataclass(frozen=True)
@@ -12,15 +45,72 @@ class NodeRef:
 
 
 @dataclass(frozen=True)
+class PortSpec:
+    direction: PortDirection
+    data_type: PortDataType
+    key: str = None
+    index: int = None
+    label: str = None
+    control_tag: str = None
+
+    def with_key(self, key):
+        if self.key == key:
+            return self
+        return replace(self, key=key)
+
+
+def InputPort(data_type, index=None, label=None, control_tag=None):
+    return PortSpec(
+        direction=PortDirection.INPUT,
+        data_type=normalize_port_data_type(data_type),
+        index=index,
+        label=label,
+        control_tag=control_tag,
+    )
+
+
+def OutputPort(data_type, index=None, label=None, control_tag=None):
+    return PortSpec(
+        direction=PortDirection.OUTPUT,
+        data_type=normalize_port_data_type(data_type),
+        index=index,
+        label=label,
+        control_tag=control_tag,
+    )
+
+
+class PortSpecs:
+    def __init__(self, **specs):
+        self._specs = tuple(
+            spec.with_key(key) for key, spec in specs.items()
+        )
+
+    def __iter__(self):
+        return iter(self._specs)
+
+    def __len__(self):
+        return len(self._specs)
+
+    def __bool__(self):
+        return bool(self._specs)
+
+
+class PortHandles(SimpleNamespace):
+    def as_dict(self):
+        return dict(self.__dict__)
+
+
+@dataclass(frozen=True)
 class PortRef:
     node_ref: NodeRef
-    direction: str
-    data_type: str
+    direction: PortDirection
+    data_type: PortDataType
     index: int
     port_name: str
     dpg_tag: str
     value_tag: str = None
     control_tag: str = None
+    spec_key: str = None
 
 
 @dataclass(frozen=True)

--- a/node/port_model.py
+++ b/node/port_model.py
@@ -52,6 +52,7 @@ class PortSpec:
     index: int = None
     label: str = None
     control_tag: str = None
+    default_control_tag: bool = False
 
     def with_key(self, key):
         if self.key == key:
@@ -59,13 +60,20 @@ class PortSpec:
         return replace(self, key=key)
 
 
-def InputPort(data_type, index=None, label=None, control_tag=None):
+def InputPort(
+    data_type,
+    index=None,
+    label=None,
+    control_tag=None,
+    default_control_tag=False,
+):
     return PortSpec(
         direction=PortDirection.INPUT,
         data_type=normalize_port_data_type(data_type),
         index=index,
         label=label,
         control_tag=control_tag,
+        default_control_tag=default_control_tag,
     )
 
 
@@ -76,6 +84,16 @@ def OutputPort(data_type, index=None, label=None, control_tag=None):
         index=index,
         label=label,
         control_tag=control_tag,
+    )
+
+
+def ParameterPort(data_type, index=None, label=None, control_tag=None):
+    return InputPort(
+        data_type,
+        index=index,
+        label=label,
+        control_tag=control_tag,
+        default_control_tag=True,
     )
 
 

--- a/node/port_serialization.py
+++ b/node/port_serialization.py
@@ -1,0 +1,68 @@
+from node.port_model import (
+    NodeRef,
+    PortDataType,
+    PortDirection,
+    PortRef,
+    enum_value,
+    normalize_port_data_type,
+    normalize_port_direction,
+)
+
+
+def legacy_port_name(direction, index):
+    direction = normalize_port_direction(direction)
+    return f'{direction.value}{int(index):02d}'
+
+
+def make_port_tag(node_id_name, data_type, port_name):
+    return f'{node_id_name}:{enum_value(data_type)}:{port_name}'
+
+
+def make_port_value_tag(port_tag):
+    return f'{port_tag}Value'
+
+
+def port_ref_to_tag(port_ref):
+    return make_port_tag(
+        port_ref.node_ref.node_id_name,
+        port_ref.data_type,
+        port_ref.port_name,
+    )
+
+
+def port_ref_from_tag(port_tag):
+    if not isinstance(port_tag, str):
+        return None
+    parts = port_tag.split(':')
+    if len(parts) < 4:
+        return None
+
+    node_ref = NodeRef(parts[0], parts[1])
+    try:
+        data_type = normalize_port_data_type(parts[2])
+    except ValueError:
+        return None
+    port_name = parts[3]
+    if port_name.startswith(PortDirection.INPUT.value):
+        direction = PortDirection.INPUT
+        index_text = port_name[len(PortDirection.INPUT.value):]
+    elif port_name.startswith(PortDirection.OUTPUT.value):
+        direction = PortDirection.OUTPUT
+        index_text = port_name[len(PortDirection.OUTPUT.value):]
+    else:
+        return None
+
+    try:
+        index = int(index_text)
+    except ValueError:
+        return None
+
+    return PortRef(
+        node_ref=node_ref,
+        direction=direction,
+        data_type=data_type,
+        index=index,
+        port_name=port_name,
+        dpg_tag=port_tag,
+        value_tag=make_port_value_tag(port_tag),
+    )

--- a/node/preview_release_node/node_code_exec.py
+++ b/node/preview_release_node/node_code_exec.py
@@ -10,6 +10,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -65,6 +66,12 @@ class Node(DpgNodeBase):
 
     _opencv_setting_dict = None
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
+
     def __init__(self):
         pass
 
@@ -78,17 +85,18 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
-        tag_node_input01_value_name = self._value_tag(tag_node_input01_name)
+        tag_node_input01_value_name = tag_node_input01_name_port.value_tag
         tag_node_input02_value_name = self._value_tag(
             self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
-        tag_node_output01_value_name = self._value_tag(tag_node_output01_name)
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output01_value_name = tag_node_output01_name_port.value_tag
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
-        tag_node_output02_value_name = self._value_tag(tag_node_output02_name)
+        tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
         # OpenCV settings
         self._opencv_setting_dict = opencv_setting_dict
@@ -168,12 +176,11 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
+        ports = self.ports(node_id)
         input_value02_tag = self._value_tag(
             self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        output_value01_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(
-            self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        output_value01_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
 
         small_window_w = int(self._opencv_setting_dict['process_width'] * 2.5)
         small_window_h = int(self._opencv_setting_dict['process_height'] * 2.5)

--- a/node/preview_release_node/node_mot.py
+++ b/node/preview_release_node/node_mot.py
@@ -9,6 +9,7 @@ import dearpygui.dearpygui as dpg
 from node_editor.util import dpg_get_value, dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import InputPort, OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 from node.preview_release_node.mot.motpy.motpy import Motpy
@@ -37,6 +38,12 @@ class Node(DpgNodeBase):
     _class_name_dict = None
     _track_id_dict = {}
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
+
     def __init__(self):
         pass
 
@@ -50,15 +57,16 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_input01_name_port = self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
+        ports = self.create_ports(node_id)
+        tag_node_input01_name_port = ports.image_input
         tag_node_input01_name = tag_node_input01_name_port.dpg_tag
         tag_node_input01_value_name = tag_node_input01_name_port.value_tag
         tag_node_input02_name = self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02')
         tag_node_input02_value_name = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -140,9 +148,10 @@ class Node(DpgNodeBase):
         node_result_dict,
     ):
         tag_node_name = self._node_name(node_id)
+        ports = self.ports(node_id)
         input_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TEXT, 'Input02'))
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        output_value01_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
 
         small_window_w = self._opencv_setting_dict['process_width']
         small_window_h = self._opencv_setting_dict['process_height']

--- a/node/preview_release_node/node_screen_capture.py
+++ b/node/preview_release_node/node_screen_capture.py
@@ -9,9 +9,10 @@ import numpy as np
 from PIL import ImageGrab
 import dearpygui.dearpygui as dpg
 
-from node_editor.util import dpg_get_value, dpg_set_value
+from node_editor.util import dpg_set_value
 
 from node.node_abc import DpgNodeBase
+from node.port_model import OutputPort, PortDataType, PortSpecs
 from node_editor.util import convert_cv_to_dpg
 
 
@@ -45,6 +46,11 @@ class Node(DpgNodeBase):
     _process = None
     _prev_frame = None
 
+    port_specs = PortSpecs(
+        image=OutputPort(PortDataType.IMAGE),
+        elapsed=OutputPort(PortDataType.TIME_MS),
+    )
+
     def __init__(self):
         pass
 
@@ -58,10 +64,11 @@ class Node(DpgNodeBase):
     ):
         # Tag names
         tag_node_name = self._node_name(node_id)
-        tag_node_output01_name_port = self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
+        ports = self.create_ports(node_id)
+        tag_node_output01_name_port = ports.image
         tag_node_output01_name = tag_node_output01_name_port.dpg_tag
         tag_node_output01_value_name = tag_node_output01_name_port.value_tag
-        tag_node_output02_name_port = self.output_port(node_id, self.TYPE_TIME_MS, 'Output02')
+        tag_node_output02_name_port = ports.elapsed
         tag_node_output02_name = tag_node_output02_name_port.dpg_tag
         tag_node_output02_value_name = tag_node_output02_name_port.value_tag
 
@@ -124,9 +131,9 @@ class Node(DpgNodeBase):
         node_image_dict,
         node_result_dict,
     ):
-        tag_node_name = self._node_name(node_id)
-        output_value01_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_IMAGE, 'Output01'))
-        output_value02_tag = self._value_tag(self._port_tag(tag_node_name, self.TYPE_TIME_MS, 'Output02'))
+        ports = self.ports(node_id)
+        output_value01_tag = ports.image.value_tag
+        output_value02_tag = ports.elapsed.value_tag
 
         small_window_w = self._opencv_setting_dict['input_window_width']
         small_window_h = self._opencv_setting_dict['input_window_height']

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -53,7 +53,7 @@ class DpgNodeEditor(object):
     _node_id = 0
     _node_instance_list = {}
     _node_list = []
-    _node_link_list = []
+    _legacy_node_link_list = []
     _link_refs = []
     _link_view_id_map = {}
 
@@ -85,7 +85,7 @@ class DpgNodeEditor(object):
         self._node_id = 0
         self._node_instance_list = {}
         self._node_list = []
-        self._node_link_list = []
+        self._legacy_node_link_list = []
         self._link_refs = []
         self._link_view_id_map = {}
         self._node_connection_dict = OrderedDict([])
@@ -111,6 +111,23 @@ class DpgNodeEditor(object):
         self._parameter_drag_stream_active = set()
         self._suspend_parameter_history = False
         self._history_node_id_remap = {}
+
+    @property
+    def _node_link_list(self):
+        """Legacy compact-pair view over canonical typed links."""
+        link_pairs = [link_ref.legacy_pair for link_ref in self._link_refs]
+        seen = {tuple(link_pair) for link_pair in link_pairs}
+        for link_pair in getattr(self, '_legacy_node_link_list', []):
+            key = tuple(link_pair)
+            if key in seen:
+                continue
+            link_pairs.append(list(link_pair))
+            seen.add(key)
+        return link_pairs
+
+    @_node_link_list.setter
+    def _node_link_list(self, link_list):
+        self._legacy_node_link_list = [list(link) for link in link_list]
 
     def _mdl_add_node(self, node_tag):
         self._node_id += 1
@@ -211,7 +228,6 @@ class DpgNodeEditor(object):
         if dest_tag in self._link_by_dest_port_ref:
             return False
         self._link_refs.append(link_ref)
-        self._node_link_list.append(link_ref.legacy_pair)
         self._link_registry[(source_tag, dest_tag)] = link_ref
         self._link_by_dest_port[dest_tag] = source_tag
         self._link_by_dest_port_ref[dest_tag] = link_ref
@@ -261,7 +277,7 @@ class DpgNodeEditor(object):
         # Compatibility boundary: some tests and old integrations still seed
         # ``_node_link_list`` directly. Normalize those compact pairs once, but
         # keep typed ``_link_refs`` as the normal graph model.
-        for source_tag, dest_tag in list(self._node_link_list):
+        for source_tag, dest_tag in list(self._legacy_node_link_list):
             key = (source_tag, dest_tag)
             if key in yielded:
                 continue
@@ -326,8 +342,8 @@ class DpgNodeEditor(object):
             ) != (source_tag, dest_tag)
         ]
         legacy_pair = [source_tag, dest_tag]
-        if legacy_pair in self._node_link_list:
-            self._node_link_list.remove(legacy_pair)
+        if legacy_pair in self._legacy_node_link_list:
+            self._legacy_node_link_list.remove(legacy_pair)
         self._mdl_sort_node_graph()
 
     def _mdl_sort_node_graph(self):

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -12,7 +12,15 @@ from importlib import import_module
 from pathlib import Path
 import dearpygui.dearpygui as dpg
 
-from node.port_model import LinkRef, NodeRef, PortRef
+from node.port_model import (
+    LinkRef,
+    NodeRef,
+    PortDataType,
+    PortDirection,
+    PortRef,
+    enum_value,
+)
+from node.port_serialization import port_ref_from_tag
 from node_editor.history import (
     AddNodeCommand,
     DeleteNodesCommand,
@@ -46,6 +54,7 @@ class DpgNodeEditor(object):
     _node_instance_list = {}
     _node_list = []
     _node_link_list = []
+    _link_refs = []
     _link_view_id_map = {}
 
     _last_pos = None
@@ -77,6 +86,7 @@ class DpgNodeEditor(object):
         self._node_instance_list = {}
         self._node_list = []
         self._node_link_list = []
+        self._link_refs = []
         self._link_view_id_map = {}
         self._node_connection_dict = OrderedDict([])
         self._node_connection_ref_dict = OrderedDict([])
@@ -134,15 +144,25 @@ class DpgNodeEditor(object):
         node_id_name=None,
         data_type=None,
     ):
+        if isinstance(direction, PortDirection):
+            direction = direction.value
+        if isinstance(data_type, PortDataType):
+            data_type = data_type.value
         for port_ref in list(self._port_registry.values()):
-            if direction is not None and port_ref.direction != direction:
+            if (
+                direction is not None
+                and enum_value(port_ref.direction) != direction
+            ):
                 continue
             if (
                 node_id_name is not None
                 and port_ref.node_ref.node_id_name != node_id_name
             ):
                 continue
-            if data_type is not None and port_ref.data_type != data_type:
+            if (
+                data_type is not None
+                and enum_value(port_ref.data_type) != data_type
+            ):
                 continue
             yield port_ref
 
@@ -151,32 +171,9 @@ class DpgNodeEditor(object):
             return None
         if port_tag in self._port_registry:
             return self._port_registry[port_tag]
-        parts = port_tag.split(':')
-        if len(parts) < 4:
+        parsed = port_ref_from_tag(port_tag)
+        if parsed is None:
             return None
-        node_ref = NodeRef(parts[0], parts[1])
-        port_name = parts[3]
-        if port_name.startswith('Input'):
-            direction = 'Input'
-            index_text = port_name[len('Input'):]
-        elif port_name.startswith('Output'):
-            direction = 'Output'
-            index_text = port_name[len('Output'):]
-        else:
-            return None
-        try:
-            index = int(index_text)
-        except ValueError:
-            return None
-        parsed = PortRef(
-            node_ref=node_ref,
-            direction=direction,
-            data_type=parts[2],
-            index=index,
-            port_name=port_name,
-            dpg_tag=port_tag,
-            value_tag=f'{port_tag}Value',
-        )
         self._mdl_register_port_ref(parsed)
         return parsed
 
@@ -190,11 +187,20 @@ class DpgNodeEditor(object):
         dest_port = self._mdl_resolve_port_ref(destination)
         if source_port is None or dest_port is None:
             return None
-        if source_port.direction != 'Output' or dest_port.direction != 'Input':
+        if (
+            source_port.direction != PortDirection.OUTPUT
+            or dest_port.direction != PortDirection.INPUT
+        ):
             return None
         if source_port.data_type != dest_port.data_type:
             return None
         return LinkRef(source_port, dest_port)
+
+    def _mdl_link_key(self, link):
+        if hasattr(link, 'legacy_pair'):
+            return tuple(link.legacy_pair)
+        source_tag, dest_tag = link
+        return source_tag, dest_tag
 
     def _mdl_add_link(self, source, destination):
         link_ref = self._mdl_validate_link(source, destination)
@@ -204,6 +210,7 @@ class DpgNodeEditor(object):
         dest_tag = link_ref.destination_tag
         if dest_tag in self._link_by_dest_port_ref:
             return False
+        self._link_refs.append(link_ref)
         self._node_link_list.append(link_ref.legacy_pair)
         self._link_registry[(source_tag, dest_tag)] = link_ref
         self._link_by_dest_port[dest_tag] = source_tag
@@ -231,8 +238,8 @@ class DpgNodeEditor(object):
                 'id': port_ref.node_ref.node_id,
                 'tag': port_ref.node_ref.node_tag,
             },
-            'direction': port_ref.direction,
-            'data_type': port_ref.data_type,
+            'direction': enum_value(port_ref.direction),
+            'data_type': enum_value(port_ref.data_type),
             'index': port_ref.index,
             'port_name': port_ref.port_name,
             'dpg_tag': port_ref.dpg_tag,
@@ -245,11 +252,28 @@ class DpgNodeEditor(object):
         }
 
     def _mdl_iter_link_refs(self):
+        yielded = set()
+        for link_ref in list(self._link_refs):
+            key = (link_ref.source_tag, link_ref.destination_tag)
+            yielded.add(key)
+            yield link_ref
+
+        # Compatibility boundary: some tests and old integrations still seed
+        # ``_node_link_list`` directly. Normalize those compact pairs once, but
+        # keep typed ``_link_refs`` as the normal graph model.
         for source_tag, dest_tag in list(self._node_link_list):
-            link_ref = self._link_registry.get((source_tag, dest_tag))
+            key = (source_tag, dest_tag)
+            if key in yielded:
+                continue
+            link_ref = self._link_registry.get(key)
             if link_ref is None:
                 link_ref = self._mdl_validate_link(source_tag, dest_tag)
             if link_ref is not None:
+                self._link_refs.append(link_ref)
+                self._link_registry[key] = link_ref
+                self._link_by_dest_port[dest_tag] = source_tag
+                self._link_by_dest_port_ref[dest_tag] = link_ref
+                yielded.add(key)
                 yield link_ref
 
     def _mdl_get_link_refs_for_export(self):
@@ -281,34 +305,29 @@ class DpgNodeEditor(object):
         node_instance.close(node_id)
         self._node_list.remove(node_id_name)
 
-        copy_node_link_list = copy.deepcopy(self._node_link_list)
-        for link_info in copy_node_link_list:
-            source_port = self._port_registry.get(link_info[0])
-            dest_port = self._port_registry.get(link_info[1])
-            source_node = source_port.node_ref.node_id_name if source_port else ''
-            destination_node = dest_port.node_ref.node_id_name if dest_port else ''
-            if not source_node and isinstance(link_info[0], str):
-                source_parts = link_info[0].split(':')
-                if len(source_parts) >= 2:
-                    source_node = f'{source_parts[0]}:{source_parts[1]}'
-            if not destination_node and isinstance(link_info[1], str):
-                dest_parts = link_info[1].split(':')
-                if len(dest_parts) >= 2:
-                    destination_node = f'{dest_parts[0]}:{dest_parts[1]}'
+        for link_ref in list(self._mdl_iter_link_refs()):
+            source_node = link_ref.source.node_ref.node_id_name
+            destination_node = link_ref.destination.node_ref.node_id_name
             if source_node == node_id_name or destination_node == node_id_name:
-                self._link_registry.pop((link_info[0], link_info[1]), None)
-                self._link_by_dest_port.pop(link_info[1], None)
-                self._link_by_dest_port_ref.pop(link_info[1], None)
-                self._node_link_list.remove(link_info)
+                self._mdl_delete_link(link_ref)
         self._node_registry.pop(node_id_name, None)
         self._mdl_sort_node_graph()
 
     def _mdl_delete_link(self, link):
-        source_tag, dest_tag = link
+        source_tag, dest_tag = self._mdl_link_key(link)
         self._link_registry.pop((source_tag, dest_tag), None)
         self._link_by_dest_port.pop(dest_tag, None)
         self._link_by_dest_port_ref.pop(dest_tag, None)
-        self._node_link_list.remove(link)
+        self._link_refs = [
+            link_ref for link_ref in self._link_refs
+            if (
+                link_ref.source_tag,
+                link_ref.destination_tag,
+            ) != (source_tag, dest_tag)
+        ]
+        legacy_pair = [source_tag, dest_tag]
+        if legacy_pair in self._node_link_list:
+            self._node_link_list.remove(legacy_pair)
         self._mdl_sort_node_graph()
 
     def _mdl_sort_node_graph(self):
@@ -615,10 +634,12 @@ class DpgNodeEditor(object):
         return capabilities
 
     def _cntrl_is_node_append_compatible(self, node_tag, source_type):
+        source_type = enum_value(source_type)
         caps = self._node_port_capabilities.get(node_tag, {})
         return source_type in caps.get('input_types', set())
 
     def _cntrl_is_node_insert_compatible(self, node_tag, link_type):
+        link_type = enum_value(link_type)
         caps = self._node_port_capabilities.get(node_tag, {})
         input_types = caps.get('input_types', set())
         output_types = caps.get('output_types', set())
@@ -1244,11 +1265,11 @@ class DpgNodeEditor(object):
         )
         if source_output_tag is None:
             return None
-        for source_tag, dest_tag in self._node_link_list:
-            if source_tag != source_output_tag:
+        for link_ref in self._mdl_iter_link_refs():
+            if link_ref.source_tag != source_output_tag:
                 continue
-            dest_port = self._port_registry.get(dest_tag)
-            if dest_port and dest_port.node_ref.node_tag == result_node_tag:
+            dest_port = link_ref.destination
+            if dest_port.node_ref.node_tag == result_node_tag:
                 return dest_port.node_ref.node_id_name
         return None
 
@@ -1356,10 +1377,10 @@ class DpgNodeEditor(object):
         return None
 
     def _cntrl_get_hovered_output_port_tag(self):
-        return self._cntrl_get_hovered_registered_port_tag('Output')
+        return self._cntrl_get_hovered_registered_port_tag(PortDirection.OUTPUT)
 
     def _cntrl_get_hovered_input_port_tag(self):
-        return self._cntrl_get_hovered_registered_port_tag('Input')
+        return self._cntrl_get_hovered_registered_port_tag(PortDirection.INPUT)
 
     def _cntrl_get_insert_node_pos(self, source_tag, dest_tag):
         source_node = ':'.join(source_tag.split(':')[:2])
@@ -1382,9 +1403,9 @@ class DpgNodeEditor(object):
 
     def _cntrl_find_node_port(self, node_id_name, port_type, port_prefix):
         expected_attr_type = None
-        if port_prefix == 'Input':
+        if port_prefix == PortDirection.INPUT.value:
             expected_attr_type = dpg.mvNode_Attr_Input
-        elif port_prefix == 'Output':
+        elif port_prefix == PortDirection.OUTPUT.value:
             expected_attr_type = dpg.mvNode_Attr_Output
 
         for port_ref in self._mdl_iter_registered_ports(
@@ -1430,7 +1451,8 @@ class DpgNodeEditor(object):
             self._mdl_delete_node(new_node_id_name)
             self._vw_delete_item(new_node_id_name)
             self._vw_set_link_feedback(
-                f'Cannot connect {user_data}: it needs a {link_type} input port.'
+                'Cannot connect '
+                f'{user_data}: it needs a {enum_value(link_type)} input port.'
             )
             return
 
@@ -1484,7 +1506,8 @@ class DpgNodeEditor(object):
             self._mdl_delete_node(new_node_id_name)
             self._vw_delete_item(new_node_id_name)
             self._vw_set_link_feedback(
-                f'Cannot connect {user_data}: it needs a {link_type} output port.'
+                'Cannot connect '
+                f'{user_data}: it needs a {enum_value(link_type)} output port.'
             )
             return
 
@@ -1597,7 +1620,8 @@ class DpgNodeEditor(object):
             self._mdl_delete_node(new_node_id_name)
             self._vw_delete_item(new_node_id_name)
             self._vw_set_link_feedback(
-                f'Cannot insert {user_data}: it needs both {link_type} '
+                'Cannot insert '
+                f'{user_data}: it needs both {enum_value(link_type)} '
                 'input and output ports.'
             )
             return
@@ -1676,8 +1700,9 @@ class DpgNodeEditor(object):
 
         if source_type != dest_type:
             self._vw_set_link_feedback(
-                f'Link rejected: {source_type} output cannot connect to '
-                f'{dest_type} input.'
+                'Link rejected: '
+                f'{enum_value(source_type)} output cannot connect to '
+                f'{enum_value(dest_type)} input.'
             )
             return
 
@@ -1959,11 +1984,12 @@ class DpgNodeEditor(object):
     def _cntrl_remove_link_by_tags(self, source_tag, dest_tag, record_history=False):
         source_tag = self._cntrl_resolve_history_port_tag(source_tag)
         dest_tag = self._cntrl_resolve_history_port_tag(dest_tag)
+        link_ref = self._link_registry.get((source_tag, dest_tag))
         link = [source_tag, dest_tag]
-        if link not in self._node_link_list:
+        if link_ref is None and link not in self._node_link_list:
             return False
         history_link = self._cntrl_history_link_payload(source_tag, dest_tag)
-        self._mdl_delete_link(link)
+        self._mdl_delete_link(link_ref if link_ref is not None else link)
         self._vw_delete_link(source_tag, dest_tag)
         if record_history:
             self._cntrl_push_undo_command(RemoveLinkCommand(history_link))
@@ -2222,11 +2248,11 @@ class DpgNodeEditor(object):
                     'setting': copy.deepcopy(node.get_setting_dict(node_id)),
                 }
             )
-            for source_tag, dest_tag in list(self._node_link_list):
-                if source_tag.startswith(f'{node_id}:{node_name}:') or dest_tag.startswith(f'{node_id}:{node_name}:'):
-                    removed_links.append(
-                        self._cntrl_history_link_payload(source_tag, dest_tag)
-                    )
+            for link_ref in list(self._mdl_iter_link_refs()):
+                source_node = link_ref.source.node_ref.node_id_name
+                dest_node = link_ref.destination.node_ref.node_id_name
+                if source_node == node_tag or dest_node == node_tag:
+                    removed_links.append(link_ref)
         for node_tag in selected_node_tags:
             self._cntrl_delete_node_by_tag(node_tag)
 

--- a/tests/unit/test_node_base_refactor.py
+++ b/tests/unit/test_node_base_refactor.py
@@ -49,6 +49,23 @@ def test_concrete_base_node_tag_helpers_compose_port_and_value_tags():
     )
 
 
+
+def test_concrete_base_control_tag_helpers_mark_non_graph_alias_boundary():
+    node = IntValueNode()
+
+    assert node._control_tag('3:IntValue', node.TYPE_TEXT, 'Toggle') == (
+        '3:IntValue:Text:Toggle'
+    )
+    assert node._control_value_tag('3:IntValue', node.TYPE_TEXT, 'Toggle') == (
+        '3:IntValue:Text:ToggleValue'
+    )
+    assert node._node_control_tag(3, node.TYPE_TEXT, 'Toggle') == (
+        '3:IntValue:Text:Toggle'
+    )
+    assert node._node_control_value_tag(3, node.TYPE_TEXT, 'Toggle') == (
+        '3:IntValue:Text:ToggleValue'
+    )
+
 def test_concrete_base_preserves_connection_iteration_guards():
     node = IntValueNode()
 

--- a/tests/unit/test_node_base_refactor.py
+++ b/tests/unit/test_node_base_refactor.py
@@ -179,6 +179,13 @@ def test_direct_node_add_node_graph_attributes_use_port_declarations():
                 add_node_source,
             )
         }
+        declared_tag_variables.update(
+            declaration.group(1)
+            for declaration in re.finditer(
+                r'(\w+)_port = ports\.\w+',
+                add_node_source,
+            )
+        )
         lines = add_node_source.splitlines()
         index = 0
         while index < len(lines):

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -8,7 +8,15 @@ import pytest
 
 # Local application imports
 from node.node_abc import DpgNodeBase
-from node.port_model import LinkRef, NodeRef, PortRef
+from node.port_model import (
+    InputPort,
+    LinkRef,
+    NodeRef,
+    OutputPort,
+    PortDataType,
+    PortRef,
+    PortSpecs,
+)
 from node_editor.node_editor import (
     AddLinkCommand,
     AddNodeCommand,
@@ -75,6 +83,13 @@ class PortDeclaringDummyNode(DpgNodeBase):
     node_tag = 'TestNode'
     node_label = 'Test Node'
 
+    port_specs = PortSpecs(
+        image_input=InputPort(PortDataType.IMAGE),
+        image=OutputPort(PortDataType.IMAGE),
+        int_input=InputPort(PortDataType.INT, index=1),
+        int_output=OutputPort(PortDataType.INT, index=1),
+    )
+
     def add_node(
         self,
         parent,
@@ -84,10 +99,7 @@ class PortDeclaringDummyNode(DpgNodeBase):
         callback=None,
     ):
         del parent, pos, opencv_setting_dict, callback
-        self.input_port(node_id, self.TYPE_IMAGE, 'Input01')
-        self.output_port(node_id, self.TYPE_IMAGE, 'Output01')
-        self.input_port(node_id, self.TYPE_INT, 'Input01')
-        self.output_port(node_id, self.TYPE_INT, 'Output01')
+        self.create_ports(node_id)
         return f"{node_id}:{self.node_tag}"
 
     def update(self, node_id, connection_list, img_dict, res_dict):
@@ -342,7 +354,11 @@ def test_add_node_keeps_dynamic_port_registration_callback(editor_and_dpg):
     editor._node_instance_list['TestNode'] = node
 
     editor._cntrl_add_node(None, None, 'TestNode')
-    node.input_port(1, node.TYPE_TEXT, 'Input02')
+    node.create_port(
+        1,
+        'dynamic_text',
+        InputPort(PortDataType.TEXT, index=2),
+    )
 
     assert '1:TestNode:Text:Input02' in editor._port_registry
 

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -219,6 +219,73 @@ def test_mdl_add_link_accepts_port_refs(editor_and_dpg):
         '1:TestNode:Image:Output01',
         '2:TestNode:Image:Input01',
     ]]
+    assert editor._link_refs == [link_ref]
+    assert list(editor._mdl_iter_link_refs()) == [link_ref]
+
+
+def test_legacy_link_pairs_normalize_to_typed_link_refs(editor_and_dpg):
+    editor, _ = editor_and_dpg
+    editor._node_link_list = [[
+        '1:TestNode:Image:Output01',
+        '2:TestNode:Image:Input01',
+    ]]
+
+    link_refs = list(editor._mdl_iter_link_refs())
+
+    assert len(link_refs) == 1
+    assert link_refs[0].source == PortRef(
+        node_ref=NodeRef('1', 'TestNode'),
+        direction='Output',
+        data_type='Image',
+        index=1,
+        port_name='Output01',
+        dpg_tag='1:TestNode:Image:Output01',
+        value_tag='1:TestNode:Image:Output01Value',
+    )
+    assert link_refs[0].destination == PortRef(
+        node_ref=NodeRef('2', 'TestNode'),
+        direction='Input',
+        data_type='Image',
+        index=1,
+        port_name='Input01',
+        dpg_tag='2:TestNode:Image:Input01',
+        value_tag='2:TestNode:Image:Input01Value',
+    )
+    assert editor._link_refs == link_refs
+    assert editor._link_registry[(
+        '1:TestNode:Image:Output01',
+        '2:TestNode:Image:Input01',
+    )] == link_refs[0]
+
+
+def test_delete_link_accepts_typed_link_refs(editor_and_dpg):
+    editor, _ = editor_and_dpg
+    source_port = PortRef(
+        node_ref=NodeRef('1', 'TestNode'),
+        direction='Output',
+        data_type='Image',
+        index=1,
+        port_name='Output01',
+        dpg_tag='1:TestNode:Image:Output01',
+    )
+    dest_port = PortRef(
+        node_ref=NodeRef('2', 'TestNode'),
+        direction='Input',
+        data_type='Image',
+        index=1,
+        port_name='Input01',
+        dpg_tag='2:TestNode:Image:Input01',
+    )
+    editor._mdl_add_link(source_port, dest_port)
+    link_ref = editor._link_refs[0]
+
+    editor._mdl_delete_link(link_ref)
+
+    assert editor._link_refs == []
+    assert editor._node_link_list == []
+    assert editor._link_registry == {}
+    assert editor._link_by_dest_port == {}
+    assert editor._link_by_dest_port_ref == {}
 
 
 def test_history_import_command_accepts_typed_link_refs(editor_and_dpg):

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -115,6 +115,10 @@ class PortDeclaringDummyNode(DpgNodeBase):
         pass
 
 
+def _typed_link_pairs(editor):
+    return [link_ref.legacy_pair for link_ref in editor._link_refs]
+
+
 @pytest.fixture
 def editor_and_dpg():
     with patch('node_editor.node_editor.dpg') as dpg, \
@@ -181,7 +185,7 @@ def test_link_callback_basic(editor_and_dpg):
     editor._cntrl_add_node(None, None, 'TestNode')
     link_ids = [101, 102]
     editor._cntrl_link('NodeEditor', link_ids)
-    assert editor._node_link_list == [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
+    assert _typed_link_pairs(editor) == [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
     link_ref = editor._link_registry[(
         '1:TestNode:Int:Output01',
         '2:TestNode:Int:Input01',
@@ -227,7 +231,7 @@ def test_mdl_add_link_accepts_port_refs(editor_and_dpg):
 
     link_ref = editor._mdl_get_link_ref_by_destination(dest_port)
     assert link_ref == LinkRef(source_port, dest_port)
-    assert editor._node_link_list == [[
+    assert _typed_link_pairs(editor) == [[
         '1:TestNode:Image:Output01',
         '2:TestNode:Image:Input01',
     ]]
@@ -295,7 +299,7 @@ def test_delete_link_accepts_typed_link_refs(editor_and_dpg):
     editor._mdl_delete_link(link_ref)
 
     assert editor._link_refs == []
-    assert editor._node_link_list == []
+    assert _typed_link_pairs(editor) == []
     assert editor._link_registry == {}
     assert editor._link_by_dest_port == {}
     assert editor._link_by_dest_port_ref == {}
@@ -324,7 +328,7 @@ def test_history_import_command_accepts_typed_link_refs(editor_and_dpg):
 
     ImportGraphCommand(nodes=[], links=[link_ref]).redo(editor)
 
-    assert editor._node_link_list == [link_ref.legacy_pair]
+    assert _typed_link_pairs(editor) == [link_ref.legacy_pair]
     registered_link = editor._mdl_get_link_ref_by_destination(dest_port)
     assert registered_link.source_tag == link_ref.source_tag
     assert registered_link.destination_tag == link_ref.destination_tag
@@ -458,7 +462,7 @@ def test_link_prevents_duplicate_dest(editor_and_dpg):
     link_ids = [101, 102]
     editor._cntrl_link('NodeEditor', link_ids)
     editor._cntrl_link('NodeEditor', link_ids)
-    assert len(editor._node_link_list) == 1
+    assert len(editor._link_refs) == 1
 
 
 def test_link_replaces_existing_dest(editor_and_dpg):
@@ -478,7 +482,7 @@ def test_link_replaces_existing_dest(editor_and_dpg):
     editor._cntrl_link('NodeEditor', [101, 102])
     editor._cntrl_link('NodeEditor', [103, 102])
 
-    assert editor._node_link_list == [['3:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
+    assert _typed_link_pairs(editor) == [['3:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
     assert editor._link_view_id_map == {
         ('3:TestNode:Int:Output01', '2:TestNode:Int:Input01'): 'link-2'
     }
@@ -510,7 +514,7 @@ def test_link_mismatched_type_ignored(editor_and_dpg):
     editor._cntrl_add_node(None, None, 'TestNode')
     editor._cntrl_add_node(None, None, 'TestNode')
     editor._cntrl_link('NodeEditor', [101, 102])
-    assert editor._node_link_list == []
+    assert _typed_link_pairs(editor) == []
     dpg.set_value.assert_called_with(
         'NodeEditorLinkFeedback',
         'Link rejected: Int output cannot connect to Float input.',
@@ -534,7 +538,7 @@ def test_link_duplicate_same_source_sets_feedback(editor_and_dpg):
     editor._cntrl_link('NodeEditor', [101, 102])
     editor._cntrl_link('NodeEditor', [101, 102])
 
-    assert editor._node_link_list == [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
+    assert _typed_link_pairs(editor) == [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
     dpg.set_value.assert_called_with(
         'NodeEditorLinkFeedback',
         'Link rejected: input is already connected to that source.',
@@ -550,7 +554,7 @@ def test_link_invalid_payload_sets_feedback(editor_and_dpg):
 
     editor._cntrl_link('NodeEditor', [101])
 
-    assert editor._node_link_list == []
+    assert _typed_link_pairs(editor) == []
     dpg.set_value.assert_called_with(
         'NodeEditorLinkFeedback',
         'Link rejected: invalid link data from DearPyGui.',
@@ -577,11 +581,11 @@ def test_link_cycle_is_rejected(editor_and_dpg):
     editor._cntrl_add_node(None, None, 'TestNode')
 
     editor._cntrl_link('NodeEditor', [101, 102])
-    assert editor._node_link_list == [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
+    assert _typed_link_pairs(editor) == [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
 
     editor._cntrl_link('NodeEditor', [103, 104])
 
-    assert editor._node_link_list == [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
+    assert _typed_link_pairs(editor) == [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
     dpg.set_value.assert_any_call(
         'NodeEditorLinkFeedback',
         'Link rejected: this connection would create a cycle.',
@@ -630,7 +634,7 @@ def test_insert_node_into_selected_link(editor_and_dpg):
     editor._cntrl_insert_node_into_selected_link(None, None, 'TestNode')
 
     assert editor._node_list == ['1:TestNode', '2:TestNode', '3:TestNode']
-    assert editor._node_link_list == [
+    assert _typed_link_pairs(editor) == [
         ['1:TestNode:Int:Output01', '3:TestNode:Int:Input01'],
         ['3:TestNode:Int:Output01', '2:TestNode:Int:Input01'],
     ]
@@ -674,12 +678,21 @@ def test_add_node_to_occupied_input_is_single_composite_undo(editor_and_dpg):
     editor._pending_add_to_input_tag = '2:TestNode:Int:Input01'
     editor._cntrl_add_node_to_input_port(None, None, 'TestNode')
 
-    assert ['4:TestNode:Int:Output01', '2:TestNode:Int:Input01'] in editor._node_link_list
-    assert ['1:TestNode:Int:Output01', '2:TestNode:Int:Input01'] not in editor._node_link_list
+    assert (
+        ['4:TestNode:Int:Output01', '2:TestNode:Int:Input01']
+        in _typed_link_pairs(editor)
+    )
+    assert (
+        ['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']
+        not in _typed_link_pairs(editor)
+    )
 
     editor._cntrl_undo(None, None)
 
-    assert ['1:TestNode:Int:Output01', '2:TestNode:Int:Input01'] in editor._node_link_list
+    assert (
+        ['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']
+        in _typed_link_pairs(editor)
+    )
     assert '4:TestNode' not in editor._node_list
 
 
@@ -733,12 +746,21 @@ def test_insert_then_move_undo_redo_sequence(editor_and_dpg):
 
     editor._cntrl_undo(None, None)  # undo insert
     assert '3:TestNode' not in editor._node_list
-    assert ['1:TestNode:Int:Output01', '2:TestNode:Int:Input01'] in editor._node_link_list
+    assert (
+        ['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']
+        in _typed_link_pairs(editor)
+    )
 
     editor._cntrl_redo(None, None)  # redo insert
     assert '3:TestNode' in editor._node_list
-    assert ['1:TestNode:Int:Output01', '3:TestNode:Int:Input01'] in editor._node_link_list
-    assert ['3:TestNode:Int:Output01', '2:TestNode:Int:Input01'] in editor._node_link_list
+    assert (
+        ['1:TestNode:Int:Output01', '3:TestNode:Int:Input01']
+        in _typed_link_pairs(editor)
+    )
+    assert (
+        ['3:TestNode:Int:Output01', '2:TestNode:Int:Input01']
+        in _typed_link_pairs(editor)
+    )
 
     editor._cntrl_redo(None, None)  # redo move
     assert pos_map['3:TestNode'] == [200, 150]
@@ -1268,7 +1290,7 @@ def test_add_node_from_hovered_output_creates_connected_node(editor_and_dpg):
 
     assert editor._pending_add_from_output_tag is None
     assert editor._node_list == ['1:TestNode', '2:TestNode']
-    assert editor._node_link_list == [[source_tag, input_tag]]
+    assert _typed_link_pairs(editor) == [[source_tag, input_tag]]
     assert editor._link_view_id_map[(source_tag, input_tag)] == 'link-new'
     dpg.add_node_link.assert_called_once_with(
         source_tag,
@@ -1301,7 +1323,7 @@ def test_add_node_to_hovered_input_creates_connected_node(editor_and_dpg):
 
     assert editor._pending_add_to_input_tag is None
     assert editor._node_list == ['1:TestNode', '2:TestNode']
-    assert editor._node_link_list == [[output_tag, dest_tag]]
+    assert _typed_link_pairs(editor) == [[output_tag, dest_tag]]
     assert editor._link_view_id_map[(output_tag, dest_tag)] == 'link-new'
     dpg.add_node_link.assert_called_once_with(
         output_tag,
@@ -1398,7 +1420,7 @@ def test_insert_node_into_selected_link_rejects_incompatible_node(editor_and_dpg
     editor._cntrl_insert_node_into_selected_link(None, None, 'TestNode')
 
     assert editor._node_list == ['1:TestNode', '2:TestNode']
-    assert editor._node_link_list == [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
+    assert _typed_link_pairs(editor) == [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
     dpg.delete_item.assert_called_once_with('3:TestNode')
     dpg.set_value.assert_called_with(
         'NodeEditorLinkFeedback',
@@ -1461,7 +1483,7 @@ def test_delete_node(editor_and_dpg):
     dpg.get_selected_nodes.return_value = ['1:TestNode']
     editor._cntrl_delete_selected(None, None)
     assert '1:TestNode' not in editor._node_list
-    assert editor._node_link_list == []
+    assert _typed_link_pairs(editor) == []
 
 
 def test_mv_key_del_no_selection(editor_and_dpg):
@@ -1503,7 +1525,10 @@ def test_delete_multiple_nodes_heals_external_path(editor_and_dpg):
 
     assert '2:TestNode' not in editor._node_list
     assert '3:TestNode' not in editor._node_list
-    assert ['1:TestNode:Int:Output01', '4:TestNode:Int:Input01'] in editor._node_link_list
+    assert (
+        ['1:TestNode:Int:Output01', '4:TestNode:Int:Input01']
+        in _typed_link_pairs(editor)
+    )
 
 
 def test_delete_multiple_nodes_heals_two_independent_paths(editor_and_dpg):
@@ -1526,8 +1551,14 @@ def test_delete_multiple_nodes_heals_two_independent_paths(editor_and_dpg):
     dpg.get_selected_links.return_value = []
     editor._cntrl_delete_selected(None, None)
 
-    assert ['1:TestNode:Int:Output01', '4:TestNode:Int:Input01'] in editor._node_link_list
-    assert ['5:TestNode:Int:Output01', '8:TestNode:Int:Input01'] in editor._node_link_list
+    assert (
+        ['1:TestNode:Int:Output01', '4:TestNode:Int:Input01']
+        in _typed_link_pairs(editor)
+    )
+    assert (
+        ['5:TestNode:Int:Output01', '8:TestNode:Int:Input01']
+        in _typed_link_pairs(editor)
+    )
 
 
 def test_delete_selected_ignores_stale_selected_link_ids(editor_and_dpg):
@@ -1538,4 +1569,4 @@ def test_delete_selected_ignores_stale_selected_link_ids(editor_and_dpg):
 
     editor._cntrl_delete_selected(None, None)
 
-    assert editor._node_link_list == []
+    assert _typed_link_pairs(editor) == []

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -231,6 +231,7 @@ def test_mdl_add_link_accepts_port_refs(editor_and_dpg):
         '1:TestNode:Image:Output01',
         '2:TestNode:Image:Input01',
     ]]
+    assert editor._legacy_node_link_list == []
     assert editor._link_refs == [link_ref]
     assert list(editor._mdl_iter_link_refs()) == [link_ref]
 

--- a/tests/unit/test_node_editor_import_export.py
+++ b/tests/unit/test_node_editor_import_export.py
@@ -51,6 +51,10 @@ def _link_ref_pairs(link_refs):
     ]
 
 
+def _typed_link_pairs_from_editor(editor):
+    return [link_ref.legacy_pair for link_ref in editor._link_refs]
+
+
 def _history_link_pairs(links):
     pairs = []
     for link in links:
@@ -246,7 +250,7 @@ class TestDpgNodeEditorImportExport:
         node_editor._cntrl_file_import(sender, data)
 
         assert node_editor._node_list == ['1:test_node', '2:test_node']
-        assert node_editor._node_link_list == [[
+        assert _typed_link_pairs_from_editor(node_editor) == [[
             '1:test_node:Image:Output01',
             '2:test_node:Image:Input01'
         ]]
@@ -309,7 +313,7 @@ class TestDpgNodeEditorImportExport:
             {'file_name': temp_path.name, 'file_path_name': str(temp_path)},
         )
 
-        assert node_editor._node_link_list == [[
+        assert _typed_link_pairs_from_editor(node_editor) == [[
             '1:test_node:Image:Output01',
             '2:test_node:Image:Input01',
         ]]
@@ -360,7 +364,7 @@ class TestDpgNodeEditorImportExport:
         )
 
         assert node_editor._node_list == ['1:test_node', '2:test_node']
-        assert node_editor._node_link_list == [[
+        assert _typed_link_pairs_from_editor(node_editor) == [[
             '1:test_node:Image:Output01',
             '2:test_node:Image:Input01',
         ]]
@@ -370,13 +374,13 @@ class TestDpgNodeEditorImportExport:
         node_editor._cntrl_undo(None, None)
 
         assert node_editor._node_list == []
-        assert node_editor._node_link_list == []
+        assert _typed_link_pairs_from_editor(node_editor) == []
         assert len(node_editor._redo_stack) == 1
 
         node_editor._cntrl_redo(None, None)
 
         assert node_editor._node_list == ['1:test_node', '2:test_node']
-        assert node_editor._node_link_list == [[
+        assert _typed_link_pairs_from_editor(node_editor) == [[
             '1:test_node:Image:Output01',
             '2:test_node:Image:Input01',
         ]]
@@ -425,7 +429,7 @@ class TestDpgNodeEditorImportExport:
             {'file_name': temp_path.name, 'file_path_name': str(temp_path)},
         )
 
-        assert node_editor._node_link_list == []
+        assert _typed_link_pairs_from_editor(node_editor) == []
         assert node_editor._link_registry == {}
         assert node_editor._link_by_dest_port == {}
         assert node_editor._undo_stack[-1].links == []
@@ -491,7 +495,7 @@ class TestDpgNodeEditorImportExport:
             {'file_name': temp_path.name, 'file_path_name': str(temp_path)},
         )
 
-        assert node_editor._node_link_list == [[
+        assert _typed_link_pairs_from_editor(node_editor) == [[
             '1:test_node:Image:Output01',
             '3:test_node:Image:Input01',
         ]]
@@ -501,10 +505,10 @@ class TestDpgNodeEditorImportExport:
         )]
 
         node_editor._cntrl_undo(None, None)
-        assert node_editor._node_link_list == []
+        assert _typed_link_pairs_from_editor(node_editor) == []
 
         node_editor._cntrl_redo(None, None)
-        assert node_editor._node_link_list == [[
+        assert _typed_link_pairs_from_editor(node_editor) == [[
             '1:test_node:Image:Output01',
             '3:test_node:Image:Input01',
         ]]
@@ -548,7 +552,7 @@ class TestDpgNodeEditorImportExport:
             {'file_name': temp_path.name, 'file_path_name': str(temp_path)},
         )
 
-        assert node_editor._node_link_list == []
+        assert _typed_link_pairs_from_editor(node_editor) == []
         assert node_editor._link_registry == {}
         assert node_editor._link_by_dest_port == {}
         assert node_editor._link_view_id_map == {}
@@ -593,7 +597,7 @@ class TestDpgNodeEditorImportExport:
             {'file_name': temp_path.name, 'file_path_name': str(temp_path)},
         )
 
-        assert node_editor._node_link_list == []
+        assert _typed_link_pairs_from_editor(node_editor) == []
         assert node_editor._link_registry == {}
         assert node_editor._link_by_dest_port == {}
         assert node_editor._undo_stack[-1].links == []
@@ -637,7 +641,7 @@ class TestDpgNodeEditorImportExport:
             {'file_name': temp_path.name, 'file_path_name': str(temp_path)},
         )
 
-        assert node_editor._node_link_list == [[
+        assert _typed_link_pairs_from_editor(node_editor) == [[
             '2:test_node:Image:Output01',
             '3:test_node:Image:Input01',
         ]]
@@ -920,7 +924,7 @@ class TestDpgNodeEditorImportExport:
 
         # Assert import reconstructed the same graph
         assert set(imported_editor._node_list) == set(original_nodes)
-        assert (set(tuple(l) for l in imported_editor._node_link_list)
+        assert (set(tuple(l) for l in _typed_link_pairs_from_editor(imported_editor))
                 == set(tuple(l) for l in original_links))
 
     def test_import_after_existing_nodes_non_conflicting(
@@ -986,7 +990,7 @@ class TestDpgNodeEditorImportExport:
 
         # grab all links that connect two imported IDs
         imported_links = [
-            link for link in node_editor._node_link_list
+            link for link in _typed_link_pairs_from_editor(node_editor)
             if int(link[0].split(':')[0]) in new_ids
             and int(link[1].split(':')[0]) in new_ids
         ]
@@ -1032,5 +1036,5 @@ class TestDpgNodeEditorImportExport:
         node_editor._cntrl_delete_selected(None, None)
 
         assert '1:test_node' not in node_editor._node_list
-        assert node_editor._node_link_list == []
+        assert _typed_link_pairs_from_editor(node_editor) == []
         assert node_editor._link_registry == {}

--- a/tests/unit/test_node_port_declaration.py
+++ b/tests/unit/test_node_port_declaration.py
@@ -1,7 +1,17 @@
 import pytest
 
+from node.draw_node.node_draw_information import Node as DrawInformationNode
+from node.draw_node.node_image_alpha_blend import Node as ImageAlphaBlendNode
 from node.draw_node.node_result_image import Node as ResultImageNode
+from node.draw_node.node_result_large_image import Node as ResultLargeImageNode
 from node.input_node.node_int_value import Node as IntValueNode
+from node.input_node.node_rtsp_input import Node as RtspInputNode
+from node.input_node.node_video_input import Node as VideoInputNode
+from node.input_node.node_video_set_frame_pos_input import (
+    Node as VideoSetFramePosNode,
+)
+from node.input_node.node_webcam_input import Node as WebCamNode
+from node.other_node.node_on_off_switch import Node as OnOffSwitchNode
 from node.preview_release_node.node_screen_capture import (
     Node as ScreenCaptureNode,
 )
@@ -154,6 +164,95 @@ def test_migrated_sink_and_source_nodes_expose_named_port_handles():
     assert capture_ports.elapsed.value_tag == (
         '32:ScreenCapture:TimeMS:Output02Value'
     )
+
+
+def test_expanded_migrated_nodes_expose_expected_port_handles():
+    cases = (
+        (
+            DrawInformationNode,
+            'DrawInformation',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+            },
+        ),
+        (
+            ImageAlphaBlendNode,
+            'ImageAlphaBlend',
+            {
+                'image_a': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'image_b': (PortDirection.INPUT, PortDataType.IMAGE, 'Input02'),
+                'alpha': (PortDirection.INPUT, PortDataType.FLOAT, 'Input03'),
+                'beta': (PortDirection.INPUT, PortDataType.FLOAT, 'Input04'),
+                'gamma': (PortDirection.INPUT, PortDataType.INT, 'Input05'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            ResultLargeImageNode,
+            'ResultImageLarge',
+            {
+                'image': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+            },
+        ),
+        (
+            RtspInputNode,
+            'RTSPInput',
+            {
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            VideoInputNode,
+            'Video',
+            {
+                'skip_rate': (PortDirection.INPUT, PortDataType.INT, 'Input03'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            VideoSetFramePosNode,
+            'VideoSetFramePos',
+            {
+                'seek': (PortDirection.INPUT, PortDataType.INT, 'Input02'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+                'frame_pos': (PortDirection.OUTPUT, PortDataType.INT, 'Output03'),
+            },
+        ),
+        (
+            WebCamNode,
+            'WebCam',
+            {
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            OnOffSwitchNode,
+            'OnOffSwitch',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+            },
+        ),
+    )
+
+    for node_class, node_tag, expectations in cases:
+        ports = node_class().create_ports(41)
+
+        for handle_name, (direction, data_type, port_name) in expectations.items():
+            port = getattr(ports, handle_name)
+
+            assert port.direction is direction
+            assert port.data_type is data_type
+            assert port.port_name == port_name
+            assert port.spec_key == handle_name
+            assert port.dpg_tag == f'41:{node_tag}:{data_type.value}:{port_name}'
+            assert port.value_tag == f'{port.dpg_tag}Value'
 
 
 def test_port_declaration_invokes_registration_callback():

--- a/tests/unit/test_node_port_declaration.py
+++ b/tests/unit/test_node_port_declaration.py
@@ -50,56 +50,74 @@ from node.port_model import (
 )
 
 
-def test_explicit_port_declaration_preserves_compact_tag_shape():
-    node = IntValueNode()
+def test_port_specs_preserve_compact_tag_shape():
+    class SpecNode(IntValueNode):
+        port_specs = PortSpecs(
+            value=OutputPort(PortDataType.INT),
+        )
 
-    port = node.output_port(7, node.TYPE_INT, 'Output01')
+    port = SpecNode().create_ports(7).value
 
     assert port == PortRef(
         node_ref=NodeRef('7', 'IntValue'),
         direction=PortDirection.OUTPUT,
-        data_type='Int',
+        data_type=PortDataType.INT,
         index=1,
         port_name='Output01',
         dpg_tag='7:IntValue:Int:Output01',
         value_tag='7:IntValue:Int:Output01Value',
         control_tag=None,
+        spec_key='value',
     )
 
 
-def test_auto_numbered_ports_increment_by_node_and_direction():
-    node = IntValueNode()
+def test_port_specs_auto_number_by_node_and_direction():
+    class SpecNode(IntValueNode):
+        port_specs = PortSpecs(
+            image_in=InputPort(PortDataType.IMAGE),
+            int_param=ParameterPort(PortDataType.INT),
+            image_out=OutputPort(PortDataType.IMAGE),
+            text_in=InputPort(PortDataType.TEXT),
+        )
 
-    image_in = node.input_port(3, node.TYPE_IMAGE)
-    int_in = node.parameter_port(3, node.TYPE_INT)
-    image_out = node.output_port(3, node.TYPE_IMAGE)
-    next_node_input = node.input_port(4, node.TYPE_TEXT)
+    node = SpecNode()
+    ports = node.create_ports(3)
+    next_node_ports = node.create_ports(4)
 
-    assert image_in.port_name == 'Input01'
-    assert image_in.dpg_tag == '3:IntValue:Image:Input01'
-    assert image_in.control_tag is None
-    assert int_in.port_name == 'Input02'
-    assert int_in.dpg_tag == '3:IntValue:Int:Input02'
-    assert int_in.control_tag == '3:IntValue:Int:Input02Value'
-    assert image_out.port_name == 'Output01'
-    assert next_node_input.port_name == 'Input01'
+    assert ports.image_in.port_name == 'Input01'
+    assert ports.image_in.dpg_tag == '3:IntValue:Image:Input01'
+    assert ports.image_in.control_tag is None
+    assert ports.int_param.port_name == 'Input02'
+    assert ports.int_param.dpg_tag == '3:IntValue:Int:Input02'
+    assert ports.int_param.control_tag == '3:IntValue:Int:Input02Value'
+    assert ports.image_out.port_name == 'Output01'
+    assert ports.text_in.port_name == 'Input03'
+    assert next_node_ports.image_in.port_name == 'Input01'
 
 
-def test_explicit_port_declaration_advances_auto_numbering():
-    node = IntValueNode()
+def test_explicit_port_spec_index_advances_auto_numbering():
+    class SpecNode(IntValueNode):
+        port_specs = PortSpecs(
+            explicit=InputPort(PortDataType.INT, index=3),
+            auto=InputPort(PortDataType.TEXT),
+        )
 
-    explicit_port = node.input_port(2, node.TYPE_INT, 'Input03')
-    auto_port = node.input_port(2, node.TYPE_TEXT)
+    ports = SpecNode().create_ports(2)
 
-    assert explicit_port.index == 3
-    assert auto_port.port_name == 'Input04'
+    assert ports.explicit.index == 3
+    assert ports.explicit.port_name == 'Input03'
+    assert ports.auto.port_name == 'Input04'
 
 
 def test_declared_port_refs_are_stored_by_node():
-    node = IntValueNode()
+    class SpecNode(IntValueNode):
+        port_specs = PortSpecs(
+            value=OutputPort(PortDataType.INT),
+        )
 
-    first = node.output_port(1, node.TYPE_INT, 'Output01')
-    second = node.output_port(2, node.TYPE_INT, 'Output01')
+    node = SpecNode()
+    first = node.create_ports(1).value
+    second = node.create_ports(2).value
 
     assert node.get_declared_port_refs(1) == [first]
     assert node.get_declared_port_refs(2) == [second]
@@ -107,18 +125,21 @@ def test_declared_port_refs_are_stored_by_node():
 
 
 def test_declared_ports_use_direction_enum_values():
-    node = IntValueNode()
+    class SpecNode(IntValueNode):
+        port_specs = PortSpecs(
+            value=OutputPort(PortDataType.INT),
+            value_input=InputPort(PortDataType.FLOAT),
+        )
 
-    output_port = node.output_port(10, node.TYPE_INT)
-    input_port = node.input_port(10, node.TYPE_FLOAT)
+    ports = SpecNode().create_ports(10)
 
-    assert output_port.direction is PortDirection.OUTPUT
-    assert output_port.direction == 'Output'
-    assert output_port.port_name == 'Output01'
-    assert output_port.value_tag == '10:IntValue:Int:Output01Value'
-    assert input_port.direction is PortDirection.INPUT
-    assert input_port.direction == 'Input'
-    assert input_port.port_name == 'Input01'
+    assert ports.value.direction is PortDirection.OUTPUT
+    assert ports.value.direction == 'Output'
+    assert ports.value.port_name == 'Output01'
+    assert ports.value.value_tag == '10:IntValue:Int:Output01Value'
+    assert ports.value_input.direction is PortDirection.INPUT
+    assert ports.value_input.direction == 'Input'
+    assert ports.value_input.port_name == 'Input01'
 
 
 def test_port_specs_create_base_owned_attribute_handles():
@@ -529,39 +550,42 @@ def test_expanded_migrated_nodes_expose_expected_port_handles():
             assert port.value_tag == f'{port.dpg_tag}Value'
 
 
-def test_port_declaration_invokes_registration_callback():
-    node = IntValueNode()
+def test_port_spec_declaration_invokes_registration_callback():
+    class SpecNode(IntValueNode):
+        port_specs = PortSpecs(
+            elapsed=OutputPort(PortDataType.TIME_MS, index=2),
+        )
+
+    node = SpecNode()
     registered_ports = []
     node.set_port_registration_callback(registered_ports.append)
 
-    declared = node.output_port(4, node.TYPE_TIME_MS, 'Output02')
+    declared = node.create_ports(4).elapsed
 
     assert registered_ports == [declared]
 
 
 def test_parameter_port_accepts_custom_control_tag():
-    node = IntValueNode()
+    class SpecNode(IntValueNode):
+        port_specs = PortSpecs(
+            combo=ParameterPort(
+                PortDataType.TEXT,
+                index=2,
+                control_tag='5:IntValue:Text:ComboControl',
+            ),
+        )
 
-    port = node.parameter_port(
-        5,
-        node.TYPE_TEXT,
-        'Input02',
-        control_tag='5:IntValue:Text:ComboControl',
-    )
+    port = SpecNode().create_ports(5).combo
 
     assert port.control_tag == '5:IntValue:Text:ComboControl'
     assert port.value_tag == '5:IntValue:Text:Input02Value'
 
 
-def test_port_declaration_rejects_mismatched_direction_prefix():
-    node = IntValueNode()
+def test_port_spec_rejects_non_numeric_index():
+    class SpecNode(IntValueNode):
+        port_specs = PortSpecs(
+            image=InputPort(PortDataType.IMAGE, index='Main'),
+        )
 
-    with pytest.raises(ValueError, match='must start with Output'):
-        node.output_port(1, node.TYPE_IMAGE, 'Input01')
-
-
-def test_port_declaration_rejects_non_numeric_index():
-    node = IntValueNode()
-
-    with pytest.raises(ValueError, match='must end with a numeric index'):
-        node.input_port(1, node.TYPE_IMAGE, 'InputMain')
+    with pytest.raises(ValueError, match="invalid literal for int"):
+        SpecNode().create_ports(1)

--- a/tests/unit/test_node_port_declaration.py
+++ b/tests/unit/test_node_port_declaration.py
@@ -193,6 +193,42 @@ def test_create_port_adds_dynamic_handle_and_collection_entries():
     ]
 
 
+def test_dynamic_slot_nodes_create_collection_port_handles(monkeypatch):
+    class NullContext:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+    for node_class, collection_name, data_type in (
+        (ImageConcatNode, 'image_inputs', PortDataType.IMAGE),
+        (FpsNode, 'elapsed_inputs', PortDataType.TIME_MS),
+    ):
+        node = node_class()
+        node_id = 22
+        tag_node_name = node._node_name(node_id)
+        node.create_ports(node_id)
+        node._slot_id[tag_node_name] = 1
+
+        module_dpg = __import__(node_class.__module__, fromlist=['dpg']).dpg
+        monkeypatch.setattr(
+            module_dpg,
+            'node_attribute',
+            lambda *args, **kwargs: NullContext(),
+        )
+        monkeypatch.setattr(module_dpg, 'add_text', lambda *args, **kwargs: None)
+
+        node._add_slot(None, None, tag_node_name)
+
+        dynamic_port = getattr(node.ports(node_id), collection_name)[2]
+        assert dynamic_port.direction is PortDirection.INPUT
+        assert dynamic_port.data_type is data_type
+        assert dynamic_port.index == 2
+        assert dynamic_port.port_name == 'Input02'
+        assert dynamic_port.spec_key == '2'
+
+
 def test_port_serialization_parses_legacy_tag_to_typed_ref():
     port = port_ref_from_tag('21:IntValue:Float:Input03')
 

--- a/tests/unit/test_node_port_declaration.py
+++ b/tests/unit/test_node_port_declaration.py
@@ -38,6 +38,7 @@ from node.preview_release_node.node_screen_capture import (
 )
 from node.port_serialization import port_ref_from_tag
 from node.port_model import (
+    InputPort,
     NodeRef,
     OutputPort,
     PortDataType,
@@ -151,6 +152,45 @@ def test_port_spec_index_override_derives_legacy_name():
     assert ports.elapsed.index == 2
     assert ports.elapsed.port_name == 'Output02'
     assert ports.elapsed.dpg_tag == '13:IntValue:TimeMS:Output02'
+
+
+def test_create_port_adds_dynamic_handle_and_collection_entries():
+    class SpecNode(IntValueNode):
+        port_specs = PortSpecs(
+            value=OutputPort(PortDataType.INT),
+        )
+
+    node = SpecNode()
+    ports = node.create_ports(14)
+
+    dynamic_slot = node.create_port(
+        14,
+        'slot_2',
+        InputPort(PortDataType.IMAGE, index=2),
+        collection='image_slots',
+    )
+    debug_port = node.create_port(
+        14,
+        'debug',
+        OutputPort(PortDataType.TEXT, index=3),
+    )
+
+    assert ports.image_slots['slot_2'] is dynamic_slot
+    assert dynamic_slot.direction is PortDirection.INPUT
+    assert dynamic_slot.data_type is PortDataType.IMAGE
+    assert dynamic_slot.port_name == 'Input02'
+    assert dynamic_slot.spec_key == 'slot_2'
+    assert dynamic_slot.dpg_tag == '14:IntValue:Image:Input02'
+    assert ports.debug is debug_port
+    assert debug_port.direction is PortDirection.OUTPUT
+    assert debug_port.port_name == 'Output03'
+    assert debug_port.spec_key == 'debug'
+    assert node.ports(14) is ports
+    assert node.get_declared_port_refs(14) == [
+        ports.value,
+        dynamic_slot,
+        debug_port,
+    ]
 
 
 def test_port_serialization_parses_legacy_tag_to_typed_ref():

--- a/tests/unit/test_node_port_declaration.py
+++ b/tests/unit/test_node_port_declaration.py
@@ -1,9 +1,27 @@
 import pytest
 
+from node.analysis_node.node_BRISQUE import Node as BrisqueNode
+from node.analysis_node.node_fps import Node as FpsNode
+from node.analysis_node.node_rgb_histgram import Node as RgbHistgramNode
+from node.deep_learning_node.node_classification import Node as ClassificationNode
+from node.deep_learning_node.node_face_detection import Node as FaceDetectionNode
+from node.deep_learning_node.node_low_light_image_enhancement import (
+    Node as LowLightImageEnhancementNode,
+)
+from node.deep_learning_node.node_monocular_depth_estimation import (
+    Node as MonocularDepthEstimationNode,
+)
+from node.deep_learning_node.node_object_detection import Node as ObjectDetectionNode
+from node.deep_learning_node.node_pose_estimation import Node as PoseEstimationNode
+from node.deep_learning_node.node_semantic_segmentation import (
+    Node as SemanticSegmentationNode,
+)
 from node.draw_node.node_draw_information import Node as DrawInformationNode
 from node.draw_node.node_image_alpha_blend import Node as ImageAlphaBlendNode
 from node.draw_node.node_result_image import Node as ResultImageNode
 from node.draw_node.node_result_large_image import Node as ResultLargeImageNode
+from node.draw_node.node_image_concat import Node as ImageConcatNode
+from node.draw_node.node_puttext import Node as PutTextNode
 from node.input_node.node_int_value import Node as IntValueNode
 from node.input_node.node_rtsp_input import Node as RtspInputNode
 from node.input_node.node_video_input import Node as VideoInputNode
@@ -12,6 +30,9 @@ from node.input_node.node_video_set_frame_pos_input import (
 )
 from node.input_node.node_webcam_input import Node as WebCamNode
 from node.other_node.node_on_off_switch import Node as OnOffSwitchNode
+from node.other_node.node_video_writer import Node as VideoWriterNode
+from node.preview_release_node.node_code_exec import Node as CodeExecNode
+from node.preview_release_node.node_mot import Node as MotNode
 from node.preview_release_node.node_screen_capture import (
     Node as ScreenCaptureNode,
 )
@@ -169,6 +190,33 @@ def test_migrated_sink_and_source_nodes_expose_named_port_handles():
 def test_expanded_migrated_nodes_expose_expected_port_handles():
     cases = (
         (
+            BrisqueNode,
+            'BRISQUE',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            ClassificationNode,
+            'Classification',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            CodeExecNode,
+            'ExecPythonCode',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
             DrawInformationNode,
             'DrawInformation',
             {
@@ -190,8 +238,115 @@ def test_expanded_migrated_nodes_expose_expected_port_handles():
             },
         ),
         (
+            FaceDetectionNode,
+            'FaceDetection',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'threshold': (PortDirection.INPUT, PortDataType.FLOAT, 'Input03'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            FpsNode,
+            'FPS',
+            {
+                'elapsed_input': (PortDirection.INPUT, PortDataType.TIME_MS, 'Input01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            ImageConcatNode,
+            'ImageConcat',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+            },
+        ),
+        (
+            LowLightImageEnhancementNode,
+            'LLIE',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            MonocularDepthEstimationNode,
+            'MonocularDepthEstimation',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            MotNode,
+            'MultiObjectTracking',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            ObjectDetectionNode,
+            'ObjectDetection',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'threshold': (PortDirection.INPUT, PortDataType.FLOAT, 'Input03'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            PoseEstimationNode,
+            'PoseEstimation',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'threshold': (PortDirection.INPUT, PortDataType.FLOAT, 'Input03'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            PutTextNode,
+            'PutText',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'text': (PortDirection.INPUT, PortDataType.TEXT, 'Input02'),
+                'elapsed_input': (PortDirection.INPUT, PortDataType.TIME_MS, 'Input03'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+            },
+        ),
+        (
+            RgbHistgramNode,
+            'RGBHistgram',
+            {
+                'image': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+            },
+        ),
+        (
             ResultLargeImageNode,
             'ResultImageLarge',
+            {
+                'image': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+            },
+        ),
+        (
+            SemanticSegmentationNode,
+            'SemanticSegmentation',
+            {
+                'image_input': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
+                'threshold': (PortDirection.INPUT, PortDataType.FLOAT, 'Input03'),
+                'image': (PortDirection.OUTPUT, PortDataType.IMAGE, 'Output01'),
+                'elapsed': (PortDirection.OUTPUT, PortDataType.TIME_MS, 'Output02'),
+            },
+        ),
+        (
+            VideoWriterNode,
+            'VideoWriter',
             {
                 'image': (PortDirection.INPUT, PortDataType.IMAGE, 'Input01'),
             },

--- a/tests/unit/test_node_port_declaration.py
+++ b/tests/unit/test_node_port_declaration.py
@@ -1,6 +1,10 @@
 import pytest
 
+from node.draw_node.node_result_image import Node as ResultImageNode
 from node.input_node.node_int_value import Node as IntValueNode
+from node.preview_release_node.node_screen_capture import (
+    Node as ScreenCaptureNode,
+)
 from node.port_serialization import port_ref_from_tag
 from node.port_model import (
     NodeRef,
@@ -127,6 +131,29 @@ def test_port_serialization_parses_legacy_tag_to_typed_ref():
     assert port.index == 3
     assert port.port_name == 'Input03'
     assert port.value_tag == '21:IntValue:Float:Input03Value'
+
+
+def test_migrated_sink_and_source_nodes_expose_named_port_handles():
+    result_node = ResultImageNode()
+    result_ports = result_node.create_ports(31)
+
+    assert result_ports.image.direction is PortDirection.INPUT
+    assert result_ports.image.data_type is PortDataType.IMAGE
+    assert result_ports.image.port_name == 'Input01'
+    assert result_ports.image.value_tag == '31:ResultImage:Image:Input01Value'
+
+    capture_node = ScreenCaptureNode()
+    capture_ports = capture_node.create_ports(32)
+
+    assert capture_ports.image.direction is PortDirection.OUTPUT
+    assert capture_ports.image.data_type is PortDataType.IMAGE
+    assert capture_ports.image.port_name == 'Output01'
+    assert capture_ports.elapsed.direction is PortDirection.OUTPUT
+    assert capture_ports.elapsed.data_type is PortDataType.TIME_MS
+    assert capture_ports.elapsed.port_name == 'Output02'
+    assert capture_ports.elapsed.value_tag == (
+        '32:ScreenCapture:TimeMS:Output02Value'
+    )
 
 
 def test_port_declaration_invokes_registration_callback():

--- a/tests/unit/test_node_port_declaration.py
+++ b/tests/unit/test_node_port_declaration.py
@@ -36,11 +36,13 @@ from node.preview_release_node.node_mot import Node as MotNode
 from node.preview_release_node.node_screen_capture import (
     Node as ScreenCaptureNode,
 )
+from node.process_node.node_brightness import Node as BrightnessNode
 from node.port_serialization import port_ref_from_tag
 from node.port_model import (
     InputPort,
     NodeRef,
     OutputPort,
+    ParameterPort,
     PortDataType,
     PortDirection,
     PortRef,
@@ -191,6 +193,47 @@ def test_create_port_adds_dynamic_handle_and_collection_entries():
         dynamic_slot,
         debug_port,
     ]
+
+
+
+def test_parameter_port_spec_defaults_control_tag_to_value_tag():
+    class SpecNode(IntValueNode):
+        port_specs = PortSpecs(
+            threshold=ParameterPort(PortDataType.INT, index=2),
+        )
+
+    ports = SpecNode().create_ports(15)
+
+    assert ports.threshold.direction is PortDirection.INPUT
+    assert ports.threshold.data_type is PortDataType.INT
+    assert ports.threshold.port_name == 'Input02'
+    assert ports.threshold.value_tag == '15:IntValue:Int:Input02Value'
+    assert ports.threshold.control_tag == ports.threshold.value_tag
+
+
+def test_declarative_process_base_creates_parameter_collection_handles():
+    node = BrightnessNode()
+
+    ports = node._ensure_declarative_port_handles(16, include_elapsed=True)
+
+    assert ports.image_input.direction is PortDirection.INPUT
+    assert ports.image_input.data_type is PortDataType.IMAGE
+    assert ports.image_input.port_name == 'Input01'
+    assert ports.image.direction is PortDirection.OUTPUT
+    assert ports.image.data_type is PortDataType.IMAGE
+    assert ports.image.port_name == 'Output01'
+    assert ports.elapsed.direction is PortDirection.OUTPUT
+    assert ports.elapsed.data_type is PortDataType.TIME_MS
+    assert ports.elapsed.port_name == 'Output02'
+
+    beta = ports.parameters['beta']
+    assert beta.direction is PortDirection.INPUT
+    assert beta.data_type is PortDataType.INT
+    assert beta.index == 2
+    assert beta.port_name == 'Input02'
+    assert beta.spec_key == 'beta'
+    assert beta.control_tag == beta.value_tag
+    assert node._parameter_port_ref(16, node.parameters[0]) is beta
 
 
 def test_dynamic_slot_nodes_create_collection_port_handles(monkeypatch):

--- a/tests/unit/test_node_port_declaration.py
+++ b/tests/unit/test_node_port_declaration.py
@@ -1,7 +1,15 @@
 import pytest
 
 from node.input_node.node_int_value import Node as IntValueNode
-from node.port_model import NodeRef, PortRef
+from node.port_serialization import port_ref_from_tag
+from node.port_model import (
+    NodeRef,
+    OutputPort,
+    PortDataType,
+    PortDirection,
+    PortRef,
+    PortSpecs,
+)
 
 
 def test_explicit_port_declaration_preserves_compact_tag_shape():
@@ -11,7 +19,7 @@ def test_explicit_port_declaration_preserves_compact_tag_shape():
 
     assert port == PortRef(
         node_ref=NodeRef('7', 'IntValue'),
-        direction='Output',
+        direction=PortDirection.OUTPUT,
         data_type='Int',
         index=1,
         port_name='Output01',
@@ -58,6 +66,67 @@ def test_declared_port_refs_are_stored_by_node():
     assert node.get_declared_port_refs(1) == [first]
     assert node.get_declared_port_refs(2) == [second]
     assert node.get_declared_port_refs() == [first, second]
+
+
+def test_declared_ports_use_direction_enum_values():
+    node = IntValueNode()
+
+    output_port = node.output_port(10, node.TYPE_INT)
+    input_port = node.input_port(10, node.TYPE_FLOAT)
+
+    assert output_port.direction is PortDirection.OUTPUT
+    assert output_port.direction == 'Output'
+    assert output_port.port_name == 'Output01'
+    assert output_port.value_tag == '10:IntValue:Int:Output01Value'
+    assert input_port.direction is PortDirection.INPUT
+    assert input_port.direction == 'Input'
+    assert input_port.port_name == 'Input01'
+
+
+def test_port_specs_create_base_owned_attribute_handles():
+    class SpecNode(IntValueNode):
+        port_specs = PortSpecs(
+            value=OutputPort(PortDataType.INT),
+            image=OutputPort(PortDataType.IMAGE),
+        )
+
+    node = SpecNode()
+
+    ports = node.create_ports(12)
+
+    assert ports.value.direction is PortDirection.OUTPUT
+    assert ports.value.data_type is PortDataType.INT
+    assert ports.value.port_name == 'Output01'
+    assert ports.value.spec_key == 'value'
+    assert ports.image.direction is PortDirection.OUTPUT
+    assert ports.image.data_type is PortDataType.IMAGE
+    assert ports.image.port_name == 'Output02'
+    assert node.ports(12) is ports
+    assert node.get_declared_port_refs(12) == [ports.value, ports.image]
+
+
+def test_port_spec_index_override_derives_legacy_name():
+    class SpecNode(IntValueNode):
+        port_specs = PortSpecs(
+            elapsed=OutputPort(PortDataType.TIME_MS, index=2),
+        )
+
+    ports = SpecNode().create_ports(13)
+
+    assert ports.elapsed.index == 2
+    assert ports.elapsed.port_name == 'Output02'
+    assert ports.elapsed.dpg_tag == '13:IntValue:TimeMS:Output02'
+
+
+def test_port_serialization_parses_legacy_tag_to_typed_ref():
+    port = port_ref_from_tag('21:IntValue:Float:Input03')
+
+    assert port.node_ref == NodeRef('21', 'IntValue')
+    assert port.direction is PortDirection.INPUT
+    assert port.data_type is PortDataType.FLOAT
+    assert port.index == 3
+    assert port.port_name == 'Input03'
+    assert port.value_tag == '21:IntValue:Float:Input03Value'
 
 
 def test_port_declaration_invokes_registration_callback():


### PR DESCRIPTION
### Motivation
- Move graph identity and port/link handling from ad-hoc compact strings toward a small typed layer so node implementations and the editor can work with semantic port/link objects while preserving compact DPG tag compatibility at the boundary.
- Provide a near-term Option A architecture that keeps the one-node-object-per-node-type lifecycle but gives nodes base-owned port handles and declarative `PortSpec` declarations to improve ergonomics and reduce repeated string-keyed lookups.

### Description
- Add a typed port model in `node/port_model.py` introducing `PortDirection`, `PortDataType`, `PortSpec`, `InputPort`/`OutputPort`, `PortSpecs`, `PortHandles`, and adapt `NodeRef`/`PortRef` to carry enum-typed direction/data_type and optional `spec_key` metadata.
- Add `node/port_serialization.py` to contain legacy compact tag helpers (`legacy_port_name`, `make_port_tag`, `make_port_value_tag`) and `port_ref_from_tag`/parser as the compatibility boundary.
- Extend `DpgNodeBase` in `node/node_abc.py` with `create_ports`, `ports`, spec-driven declaration paths, normalized direction/data-type handling, handle storage (`_port_handles`), and updated tag helpers to use the serialization module.
- Migrate several input nodes (`IntValue`, `FloatValue`, `Image`) to declare `port_specs` and use `create_ports`/`ports(...)` handles and `value_tag` attributes instead of manual compact tag construction.
- Update the editor (`node_editor/node_editor.py`) to maintain canonical typed links in `_link_refs`, normalize legacy `_node_link_list` compact pairs into typed `LinkRef`s, prefer typed `PortRef` objects when parsing, and update link/port handling to use enum values and `enum_value` helpers for serialization/compatibility.
- Update docs (`docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md`) with the chosen Option A plan and current status, and extend/adjust unit tests to exercise the new typed APIs and normalization code paths.

### Testing
- Ran unit tests touching the refactor: `tests/unit/test_node_port_declaration.py`, `tests/unit/test_node_editor_core.py`, and `tests/unit/test_node_base_refactor.py` which include added/updated cases for `PortSpecs` handles, legacy tag normalization, and typed link lifecycle; these tests succeeded.
- Verified that migrated node classes (`node_int_value`, `node_float_value`, `node_still_image`) construct and use `value_tag` and `dpg_tag` via generated handles in `create_ports`/`ports` paths by the unit tests above, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b94dfb12883238631082cb5a7961a)