### PR TITLE
Remove legacy compact link-list storage and prefer typed LinkRef model

### DIFF
--- a/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
+++ b/docs/TYPED_PORT_MODEL_REFACTOR_PLAN.md
@@ -72,9 +72,9 @@ Current implementation note:
   cycle detection, delete-through-node reconnection, the runtime scheduler,
   undo/redo link history, and the node `update()` connection boundary all consume
   or preserve typed `LinkRef` data. The editor stores canonical links in
-  `_link_refs`; `_node_link_list` is now a computed legacy compact-pair view over
-  typed links plus directly seeded legacy pairs for older tests/integrations and
-  DearPyGui boundary code. The
+  `_link_refs`; old compact-pair link lists are no longer stored or seeded in
+  the editor model. DearPyGui callback aliases are parsed only at explicit
+  boundary points. The
   declarative image process base and direct non-declarative nodes read typed
   connection-info records, while `_iter_connections()` remains only as a legacy
   compatibility adapter for external callers and tests that explicitly cover that
@@ -156,11 +156,9 @@ node-by-node graph-port migration:
    parameter definitions are still dictionaries (`type`, `port`, `widget`,
    `default`, etc.). If those dictionaries remain annoying, introduce a typed
    `ParameterSpec`/widget metadata object; otherwise leave them alone.
-4. **Keep tests focused on typed links.** `_link_refs` is canonical, and
-   `_node_link_list` is only a computed compatibility view. Core editor and
-   import/export tests now assert typed link pairs for normal graph operations;
-   direct `_node_link_list` usage should stay limited to explicit legacy seeding
-   or compatibility-view tests.
+4. **Keep tests focused on typed links.** `_link_refs` is canonical. Core
+   editor and import/export tests should seed links through `_mdl_add_link()` or
+   typed import payloads, then assert typed link pairs for graph operations.
 5. **Audit disabled/legacy nodes when re-enabling them.** `*.py.disable` files
    such as the disabled QR-code node are outside the active migration. If one is
    re-enabled, migrate its graph ports to `PortSpecs` first.
@@ -270,9 +268,6 @@ shifting editor internals from string pairs toward typed objects.
 Implemented model:
 
 - `_link_refs` is the canonical in-memory list of typed `LinkRef` records,
-- `_node_link_list` is a computed legacy compact-pair view over typed links plus
-  directly seeded legacy pairs for older tests, integrations, and DearPyGui
-  boundary code,
 - `_mdl_add_link()` accepts string aliases or `PortRef` endpoints and normalizes
   successful links to `LinkRef`,
 - graph sorting, cycle detection, delete/reconnect, runtime scheduling, history
@@ -432,10 +427,8 @@ plus a readable compact boundary string.
 - Done: replace hovered-port discovery and node-port lookup with registered
   `PortRef` iteration; legacy compact-tag scanning has been removed from these
   normal paths.
-- Done: add canonical typed `LinkRef` storage in `_link_refs` while keeping
-  `_node_link_list` as a computed compatibility view over typed links and seeded
-  legacy compact pairs. Normal editor-core and import/export link assertions now
-  prefer typed link pairs.
+- Done: add canonical typed `LinkRef` storage in `_link_refs`. Normal
+  editor-core and import/export link assertions now prefer typed link pairs.
 - Done: add typed `link_refs` import/export schema and remove normal-path legacy
   `link_list` import/export fallback after fixture conversion.
 - Done: move graph sorting, cycle detection, delete-through-node reconnection, and
@@ -460,8 +453,8 @@ plus a readable compact boundary string.
 - Done: remove the public graph declaration adapters (`input_port()`,
   `output_port()`, `parameter_port()`) after active nodes and tests moved to
   `PortSpecs`/`create_port()`.
-- Done: reduce normal import/export test coupling to `_node_link_list`; the
-  remaining direct assignments seed legacy compatibility state before export or
-  import-collision scenarios.
+- Done: remove normal import/export test coupling to old compact link-list
+  storage; tests now seed links through `_mdl_add_link()` or typed import
+  payloads.
 - Remaining: finish reviewing compact static/control tags and compatibility
   helper usage.

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -53,7 +53,6 @@ class DpgNodeEditor(object):
     _node_id = 0
     _node_instance_list = {}
     _node_list = []
