### PR TITLE
Fix legacy link assignment after typed port refactor

### DIFF
--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -127,6 +127,14 @@ class DpgNodeEditor(object):
 
     @_node_link_list.setter
     def _node_link_list(self, link_list):
+        # Treat legacy assignments as replacing the graph link model, matching
+        # the pre-typed-port list semantics.  Keep the assigned compact pairs in
+        # the compatibility bucket until they can be normalized to LinkRef
+        # instances by _mdl_iter_link_refs().
+        self._link_refs = []
+        self._link_registry = {}
+        self._link_by_dest_port = {}
+        self._link_by_dest_port_ref = {}
         self._legacy_node_link_list = [list(link) for link in link_list]
 
     def _mdl_add_node(self, node_tag):

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -240,6 +240,34 @@ def test_mdl_add_link_accepts_port_refs(editor_and_dpg):
     assert list(editor._mdl_iter_link_refs()) == [link_ref]
 
 
+def test_legacy_link_assignment_replaces_typed_link_model(editor_and_dpg):
+    editor, _ = editor_and_dpg
+    editor._mdl_add_link(
+        '1:TestNode:Int:Output01',
+        '2:TestNode:Int:Input01',
+    )
+
+    editor._node_link_list = [[
+        '2:TestNode:Int:Output01',
+        '3:TestNode:Int:Input01',
+    ]]
+
+    assert _typed_link_pairs(editor) == []
+    assert editor._link_registry == {}
+    assert editor._link_by_dest_port == {}
+    assert editor._link_by_dest_port_ref == {}
+
+    link_refs = list(editor._mdl_iter_link_refs())
+    assert _typed_link_pairs(editor) == [[
+        '2:TestNode:Int:Output01',
+        '3:TestNode:Int:Input01',
+    ]]
+    assert link_refs[0].legacy_pair == [
+        '2:TestNode:Int:Output01',
+        '3:TestNode:Int:Input01',
+    ]
+
+
 def test_legacy_link_pairs_normalize_to_typed_link_refs(editor_and_dpg):
     editor, _ = editor_and_dpg
     editor._node_link_list = [[


### PR DESCRIPTION
### Motivation
- Legacy assignments to `_node_link_list` were intended to replace the editor's compact-pair link model, but after the typed-port refactor they only updated `_legacy_node_link_list` and left stale typed link registries in `_link_refs`/registries, causing incorrect graph state.

### Description
- Update the `_node_link_list` setter in `node_editor/node_editor.py` to clear the canonical typed link model by resetting `self._link_refs`, `self._link_registry`, `self._link_by_dest_port`, and `self._link_by_dest_port_ref` before storing the legacy compact pairs.
- Add a regression test `test_legacy_link_assignment_replaces_typed_link_model` to `tests/unit/test_node_editor_core.py` that asserts legacy assignment clears typed registries and that `_mdl_iter_link_refs()` later normalizes the new compact pairs into `LinkRef` objects.

### Testing
- Ran the targeted tests: `python -m pytest --use-cv2-stub tests/unit/test_node_editor_core.py::test_legacy_link_assignment_replaces_typed_link_model tests/unit/test_node_editor_core.py::test_legacy_link_pairs_normalize_to_typed_link_refs`, and they passed.
- Ran the full test suite: `python -m pytest --use-cv2-stub`, which completed with all tests passing (`179 passed, 19 skipped`).
- Verified bytecode compilation with `python -m compileall -q node node_editor tests`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a236b6a39c48323829f864f2e82269c)