-    _legacy_node_link_list = []
     _link_refs = []
     _link_view_id_map = {}
 
@@ -85,7 +84,6 @@ class DpgNodeEditor(object):
         self._node_id = 0
         self._node_instance_list = {}
         self._node_list = []
-        self._legacy_node_link_list = []
         self._link_refs = []
         self._link_view_id_map = {}
         self._node_connection_dict = OrderedDict([])
@@ -111,23 +109,6 @@ class DpgNodeEditor(object):
         self._parameter_drag_stream_active = set()
         self._suspend_parameter_history = False
         self._history_node_id_remap = {}
-
-    @property
-    def _node_link_list(self):
-        """Legacy compact-pair view over canonical typed links."""
-        link_pairs = [link_ref.legacy_pair for link_ref in self._link_refs]
-        seen = {tuple(link_pair) for link_pair in link_pairs}
-        for link_pair in getattr(self, '_legacy_node_link_list', []):
-            key = tuple(link_pair)
-            if key in seen:
-                continue
-            link_pairs.append(list(link_pair))
-            seen.add(key)
-        return link_pairs
-
-    @_node_link_list.setter
-    def _node_link_list(self, link_list):
-        self._legacy_node_link_list = [list(link) for link in link_list]
 
     def _mdl_add_node(self, node_tag):
         self._node_id += 1
@@ -268,29 +249,10 @@ class DpgNodeEditor(object):
         }
 
     def _mdl_iter_link_refs(self):
-        yielded = set()
-        for link_ref in list(self._link_refs):
-            key = (link_ref.source_tag, link_ref.destination_tag)
-            yielded.add(key)
-            yield link_ref
+        yield from list(self._link_refs)
 
-        # Compatibility boundary: some tests and old integrations still seed
-        # ``_node_link_list`` directly. Normalize those compact pairs once, but
-        # keep typed ``_link_refs`` as the normal graph model.
-        for source_tag, dest_tag in list(self._legacy_node_link_list):
-            key = (source_tag, dest_tag)
-            if key in yielded:
-                continue
-            link_ref = self._link_registry.get(key)
-            if link_ref is None:
-                link_ref = self._mdl_validate_link(source_tag, dest_tag)
-            if link_ref is not None:
-                self._link_refs.append(link_ref)
-                self._link_registry[key] = link_ref
-                self._link_by_dest_port[dest_tag] = source_tag
-                self._link_by_dest_port_ref[dest_tag] = link_ref
-                yielded.add(key)
-                yield link_ref
+    def _mdl_link_tag_pairs(self):
+        return [link_ref.legacy_pair for link_ref in self._link_refs]
 
     def _mdl_get_link_refs_for_export(self):
         return list(self._mdl_iter_link_refs())
@@ -341,9 +303,6 @@ class DpgNodeEditor(object):
                 link_ref.destination_tag,
             ) != (source_tag, dest_tag)
         ]
-        legacy_pair = [source_tag, dest_tag]
-        if legacy_pair in self._legacy_node_link_list:
-            self._legacy_node_link_list.remove(legacy_pair)
         self._mdl_sort_node_graph()
 
     def _mdl_sort_node_graph(self):
@@ -1684,7 +1643,7 @@ class DpgNodeEditor(object):
             print(f'\tselected_link_dpg_id      : {selected_link_dpg_id}')
             print(f'\tinserted_node             : {new_node_id_name}')
             print(f'\tself._node_list           : {self._node_list}')
-            print(f'\tself._node_link_list      : {self._node_link_list}')
+            print(f'\tself._link_refs            : {self._mdl_link_tag_pairs()}')
             print()
 
     def _cntrl_link(self, sender, data):
@@ -1768,7 +1727,7 @@ class DpgNodeEditor(object):
             print(f'\tsender                     : {sender}')
             print(f'\tdata                       : {data}')
             print(f'\tself._node_list            : {self._node_list}')
-            print(f'\tself._node_link_list       : {self._node_link_list}')
+            print(f'\tself._link_refs            : {self._mdl_link_tag_pairs()}')
             print(f'\tself._node_connection_dict : {self._node_connection_dict}')
             print()
 
@@ -2001,11 +1960,10 @@ class DpgNodeEditor(object):
         source_tag = self._cntrl_resolve_history_port_tag(source_tag)
         dest_tag = self._cntrl_resolve_history_port_tag(dest_tag)
         link_ref = self._link_registry.get((source_tag, dest_tag))
-        link = [source_tag, dest_tag]
-        if link_ref is None and link not in self._node_link_list:
+        if link_ref is None:
             return False
         history_link = self._cntrl_history_link_payload(source_tag, dest_tag)
-        self._mdl_delete_link(link_ref if link_ref is not None else link)
+        self._mdl_delete_link(link_ref)
         self._vw_delete_link(source_tag, dest_tag)
         if record_history:
             self._cntrl_push_undo_command(RemoveLinkCommand(history_link))
@@ -2305,7 +2263,7 @@ class DpgNodeEditor(object):
         if self._use_debug_print:
             print('**** _cntrl_delete_selected ****')
             print(f'\tself._node_list            : {self._node_list}')
-            print(f'\tself._node_link_list       : {self._node_link_list}')
+            print(f'\tself._link_refs            : {self._mdl_link_tag_pairs()}')
             print(f'\tself._node_connection_dict : {self._node_connection_dict}')
 
     def _cntrl_would_create_cycle(self, source_tag, dest_tag):

--- a/node_editor/node_editor.py
+++ b/node_editor/node_editor.py
@@ -95,8 +95,7 @@ class DpgNodeEditor(object):
         self._node_registry = {}
         self._port_registry = {}
         self._link_registry = {}
-        self._link_by_dest_port = {}
-        self._link_by_dest_port_ref = {}
+        self._link_ref_by_destination = {}
         self._use_debug_print = use_debug_print
         self._terminate_flag = False
         self._opencv_setting_dict = opencv_setting_dict
@@ -206,28 +205,24 @@ class DpgNodeEditor(object):
             return False
         source_tag = link_ref.source_tag
         dest_tag = link_ref.destination_tag
-        if dest_tag in self._link_by_dest_port_ref:
+        if dest_tag in self._link_ref_by_destination:
             return False
         self._link_refs.append(link_ref)
         self._link_registry[(source_tag, dest_tag)] = link_ref
-        self._link_by_dest_port[dest_tag] = source_tag
-        self._link_by_dest_port_ref[dest_tag] = link_ref
+        self._link_ref_by_destination[dest_tag] = link_ref
         return True
 
     def _mdl_get_link_ref_by_destination(self, destination):
         dest_port = self._mdl_resolve_port_ref(destination)
         if dest_port is None:
             return None
-        return self._link_by_dest_port_ref.get(dest_port.dpg_tag)
+        return self._link_ref_by_destination.get(dest_port.dpg_tag)
 
     def _mdl_get_link_by_destination(self, dest_tag):
         link_ref = self._mdl_get_link_ref_by_destination(dest_tag)
-        if link_ref is not None:
-            return link_ref.legacy_pair
-        source_tag = self._link_by_dest_port.get(dest_tag)
-        if source_tag is not None:
-            return [source_tag, dest_tag]
-        return None
+        if link_ref is None:
+            return None
+        return link_ref.legacy_pair
 
     def _mdl_serialize_port_ref(self, port_ref):
         return {
@@ -294,8 +289,7 @@ class DpgNodeEditor(object):
     def _mdl_delete_link(self, link):
         source_tag, dest_tag = self._mdl_link_key(link)
         self._link_registry.pop((source_tag, dest_tag), None)
-        self._link_by_dest_port.pop(dest_tag, None)
-        self._link_by_dest_port_ref.pop(dest_tag, None)
+        self._link_ref_by_destination.pop(dest_tag, None)
         self._link_refs = [
             link_ref for link_ref in self._link_refs
             if (

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -119,6 +119,11 @@ def _typed_link_pairs(editor):
     return [link_ref.legacy_pair for link_ref in editor._link_refs]
 
 
+def _add_link_pairs(editor, link_pairs):
+    for source_tag, dest_tag in link_pairs:
+        assert editor._mdl_add_link(source_tag, dest_tag) is True
+
+
 @pytest.fixture
 def editor_and_dpg():
     with patch('node_editor.node_editor.dpg') as dpg, \
@@ -235,44 +240,8 @@ def test_mdl_add_link_accepts_port_refs(editor_and_dpg):
         '1:TestNode:Image:Output01',
         '2:TestNode:Image:Input01',
     ]]
-    assert editor._legacy_node_link_list == []
     assert editor._link_refs == [link_ref]
     assert list(editor._mdl_iter_link_refs()) == [link_ref]
-
-
-def test_legacy_link_pairs_normalize_to_typed_link_refs(editor_and_dpg):
-    editor, _ = editor_and_dpg
-    editor._node_link_list = [[
-        '1:TestNode:Image:Output01',
-        '2:TestNode:Image:Input01',
-    ]]
-
-    link_refs = list(editor._mdl_iter_link_refs())
-
-    assert len(link_refs) == 1
-    assert link_refs[0].source == PortRef(
-        node_ref=NodeRef('1', 'TestNode'),
-        direction='Output',
-        data_type='Image',
-        index=1,
-        port_name='Output01',
-        dpg_tag='1:TestNode:Image:Output01',
-        value_tag='1:TestNode:Image:Output01Value',
-    )
-    assert link_refs[0].destination == PortRef(
-        node_ref=NodeRef('2', 'TestNode'),
-        direction='Input',
-        data_type='Image',
-        index=1,
-        port_name='Input01',
-        dpg_tag='2:TestNode:Image:Input01',
-        value_tag='2:TestNode:Image:Input01Value',
-    )
-    assert editor._link_refs == link_refs
-    assert editor._link_registry[(
-        '1:TestNode:Image:Output01',
-        '2:TestNode:Image:Input01',
-    )] == link_refs[0]
 
 
 def test_delete_link_accepts_typed_link_refs(editor_and_dpg):
@@ -1415,7 +1384,7 @@ def test_insert_node_into_selected_link_rejects_incompatible_node(editor_and_dpg
 
     editor._cntrl_add_node(None, None, 'TestNode')
     editor._cntrl_add_node(None, None, 'TestNode')
-    editor._node_link_list = [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']]
+    _add_link_pairs(editor, [['1:TestNode:Int:Output01', '2:TestNode:Int:Input01']])
 
     editor._cntrl_insert_node_into_selected_link(None, None, 'TestNode')
 
@@ -1437,12 +1406,12 @@ def test_close_window(editor_and_dpg):
 def test_sort_node_graph(editor_and_dpg):
     editor, _ = editor_and_dpg
     editor._node_list = ['1:TestNode', '2:TestNode', '3:TestNode', '4:TestNode']
-    editor._node_link_list = [
+    _add_link_pairs(editor, [
         ['1:TestNode:Int:Output01', '2:TestNode:Int:Input01'],
         ['1:TestNode:Int:Output01', '3:TestNode:Int:Input01'],
         ['2:TestNode:Int:Output01', '4:TestNode:Int:Input01'],
-        ['3:TestNode:Int:Output01', '4:TestNode:Int:Input01'],
-    ]
+        ['3:TestNode:Int:Output01', '4:TestNode:Int:Input02'],
+    ])
     editor._mdl_sort_node_graph()
     result = editor.get_sorted_node_connection()
     assert list(result.keys()) == ['1:TestNode', '2:TestNode', '3:TestNode', '4:TestNode']
@@ -1451,7 +1420,6 @@ def test_sort_node_graph(editor_and_dpg):
 def test_sort_node_graph_unconnected(editor_and_dpg):
     editor, _ = editor_and_dpg
     editor._node_list = ['1:TestNode', '2:TestNode']
-    editor._node_link_list = []
     editor._mdl_sort_node_graph()
     result = editor.get_sorted_node_connection()
     assert result == OrderedDict()
@@ -1461,7 +1429,6 @@ def test_sort_node_graph_empty_list(editor_and_dpg):
     editor, _ = editor_and_dpg
     # Empty node list should yield empty result
     editor._node_list = []
-    editor._node_link_list = []
     editor._mdl_sort_node_graph()
     result = editor.get_sorted_node_connection()
     assert result == OrderedDict()
@@ -1489,14 +1456,20 @@ def test_delete_node(editor_and_dpg):
 def test_mv_key_del_no_selection(editor_and_dpg):
     editor, dpg = editor_and_dpg
     # initial state
-    editor._node_list = ['1:TestNode']
-    editor._node_link_list = [['1:TestNode:Output01', '1:TestNode:Input01']]
+    editor._node_list = ['1:TestNode', '2:TestNode']
+    _add_link_pairs(editor, [[
+        '1:TestNode:Int:Output01',
+        '2:TestNode:Int:Input01',
+    ]])
     # no nodes or links selected
     dpg.get_selected_nodes.return_value = []
     dpg.get_selected_links.return_value = []
     editor._cntrl_delete_selected(None, None)
-    assert editor._node_list == ['1:TestNode']
-    assert editor._node_link_list == [['1:TestNode:Output01', '1:TestNode:Input01']]
+    assert editor._node_list == ['1:TestNode', '2:TestNode']
+    assert _typed_link_pairs(editor) == [[
+        '1:TestNode:Int:Output01',
+        '2:TestNode:Int:Input01',
+    ]]
 
 
 def test_set_get_terminate_flag(editor_and_dpg):

--- a/tests/unit/test_node_editor_core.py
+++ b/tests/unit/test_node_editor_core.py
@@ -202,7 +202,6 @@ def test_link_callback_basic(editor_and_dpg):
         '1:TestNode:Int:Output01',
         '2:TestNode:Int:Input01',
     ]
-    assert editor._link_by_dest_port['2:TestNode:Int:Input01'] == '1:TestNode:Int:Output01'
     assert editor._mdl_get_link_ref_by_destination(
         '2:TestNode:Int:Input01'
     ) == link_ref
@@ -270,8 +269,6 @@ def test_delete_link_accepts_typed_link_refs(editor_and_dpg):
     assert editor._link_refs == []
     assert _typed_link_pairs(editor) == []
     assert editor._link_registry == {}
-    assert editor._link_by_dest_port == {}
-    assert editor._link_by_dest_port_ref == {}
 
 
 def test_history_import_command_accepts_typed_link_refs(editor_and_dpg):
@@ -420,7 +417,6 @@ def test_delete_link_updates_typed_registries(editor_and_dpg):
 
     assert editor._mdl_get_link_by_destination(dest_tag) is None
     assert (source_tag, dest_tag) not in editor._link_registry
-    assert dest_tag not in editor._link_by_dest_port
 
 
 def test_link_prevents_duplicate_dest(editor_and_dpg):

--- a/tests/unit/test_node_editor_import_export.py
+++ b/tests/unit/test_node_editor_import_export.py
@@ -55,6 +55,11 @@ def _typed_link_pairs_from_editor(editor):
     return [link_ref.legacy_pair for link_ref in editor._link_refs]
 
 
+def _add_link_pairs(editor, link_pairs):
+    for source_tag, dest_tag in link_pairs:
+        assert editor._mdl_add_link(source_tag, dest_tag) is True
+
+
 def _history_link_pairs(links):
     pairs = []
     for link in links:
@@ -143,10 +148,10 @@ class TestDpgNodeEditorImportExport:
     ):
         """Test exporting with nodes in the editor"""
         node_editor._node_list = ['1:test_node', '2:test_node']
-        node_editor._node_link_list = [[
+        _add_link_pairs(node_editor, [[
             '1:test_node:Image:Output01',
             '2:test_node:Image:Input01'
-        ]]
+        ]])
 
         temp_path = tmp_path / "with_nodes.json"
         sender = 'file_export'
@@ -837,10 +842,10 @@ class TestDpgNodeEditorImportExport:
 
         # Arrange: seed editor with two nodes and a link between them
         node_editor._node_list = ['1:test_node', '2:test_node']
-        node_editor._node_link_list = [[
+        _add_link_pairs(node_editor, [[
             '1:test_node:Image:Output01',
             '2:test_node:Image:Input01',
-        ]]
+        ]])
 
         # Act: export the original state to JSON
         orig = tmp_path / 'orig.json'
@@ -887,7 +892,7 @@ class TestDpgNodeEditorImportExport:
             ['3:test_node:Image:Output01', '4:test_node:Image:Input02'],
         ]
         node_editor._node_list = original_nodes.copy()
-        node_editor._node_link_list = original_links.copy()
+        _add_link_pairs(node_editor, original_links)
         # Provide distinct settings
         mock_node_instance.get_setting_dict.side_effect = lambda nid: {
             'ver': '1.0.0',
@@ -938,10 +943,10 @@ class TestDpgNodeEditorImportExport:
            existing IDs."""
         # Arrange: editor already has nodes 1 and 2
         node_editor._node_list = ['1:test_node', '2:test_node']
-        node_editor._node_link_list = [[
+        _add_link_pairs(node_editor, [[
             '1:test_node:Image:Output01',
             '2:test_node:Image:Input01',
-        ]]
+        ]])
         node_editor._node_id = 2
 
         # import JSON with the same IDs (1 & 2), so they must be remapped

--- a/tests/unit/test_node_editor_import_export.py
+++ b/tests/unit/test_node_editor_import_export.py
@@ -436,7 +436,6 @@ class TestDpgNodeEditorImportExport:
 
         assert _typed_link_pairs_from_editor(node_editor) == []
         assert node_editor._link_registry == {}
-        assert node_editor._link_by_dest_port == {}
         assert node_editor._undo_stack[-1].links == []
         mock_dpg.add_node_link.assert_not_called()
 
@@ -559,7 +558,6 @@ class TestDpgNodeEditorImportExport:
 
         assert _typed_link_pairs_from_editor(node_editor) == []
         assert node_editor._link_registry == {}
-        assert node_editor._link_by_dest_port == {}
         assert node_editor._link_view_id_map == {}
         assert node_editor._undo_stack[-1].links == []
         mock_dpg.add_node_link.assert_not_called()
@@ -604,7 +602,6 @@ class TestDpgNodeEditorImportExport:
 
         assert _typed_link_pairs_from_editor(node_editor) == []
         assert node_editor._link_registry == {}
-        assert node_editor._link_by_dest_port == {}
         assert node_editor._undo_stack[-1].links == []
         mock_dpg.add_node_link.assert_not_called()
 


### PR DESCRIPTION
### Motivation

- Consolidate the editor graph model on canonical typed `LinkRef` records and remove the legacy compact-pair link-list as stored state.  
- Harden import/export and editor boundaries so links are always seeded and validated through typed APIs rather than ad-hoc legacy lists.  

### Description

- Removed the `_legacy_node_link_list` storage and the `_node_link_list` property, and simplified `_mdl_iter_link_refs()` to iterate the canonical `self._link_refs` list.  
- Added `_mdl_link_tag_pairs()` helper to expose legacy-style tag pairs computed from typed `LinkRef` objects and updated debug prints and call sites to use it.  
- Updated link add/delete/lookup logic to operate on typed `PortRef`/`LinkRef` objects and removed compatibility normalization paths that previously migrated seeded compact pairs into typed links.  
- Updated tests and test helpers to stop assigning to legacy compact lists and instead seed links via `._mdl_add_link()` (added `_add_link_pairs()` test helper), and adjusted assertions to examine `._link_refs` or `_mdl_link_tag_pairs()` accordingly; also updated the docs in `TYPED_PORT_MODEL_REFACTOR_PLAN.md` to reflect the boundary change.  

### Testing

- Ran unit tests that exercise editor core and import/export behavior (`tests/unit/test_node_editor_core.py` and `tests/unit/test_node_editor_import_export.py`).  
- All updated unit tests passed locally after the changes.  
- Existing import/export and link-management tests were updated and validated to assert typed `link_refs` instead of legacy compact lists.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a236b6a39c48323829f864f2e82269c)